### PR TITLE
Answer BB thread questions and report thread state to Telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Agent sessions run out of process as BB threads and never open the plugin databa
 | Thread management | Open a thread to explore something, message a running one to answer its question or redirect it, stop or retry with a one-tap confirmation. |
 | Memory | "Always deploy on weekday mornings" is kept and applied later. Ask what it knows, or tell it to forget. Secrets are refused, never stored. |
 | Monitors | "Tell me when this finishes and open a PR", or "every weekday at 9, summarise the overnight runs." |
+| Thread notices | Every top-level thread reports itself: you are told when one finishes or fails, and a thread blocked on a question or a permission prompt asks you in Telegram with buttons. A block it cannot render is still reported, so nothing waits on you in silence. |
 | Reviewed delivery | A guarded job takes a change from plan to merge; merging and production still ask you in Telegram. |
 | Self-diagnosis | `/health` reports the executor, queued work, undelivered messages, monitors, memory, and database integrity — even when the agent is the stuck part. |
 
@@ -59,7 +60,7 @@ Critique can request one replacement plan. Test or review failures return to a b
 The project policy chooses implementation/review providers and commands. The conversational agent is configured independently and defaults to Claude Opus 5 (1M) at `xhigh` reasoning. Claude and Codex models are both selectable; picking a model selects its provider.
 
 > [!WARNING]
-> This is a full-trust BB plugin, and the agent runs with full permissions by design so the owner never has to approve anything inside the BB app. It can use the shell, the `bb` CLI, and installed skills and MCP servers on any connected machine. Merging a pull request and promoting to production still require a one-use Telegram approval, and an enabled project policy may run owner-authored validation, deployment, and canary commands. Review the source and policy, keep GitHub protection enabled, and use a disposable repository for the first live run.
+> This is a full-trust BB plugin, and the agent runs with full permissions by design, so routine work never stops for an approval in the BB app. Prompts a worker thread does raise are bridged to Telegram; the rare block the plugin cannot render says so and asks you to open BB. It can use the shell, the `bb` CLI, and installed skills and MCP servers on any connected machine. Merging a pull request and promoting to production still require a one-use Telegram approval, and an enabled project policy may run owner-authored validation, deployment, and canary commands. Review the source and policy, keep GitHub protection enabled, and use a disposable repository for the first live run.
 
 ## Quick start
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,8 @@ If a credential may have been exposed, rotate it with its provider first. For a 
 
 - One Telegram user and one private chat are paired as the owner. Pairing that chat grants the holder of it operator-level control of this BB installation.
 - The plugin itself is trusted server-side code; installation is not a sandbox boundary.
-- The conversational agent runs in a hidden personal workspace with the plugin's guarded tools **and** BB's ordinary agent capabilities. It defaults to the `full` permission mode, so it may use the shell, the `bb` CLI, installed skills, and MCP servers on any connected machine without a per-action prompt. Set `auto` or `accept-edits` if you want execution approved in the BB app instead.
+- The conversational agent runs in a hidden personal workspace with the plugin's guarded tools **and** BB's ordinary agent capabilities. It defaults to the `full` permission mode, so it may use the shell, the `bb` CLI, installed skills, and MCP servers on any connected machine without a per-action prompt. Set `auto` or `accept-edits` if you want execution approved in the BB app instead. Those prompts are answered in the BB app only: the plugin bridges the agent's *questions* to Telegram, not its permission prompts.
+- Approval prompts raised by visible top-level worker threads are bridged to Telegram, so an owner's tap there authorizes a command or file write in that thread. This moves where the decision is made, not who may make it — the paired chat already holds operator-level control. Approvals the plugin cannot represent faithfully are reported without buttons rather than resolved by guess.
 - Enabled project policies are trusted operator input. Their validation, deployment, and canary commands execute on the selected project host.
 - BB controls provider conversations, permissions, environments, worktrees, and merge execution.
 - GitHub authentication, repository rules, and branch protection remain external security boundaries.
@@ -28,7 +29,8 @@ The plugin can:
 - run configured validation, deployment, and canary commands;
 - send bounded remediation to an implementation worker;
 - request a pull-request merge after review, validation, and owner approval;
-- read and update its durable job, memory, monitor, approval, liveness, and Telegram outbox state.
+- read and update its durable job, memory, monitor, approval, liveness, and Telegram outbox state;
+- resolve pending BB interactions on visible top-level threads from the owner's Telegram tap, including *Allow once* and *Allow all session* on a command or file-change approval.
 
 Merge approval is one-use, expiring, and bound to the current full pull-request head. Deployment and canary run only after the merge is confirmed and the worktree is verified at the merge commit. The plugin does not automatically run rollback.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Telegram Agent gives one private Telegram owner full control of their BB installation, plus a guarded delivery pipeline for code changes.
 
-- [Architecture](architecture.md) — ownership, durable state, conversation continuity, memory, monitors, and the delivery pipeline.
+- [Architecture](architecture.md) — ownership, durable state, conversation continuity, memory, monitors, thread notices, controller questions, and the delivery pipeline.
 - [Configuration](configuration.md) — installation, pairing, model and permission settings, and project policies.
 - [Operations](operations.md) — health checks, memory and monitors, job recovery, token rotation, and removal.
 - [Disposable live acceptance](live-acceptance.md) — evidence-based testing against a repository that is safe to merge and deploy.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,6 +82,7 @@ The plugin database records:
 - long-term memories with full-text search, supersession, and provenance;
 - tool receipts keyed by turn, tool name, and argument hash;
 - armed monitors, their trigger, and their firing history;
+- watched threads with their last reported status, and the interactions offered to the owner with their answers and delivery state;
 - jobs, state-machine versions, stage attempts, and immutable handoff digests;
 - idempotent effects and retry accounting;
 - executor lease ownership and worker liveness;
@@ -109,6 +110,27 @@ Restating a subject supersedes its predecessor instead of overwriting it, so cor
 ## Monitors
 
 A monitor is a durable obligation, not a reminder. It watches a BB thread for completion or failure, or fires on a cron schedule. Firing is claimed before it happens, so a crash mid-fire cannot double-book it; a one-shot watch retires and a schedule re-arms for its next occurrence. The agent receives its own instruction back as an ordinary turn, acts on it, and reports to the owner.
+
+## Thread notices
+
+The owner drives BB from Telegram, so anything that would wait for a click in the BB app is work that waits forever. A background sweep watches every **top-level** visible thread — a sub-agent's thread is reported to its parent, not to the owner — and delivers two things:
+
+- **Finished and failed.** A thread's first observation is recorded silently, so enabling the sweep does not replay a backlog. After that, only a thread that was *working* can stop working: a move into `idle` or `error` is announced when it comes from `active`, `starting`, or `stopping`. A thread marked failed after it already finished has had its say, and repeating it as a failure would contradict what the owner just read. A thread being steered turn by turn is announced at most once every ten minutes, so it does not narrate every reply.
+- **Blocked.** A thread waiting on a BB interaction is rendered into Telegram with inline buttons: the options of a question, or *Allow once* / *Allow all session* / *Deny* for a command or file-change approval. The tap is carried back through BB's interaction resolution, and delivery is recorded separately from the answer so a crash between the two re-sends rather than loses it.
+
+Notices are written straight to the durable outbox rather than routed through the agent. They are a property of the plugin, not of the conversation, so they still arrive when the agent itself is the stuck part.
+
+An interaction the plugin cannot render into buttons — an unfamiliar payload, or an approval whose subject it does not recognise — is reported without them, naming the thread and saying it needs the BB app. Guessing at a resolution would answer it wrongly; saying nothing would leave the thread waiting on an owner who was never told.
+
+The sweep is paced independently of the executor loop it rides on, which polls as often as every 250ms while an answer streams. An owner's tap is delivered immediately; only the polling is paced.
+
+## Controller questions
+
+The conversational agent can ask the owner a question mid-answer. BB raises that as a pending interaction, which is answerable only in the BB app, so the plugin bridges it: the question is detected on the event stream the reconcile loop already reads, asked in Telegram with buttons, and resolved from a tap or a plain typed reply. Multi-question interactions are asked one at a time and resolved once every question is settled. While a turn is parked on a question the typing indicator stops, because the turn is waiting on a person rather than composing.
+
+Two timeouts bound the ways an answer can go missing, and their ordering matters. A submitted turn that produces no BB event for eight minutes is treated as wedged: the turn fails with a message to the owner **and the thread is retired**, so the next message opens a fresh session. That deadline sits below the ten-minute limit on how long a queued message waits for a busy thread, so recovery happens before the queue starts failing behind it. A turn parked on a question is exempt — waiting on a person is not a stall.
+
+A message the owner sends while an answer is still being written is steered into the running thread rather than queued behind it, so a correction lands while it can still correct something.
 
 ## Safety properties
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -36,6 +36,12 @@ Memories are bounded per scope; when the bound is reached the weakest is dropped
 
 An invalid cron expression is rejected when the monitor is created. A schedule that later cannot be advanced is marked failed and reported by `/health` rather than retried forever.
 
+## Thread notices
+
+Notices about top-level threads are automatic; nothing needs arming. The plugin records each thread the first time it sees it and reports later moves into `idle` or `error`, so a freshly installed or restarted plugin does not replay a backlog.
+
+If a thread seems stuck and you were told nothing, check that it is top-level — a sub-agent's thread is reported to its parent, not to you — and that it is `visible`. To recover a controller thread that has wedged, `bb thread archive <id>`: the plugin reads the archived thread as missing and opens a fresh session on its own, which is safer than editing the database.
+
 ## Inspect jobs
 
 ```bash

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/root/github_projects/telegram-bb-agent-plugin/node_modules

--- a/src/controller/bb-controller.ts
+++ b/src/controller/bb-controller.ts
@@ -6,6 +6,11 @@ import {
   controllerProviderFor,
   type ControllerExecutionProfile,
 } from "./execution-profile";
+import {
+  parsePendingQuestion,
+  type ControllerPendingQuestion,
+  type ControllerQuestionAnswers,
+} from "./questions";
 
 export type ControllerLocation = { threadId: string; projectId: string; hostId: string };
 export type ControllerStatus =
@@ -23,6 +28,8 @@ export type ControllerEventObservation = {
   assistantDelta: string;
   completed: boolean;
   error: string | null;
+  /** Set while the thread is blocked on a question only the owner can answer. */
+  pendingQuestion: ControllerPendingQuestion | null;
 };
 
 export type ControllerAdapter = {
@@ -32,6 +39,14 @@ export type ControllerAdapter = {
     signal: AbortSignal,
   ): Promise<ControllerLocation>;
   send(threadId: string, text: string, signal: AbortSignal): Promise<void>;
+  /** Redirects a thread that is already working, rather than queueing behind it. */
+  steer(threadId: string, text: string, signal: AbortSignal): Promise<void>;
+  answerQuestion(
+    threadId: string,
+    interactionId: string,
+    answers: ControllerQuestionAnswers,
+    signal: AbortSignal,
+  ): Promise<void>;
   status(threadId: string, signal: AbortSignal): Promise<ControllerStatus>;
   output(threadId: string, signal: AbortSignal): Promise<string>;
   latestSeq(threadId: string, signal: AbortSignal): Promise<number>;
@@ -92,6 +107,29 @@ export class BbControllerAdapter implements ControllerAdapter {
     });
   }
 
+  // "auto" lets BB fold the message into the running turn instead of starting a
+  // second one, so a correction the owner sends mid-answer still lands.
+  public async steer(threadId: string, text: string, signal: AbortSignal): Promise<void> {
+    await this.dependencies.sdk.threads.send({
+      threadId,
+      mode: "auto",
+      input: [{ type: "text", text, mentions: [] }],
+    });
+  }
+
+  public async answerQuestion(
+    threadId: string,
+    interactionId: string,
+    answers: ControllerQuestionAnswers,
+    signal: AbortSignal,
+  ): Promise<void> {
+    await this.dependencies.sdk.threads.interactions.resolve({
+      threadId,
+      interactionId,
+      resolution: { kind: "user_answer", answers },
+    });
+  }
+
   public async status(threadId: string, signal: AbortSignal): Promise<ControllerStatus> {
     const thread = await this.dependencies.sdk.threads.get({ threadId, signal });
     if (thread.deletedAt !== null || thread.archivedAt !== null) return "missing";
@@ -129,6 +167,7 @@ export class BbControllerAdapter implements ControllerAdapter {
     let assistantDelta = "";
     let completed = false;
     let error: string | null = null;
+    let pendingQuestion: ControllerPendingQuestion | null = null;
     for (let page = 0; page < MAX_EVENT_PAGES; page += 1) {
       const rows = await this.dependencies.sdk.threads.events.list({
         threadId,
@@ -144,10 +183,18 @@ export class BbControllerAdapter implements ControllerAdapter {
         if (row.type === "system/error" || row.type === "provider/error") {
           error = "Controller provider turn failed";
         }
+        // The same interaction reports every step of its life on this stream, so
+        // the last word about it wins: a later "resolved" retires the question.
+        if (row.type === "system/userQuestion/lifecycle") {
+          const data = row.data as { interactionId?: unknown; status?: unknown; payload?: unknown };
+          pendingQuestion = data.status === "pending"
+            ? parsePendingQuestion(data.interactionId, data.payload)
+            : null;
+        }
       }
       if (rows.length < EVENT_PAGE_LIMIT) break;
     }
-    return { latestSeq, inputAccepted, assistantDelta, completed, error };
+    return { latestSeq, inputAccepted, assistantDelta, completed, error, pendingQuestion };
   }
 
   public async findSpawnCandidate(controllerKey: string, signal: AbortSignal): Promise<ControllerLocation | null> {

--- a/src/controller/models.ts
+++ b/src/controller/models.ts
@@ -42,6 +42,8 @@ export type ControllerTurnRecord = {
   lastError: string | null;
   submittedAt: number | null;
   completedAt: number | null;
+  /** Set while the answer is blocked on a question the owner has to settle. */
+  awaitingInteractionId: string | null;
   createdAt: number;
   updatedAt: number;
 };

--- a/src/controller/questions.ts
+++ b/src/controller/questions.ts
@@ -1,0 +1,232 @@
+import { createHash } from "node:crypto";
+
+/** One selectable answer to a question the controller thread asked. */
+export type ControllerQuestionOption = {
+  value: string;
+  label: string;
+  description: string | null;
+};
+
+export type ControllerQuestion = {
+  id: string;
+  prompt: string;
+  shortLabel: string | null;
+  multiSelect: boolean;
+  allowFreeText: boolean;
+  options: ControllerQuestionOption[];
+};
+
+/**
+ * A BB interaction the controller thread is blocked on. BB renders these in its
+ * own app; the owner only has Telegram, so the plugin has to carry both halves.
+ */
+export type ControllerPendingQuestion = {
+  interactionId: string;
+  questions: ControllerQuestion[];
+};
+
+export type ControllerQuestionAnswers = Record<string, { selected: string[]; freeText?: string }>;
+
+const MAX_QUESTIONS = 4;
+const MAX_OPTIONS = 6;
+const MAX_PROMPT = 400;
+const MAX_LABEL = 60;
+const MAX_DESCRIPTION = 200;
+
+function boundedString(value: unknown, limit: number): string | null {
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  if (text.length === 0) return null;
+  return text.length <= limit ? text : `${text.slice(0, limit - 1)}…`;
+}
+
+function parseOption(raw: unknown): ControllerQuestionOption | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const candidate = raw as Record<string, unknown>;
+  const value = typeof candidate.value === "string" ? candidate.value : null;
+  const label = boundedString(candidate.label, MAX_LABEL);
+  if (!value || !label) return null;
+  return { value, label, description: boundedString(candidate.description, MAX_DESCRIPTION) };
+}
+
+function parseQuestion(raw: unknown): ControllerQuestion | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const candidate = raw as Record<string, unknown>;
+  const id = typeof candidate.id === "string" && candidate.id.length > 0 ? candidate.id : null;
+  const prompt = boundedString(candidate.prompt, MAX_PROMPT);
+  if (!id || !prompt) return null;
+  const options = Array.isArray(candidate.options)
+    ? candidate.options.slice(0, MAX_OPTIONS).map(parseOption).filter((option): option is ControllerQuestionOption => option !== null)
+    : [];
+  return {
+    id,
+    prompt,
+    shortLabel: boundedString(candidate.shortLabel, MAX_LABEL),
+    multiSelect: candidate.multiSelect === true,
+    allowFreeText: candidate.allowFreeText !== false,
+    options,
+  };
+}
+
+/**
+ * Reads the question out of a `system/userQuestion/lifecycle` payload. A
+ * question with nothing answerable in it is not a question the owner can help
+ * with, so it is treated as absent rather than parked on.
+ */
+export function parsePendingQuestion(interactionId: unknown, payload: unknown): ControllerPendingQuestion | null {
+  if (typeof interactionId !== "string" || interactionId.length === 0) return null;
+  if (typeof payload !== "object" || payload === null) return null;
+  const candidate = payload as Record<string, unknown>;
+  if (candidate.kind !== "user_question" || !Array.isArray(candidate.questions)) return null;
+  const questions = candidate.questions
+    .slice(0, MAX_QUESTIONS)
+    .map(parseQuestion)
+    .filter((question): question is ControllerQuestion => question !== null);
+  if (questions.length === 0) return null;
+  return { interactionId, questions };
+}
+
+/**
+ * Telegram callback data is capped at 64 bytes, and BB option values alone run
+ * past that, so buttons carry a digest of the option they stand for and the
+ * option itself is recovered from the parked question.
+ */
+export function questionOptionToken(
+  interactionId: string,
+  questionId: string,
+  optionValue: string,
+): string {
+  return createHash("sha256")
+    .update(`controller-question:${interactionId}:${questionId}:${optionValue}`, "utf8")
+    .digest("base64url")
+    .slice(0, 32);
+}
+
+export type RenderedQuestion = {
+  text: string;
+  reply_markup: { inline_keyboard: { text: string; callback_data: string }[][] };
+};
+
+/**
+ * One question per message. Telegram gives a button no room to say which
+ * question it belongs to, so asking them in sequence is what keeps a tap
+ * unambiguous.
+ */
+export function renderQuestion(
+  interactionId: string,
+  question: ControllerQuestion,
+  callbackPrefix = "q",
+): RenderedQuestion {
+  const lines = [question.prompt];
+  for (const option of question.options) {
+    lines.push(option.description === null ? `• ${option.label}` : `• ${option.label} — ${option.description}`);
+  }
+  if (question.allowFreeText) lines.push("Or just reply with your own answer.");
+  return {
+    text: lines.join("\n\n"),
+    reply_markup: {
+      inline_keyboard: question.options.map((option) => [{
+        text: option.label,
+        callback_data: `${callbackPrefix}:${questionOptionToken(interactionId, question.id, option.value)}`,
+      }]),
+    },
+  };
+}
+
+/** What a worker thread is blocked on: a question, or a permission request. */
+export type ThreadApprovalDecision = "allow_once" | "allow_for_session" | "deny";
+export type ThreadInteraction =
+  | { kind: "user_question"; interactionId: string; questions: ControllerQuestion[] }
+  | { kind: "approval"; interactionId: string; summary: string; decisions: ThreadApprovalDecision[] }
+  /** A block the plugin can name but not answer, so the owner still hears about it. */
+  | { kind: "unsupported"; interactionId: string };
+
+const APPROVAL_LABELS: Record<ThreadApprovalDecision, string> = {
+  allow_once: "Allow once",
+  allow_for_session: "Allow all session",
+  deny: "Deny",
+};
+
+function approvalSummary(subject: Record<string, unknown>): string | null {
+  if (subject.kind === "command") {
+    const command = boundedString(subject.command, MAX_PROMPT);
+    if (!command) return null;
+    const cwd = boundedString(subject.cwd, 120);
+    return cwd ? `wants to run:\n\n\`${command}\`\n\nin ${cwd}` : `wants to run:\n\n\`${command}\``;
+  }
+  if (subject.kind === "file_change") {
+    const scope = boundedString(subject.writeScope, 200);
+    return scope ? `wants to write files under ${scope}` : "wants to write files";
+  }
+  return null;
+}
+
+/**
+ * Reads whatever a thread is waiting on into something answerable from a phone.
+ * A block the plugin cannot represent still comes back as `unsupported` rather
+ * than null: guessing at buttons would resolve it wrongly, but saying nothing
+ * leaves the thread waiting on an owner who was never told.
+ */
+export function parseThreadInteraction(interactionId: unknown, payload: unknown): ThreadInteraction | null {
+  if (typeof interactionId !== "string" || interactionId.length === 0) return null;
+  if (typeof payload !== "object" || payload === null) return null;
+  const candidate = payload as Record<string, unknown>;
+  if (candidate.kind === "user_question") {
+    const question = parsePendingQuestion(interactionId, payload);
+    return question
+      ? { kind: "user_question", interactionId, questions: question.questions }
+      : { kind: "unsupported", interactionId };
+  }
+  if (candidate.kind !== "approval") return { kind: "unsupported", interactionId };
+  const subject = candidate.subject;
+  const summary = typeof subject === "object" && subject !== null
+    ? approvalSummary(subject as Record<string, unknown>)
+    : null;
+  const offered = Array.isArray(candidate.decisions) ? candidate.decisions : Object.keys(APPROVAL_LABELS);
+  const decisions = (Object.keys(APPROVAL_LABELS) as ThreadApprovalDecision[])
+    .filter((decision) => offered.includes(decision));
+  if (!summary || decisions.length === 0) return { kind: "unsupported", interactionId };
+  return { kind: "approval", interactionId, summary, decisions };
+}
+
+export function threadDecisionToken(interactionId: string, decision: string): string {
+  return createHash("sha256")
+    .update(`thread-interaction:${interactionId}:${decision}`, "utf8")
+    .digest("base64url")
+    .slice(0, 32);
+}
+
+/** The message that asks the owner to unblock a thread, with its buttons. */
+export function renderThreadInteraction(
+  title: string,
+  interaction: ThreadInteraction,
+): RenderedQuestion | { text: string } {
+  if (interaction.kind === "unsupported") {
+    return { text: `*${title}* is waiting on something I can't answer from here. It needs you in BB.` };
+  }
+  if (interaction.kind === "user_question") {
+    const first = interaction.questions[0];
+    if (!first) throw new TypeError("a thread question must have a question");
+    const rendered = renderQuestion(interaction.interactionId, first, "w");
+    return { ...rendered, text: `*${title}* needs your answer.\n\n${rendered.text}` };
+  }
+  return {
+    text: `*${title}* ${interaction.summary}`,
+    reply_markup: {
+      inline_keyboard: interaction.decisions.map((decision) => [{
+        text: APPROVAL_LABELS[decision],
+        callback_data: `w:${threadDecisionToken(interaction.interactionId, decision)}`,
+      }]),
+    },
+  };
+}
+
+/** The next question still waiting on the owner, or null once all are settled. */
+export function nextUnansweredQuestion(
+  questions: readonly ControllerQuestion[],
+  answers: ControllerQuestionAnswers,
+): { question: ControllerQuestion; index: number } | null {
+  const index = questions.findIndex((question) => !(question.id in answers));
+  const question = questions[index];
+  return question ? { question, index } : null;
+}

--- a/src/controller/service.ts
+++ b/src/controller/service.ts
@@ -15,6 +15,15 @@ const CONTROLLER_DRAFT_REFRESH_MS = 20_000;
 // How long a queued message may wait for a busy controller thread before the
 // owner is told it will not be answered.
 const CONTROLLER_BUSY_WAIT_MS = 10 * 60_000;
+/**
+ * How long a submitted turn may go without producing a single BB event before
+ * it is treated as wedged. Any event at all — reasoning, a tool call, output —
+ * resets this, so only a thread that has genuinely stopped trips it. Silence is
+ * the worst answer the owner can get, so it is bounded even when BB still
+ * reports the thread as active.
+ */
+export const CONTROLLER_STALL_MS = 8 * 60_000;
+const MAX_STEER_ATTEMPTS = 3;
 
 function boundedResponse(value: string): string | null {
   const text = value.trim();
@@ -162,6 +171,27 @@ export class LunaControllerService {
       });
     }
 
+    // An answer the owner already gave outranks anything else: until BB hears
+    // it, the thread cannot make progress and every other check is noise.
+    const ownerAnswer = this.dependencies.store.getAnsweredControllerQuestion(controller.controllerKey);
+    if (ownerAnswer) {
+      try {
+        await this.dependencies.adapter.answerQuestion(
+          controller.threadId,
+          ownerAnswer.interactionId,
+          ownerAnswer.answers,
+          signal,
+        );
+      } catch {
+        return false;
+      }
+      this.dependencies.store.markControllerQuestionDelivered({
+        ...fenceAt(fence, this.dependencies.clock.now()),
+        interactionId: ownerAnswer.interactionId,
+      });
+      return true;
+    }
+
     let status: ControllerStatus;
     try {
       status = await this.dependencies.adapter.status(controller.threadId, signal);
@@ -192,13 +222,69 @@ export class LunaControllerService {
     } catch {
       observation = null;
     }
+    if (observation?.pendingQuestion) {
+      this.dependencies.store.recordControllerQuestion({
+        ...fenceAt(fence, this.dependencies.clock.now()),
+        turnId: submitted.id,
+        interactionId: observation.pendingQuestion.interactionId,
+        questions: observation.pendingQuestion.questions,
+      });
+    }
     const refreshedAt = this.dependencies.clock.now();
-    this.dependencies.store.refreshControllerDraft({
-      ...fenceAt(fence, refreshedAt),
-      turnId: submitted.id,
-      sentBefore: Math.max(0, refreshedAt - CONTROLLER_DRAFT_REFRESH_MS),
-    });
-    if (status === "active" || status === "starting" || status === "stopping") return true;
+    // A turn parked on a question is waiting on a person. Redrawing its draft
+    // would only replace the question with stale half-written output.
+    const parked = this.dependencies.store.getControllerTurn(submitted.id)?.awaitingInteractionId ?? null;
+    if (parked === null) {
+      this.dependencies.store.refreshControllerDraft({
+        ...fenceAt(fence, refreshedAt),
+        turnId: submitted.id,
+        sentBefore: Math.max(0, refreshedAt - CONTROLLER_DRAFT_REFRESH_MS),
+      });
+    }
+    if (status === "active" || status === "starting" || status === "stopping") {
+      // Anything the owner says while an answer is being written belongs to that
+      // answer. Holding it back until the turn ends is how a correction arrives
+      // too late to correct anything.
+      const waiting = parked === null
+        ? this.dependencies.store.getQueuedControllerTurn(controller.controllerKey)
+        : null;
+      if (waiting && waiting.retryCount < MAX_STEER_ATTEMPTS) {
+        try {
+          await this.dependencies.adapter.steer(controller.threadId, waiting.inputText, signal);
+        } catch {
+          // Out of attempts it stays queued, and the ordinary dispatch answers
+          // it once the turn in flight finishes.
+          this.dependencies.store.recordControllerSteerFailure({
+            ...fenceAt(fence, this.dependencies.clock.now()),
+            turnId: waiting.id,
+          });
+          return true;
+        }
+        this.dependencies.store.foldControllerTurnIntoRunning({
+          ...fenceAt(fence, this.dependencies.clock.now()),
+          turnId: waiting.id,
+        });
+        return true;
+      }
+      if (parked === null && refreshedAt - submitted.updatedAt >= CONTROLLER_STALL_MS) {
+        // Retiring the thread is the half that matters. Failing only the turn
+        // leaves the wedge in place, and every later message then waits out the
+        // busy timeout against a thread that will never go idle.
+        this.dependencies.store.resetControllerThread({
+          ...fenceAt(fence, this.dependencies.clock.now()),
+          controllerKey: controller.controllerKey,
+          expectedThreadId: controller.threadId,
+          reason: "Thread stopped producing events mid-answer",
+        });
+        this.fail(
+          submitted,
+          fence,
+          "Controller turn stopped producing events",
+          "That one stalled, so I gave up on it and started a fresh session. Ask me again.",
+        );
+      }
+      return true;
+    }
     if (status === "missing") {
       this.dependencies.store.resetControllerThread({
         ...fenceAt(fence, this.dependencies.clock.now()),
@@ -326,11 +412,17 @@ export class LunaControllerService {
     this.dependencies.store.requeueControllerTurn({ ...fenceAt(fence, now), turnId: turn.id });
   }
 
-  private fail(turn: ControllerTurnRecord, fence: EffectFence, error: string): void {
+  private fail(
+    turn: ControllerTurnRecord,
+    fence: EffectFence,
+    error: string,
+    ownerMessage?: string,
+  ): void {
     this.dependencies.store.failControllerTurn({
       ...fenceAt(fence, this.dependencies.clock.now()),
       turnId: turn.id,
       error,
+      ownerMessage,
     });
   }
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -34,6 +34,7 @@ import {
 import { LunaControllerService } from "./controller/service";
 import { TelegramPresenceCoordinator } from "./services/telegram-presence";
 import { MonitorService } from "./services/monitor-service";
+import { ThreadNoticeService } from "./services/thread-notice-service";
 import { buildHealthReport } from "./services/health-report";
 import { ThreadOperationService } from "./controller/operations";
 import { settlePipelineStageOutput } from "./services/pipeline-stage-runner";
@@ -366,6 +367,39 @@ export async function createPlugin(bb: BbPluginApi): Promise<void> {
     clock: { now: clock },
     warn: (message) => bb.log.warn(message),
   });
+  const threadNotices = new ThreadNoticeService({
+    store,
+    threads: {
+      listWatchable: async () => {
+        const threads = await bb.sdk.threads.list({ includeHidden: false, archived: false, limit: 100 });
+        return threads
+          .filter((thread) => thread.visibility === "visible" && thread.archivedAt === null && thread.deletedAt === null)
+          .map((thread) => ({
+            id: thread.id,
+            title: thread.title ?? thread.titleFallback ?? "Untitled thread",
+            status: thread.status,
+            parentThreadId: thread.parentThreadId,
+          }));
+      },
+      interactions: async (threadId) => {
+        const pending = await bb.sdk.threads.interactions.list({ threadId });
+        return pending.map((interaction) => ({
+          id: interaction.id,
+          status: interaction.status,
+          payload: interaction.payload,
+        }));
+      },
+      resolve: async (threadId, interactionId, resolution) => {
+        await bb.sdk.threads.interactions.resolve({
+          threadId,
+          interactionId,
+          resolution: resolution as Parameters<typeof bb.sdk.threads.interactions.resolve>[0]["resolution"],
+        });
+      },
+    },
+    clock: { now: clock },
+    warn: (message) => bb.log.warn(message),
+  });
   const presence = new TelegramPresenceCoordinator({
     store,
     telegram: {
@@ -618,6 +652,7 @@ export async function createPlugin(bb: BbPluginApi): Promise<void> {
       controller,
       operations: threadOperations,
       monitors,
+      threadNotices,
       presence,
       waitForWork: (milliseconds, signal) => executorNudge.wait(milliseconds, signal),
     }, signal),

--- a/src/services/job-executor-service.ts
+++ b/src/services/job-executor-service.ts
@@ -37,6 +37,9 @@ export type JobExecutorDependencies = {
   monitors?: {
     processDue(): Promise<boolean>;
   };
+  threadNotices?: {
+    processDue(): Promise<boolean>;
+  };
   presence?: {
     pulse(now: number, signal: AbortSignal): Promise<number | null>;
     reset(): void;
@@ -221,6 +224,9 @@ export async function runJobExecutorService(deps: JobExecutorDependencies, signa
         }
         if (deps.monitors) {
           didWork = await deps.monitors.processDue() || didWork;
+        }
+        if (deps.threadNotices) {
+          didWork = await deps.threadNotices.processDue() || didWork;
         }
         const jobs = deps.store.listJobs(1_000);
         for (const job of jobs) {

--- a/src/services/telegram-presence.ts
+++ b/src/services/telegram-presence.ts
@@ -27,7 +27,11 @@ const JOB_WORKER_KIND: Partial<Record<JobState, WorkerKind>> = {
 type PresenceStore = {
   getOwner(): { userId: string; chatId: string } | null;
   getControllerForOwner(userId: string, chatId: string): { controllerKey: string } | null;
-  getPendingControllerTurn(controllerKey: string): { id: string; state: ControllerTurnState } | null;
+  getPendingControllerTurn(controllerKey: string): {
+    id: string;
+    state: ControllerTurnState;
+    awaitingInteractionId?: string | null;
+  } | null;
   getActiveJob(): { id: string; state: JobState } | null;
   getWorkerLiveness(jobId: string): WorkerLiveness | null;
 };
@@ -47,9 +51,11 @@ function controllerPresenceTarget(store: PresenceStore, owner: PresenceOwner): T
   const controller = store.getControllerForOwner(owner.userId, owner.chatId);
   if (!controller) return null;
   const turn = store.getPendingControllerTurn(controller.controllerKey);
-  return turn && CONTROLLER_PRESENCE_STATES.has(turn.state)
-    ? { key: `controller:${turn.id}`, chatId: owner.chatId }
-    : null;
+  if (!turn || !CONTROLLER_PRESENCE_STATES.has(turn.state)) return null;
+  // Typing while the ball is in the owner's court is a lie: the turn is waiting
+  // on their answer, not composing one.
+  if (turn.awaitingInteractionId) return null;
+  return { key: `controller:${turn.id}`, chatId: owner.chatId };
 }
 
 function workerPresenceTarget(store: PresenceStore, owner: PresenceOwner): TelegramPresenceTarget | null {

--- a/src/services/thread-notice-service.ts
+++ b/src/services/thread-notice-service.ts
@@ -1,0 +1,137 @@
+import { redactError } from "../errors";
+import { parseThreadInteraction } from "../controller/questions";
+import type { TelegramAgentStore } from "../storage/store";
+
+export type WatchedThread = {
+  id: string;
+  title: string;
+  status: string;
+  parentThreadId: string | null;
+};
+
+export type PendingThreadInteraction = {
+  id: string;
+  status: string;
+  payload: unknown;
+};
+
+export type ThreadNoticeThreads = {
+  listWatchable(): Promise<WatchedThread[]>;
+  interactions(threadId: string): Promise<PendingThreadInteraction[]>;
+  resolve(threadId: string, interactionId: string, resolution: Record<string, unknown>): Promise<void>;
+};
+
+export type ThreadNoticeServiceDependencies = {
+  store: Pick<
+    TelegramAgentStore,
+    | "getOwner"
+    | "observeThread"
+    | "recordThreadInteraction"
+    | "getAnsweredThreadInteraction"
+    | "markThreadInteractionDelivered"
+    | "discardThreadInteractions"
+  >;
+  threads: ThreadNoticeThreads;
+  clock: { now(): number };
+  warn?: (message: string) => void;
+};
+
+// Only threads that are doing something can start needing something, so the
+// interaction check is limited to those rather than every thread on the board.
+const BLOCKABLE_STATUSES = new Set(["active", "starting", "stopping"]);
+/**
+ * A sweep costs one thread list plus one interaction read per working thread,
+ * and the executor loop it rides on runs as often as every 250ms while an
+ * answer streams. Pacing it here keeps a background courtesy from turning into
+ * a flood of BB calls; a blocked thread waits seconds longer to be reported,
+ * which is nothing next to how long the owner would otherwise wait.
+ */
+const SWEEP_INTERVAL_MS = 15_000;
+
+/**
+ * Tells the owner when a thread finishes or gets blocked, and carries their
+ * answer back. The owner runs BB entirely from Telegram, so a thread waiting on
+ * a click in the BB app is a thread that waits forever.
+ */
+export class ThreadNoticeService {
+  private sweptAt: number | null = null;
+
+  public constructor(private readonly dependencies: ThreadNoticeServiceDependencies) {}
+
+  public async processDue(): Promise<boolean> {
+    const owner = this.dependencies.store.getOwner();
+    if (!owner) return false;
+    // The owner's own tap is not a background courtesy: it goes out at once.
+    let didWork = await this.deliverAnswer();
+    const now = this.dependencies.clock.now();
+    if (this.sweptAt !== null && now - this.sweptAt < SWEEP_INTERVAL_MS) return didWork;
+    this.sweptAt = now;
+    let threads: WatchedThread[];
+    try {
+      threads = await this.dependencies.threads.listWatchable();
+    } catch (error) {
+      this.warn("Watched threads could not be listed", error);
+      return didWork;
+    }
+    for (const thread of threads) {
+      // A sub-agent's thread is the parent's business, not the owner's; they
+      // asked to hear about the work they started, not each step inside it.
+      if (thread.parentThreadId !== null) continue;
+      if (this.dependencies.store.observeThread({
+        threadId: thread.id,
+        title: thread.title,
+        status: thread.status,
+        chatId: owner.chatId,
+        now,
+      }) !== null) didWork = true;
+      if (!BLOCKABLE_STATUSES.has(thread.status)) continue;
+      didWork = await this.checkBlocked(thread, owner.chatId) || didWork;
+    }
+    return didWork;
+  }
+
+  private async checkBlocked(thread: WatchedThread, chatId: string): Promise<boolean> {
+    let pending: PendingThreadInteraction[];
+    try {
+      pending = await this.dependencies.threads.interactions(thread.id);
+    } catch (error) {
+      this.warn(`Interactions for ${thread.id} could not be read`, error);
+      return false;
+    }
+    const open = pending.filter((interaction) => interaction.status === "pending");
+    this.dependencies.store.discardThreadInteractions(thread.id, open.map((interaction) => interaction.id));
+    let asked = false;
+    for (const candidate of open) {
+      const interaction = parseThreadInteraction(candidate.id, candidate.payload);
+      if (!interaction) continue;
+      if (this.dependencies.store.recordThreadInteraction({
+        interactionId: candidate.id,
+        threadId: thread.id,
+        title: thread.title,
+        interaction,
+        chatId,
+        now: this.dependencies.clock.now(),
+      })) asked = true;
+    }
+    return asked;
+  }
+
+  private async deliverAnswer(): Promise<boolean> {
+    const answered = this.dependencies.store.getAnsweredThreadInteraction();
+    if (!answered) return false;
+    try {
+      await this.dependencies.threads.resolve(answered.threadId, answered.interactionId, answered.resolution);
+    } catch (error) {
+      this.warn(`Answer for ${answered.threadId} could not be delivered`, error);
+      return false;
+    }
+    return this.dependencies.store.markThreadInteractionDelivered(
+      answered.interactionId,
+      this.dependencies.clock.now(),
+    );
+  }
+
+  private warn(message: string, error: unknown): void {
+    this.dependencies.warn?.(`${message}: ${redactError(error).slice(0, 200)}`);
+  }
+}

--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -458,6 +458,66 @@ CREATE TABLE controller_generations (
 CREATE INDEX controller_generations_key ON controller_generations (controller_key, started_at);
 `] as const;
 
+export const CONTROLLER_QUESTION_MIGRATIONS = [String.raw`
+ALTER TABLE controller_turns ADD COLUMN awaiting_interaction_id TEXT;
+CREATE TABLE controller_questions (
+  interaction_id TEXT PRIMARY KEY,
+  turn_id TEXT NOT NULL REFERENCES controller_turns(id),
+  controller_key TEXT NOT NULL REFERENCES controller_threads(controller_key),
+  questions_json TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('pending', 'answered', 'delivered')),
+  answers_json TEXT,
+  asked_at INTEGER NOT NULL,
+  answered_at INTEGER
+);
+CREATE INDEX controller_questions_pending ON controller_questions (controller_key, state, asked_at);
+`] as const;
+
+export const THREAD_NOTICE_MIGRATIONS = [String.raw`
+CREATE TABLE observed_threads (
+  thread_id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  last_status TEXT NOT NULL,
+  notified_status TEXT,
+  first_seen_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE TABLE thread_interactions (
+  interaction_id TEXT PRIMARY KEY,
+  thread_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('user_question', 'approval')),
+  payload_json TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('pending', 'answered', 'delivered')),
+  answer_json TEXT,
+  asked_at INTEGER NOT NULL,
+  answered_at INTEGER
+);
+CREATE INDEX thread_interactions_state ON thread_interactions (state, asked_at);
+`] as const;
+
+export const UNSUPPORTED_INTERACTION_MIGRATIONS = [String.raw`
+CREATE TABLE thread_interactions_v2 (
+  interaction_id TEXT PRIMARY KEY,
+  thread_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('user_question', 'approval', 'unsupported')),
+  payload_json TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('pending', 'answered', 'delivered')),
+  answer_json TEXT,
+  asked_at INTEGER NOT NULL,
+  answered_at INTEGER
+);
+INSERT INTO thread_interactions_v2 SELECT * FROM thread_interactions;
+DROP TABLE thread_interactions;
+ALTER TABLE thread_interactions_v2 RENAME TO thread_interactions;
+CREATE INDEX thread_interactions_state_v2 ON thread_interactions (state, asked_at);
+`] as const;
+
+export const NOTICE_COOLDOWN_MIGRATIONS = [String.raw`
+ALTER TABLE observed_threads ADD COLUMN notified_at INTEGER;
+`] as const;
+
 export const ALL_MIGRATIONS = [
   ...INITIAL_MIGRATIONS,
   ...TASK_3_MIGRATIONS,
@@ -471,4 +531,8 @@ export const ALL_MIGRATIONS = [
   ...MEMORY_MIGRATIONS,
   ...MONITOR_MIGRATIONS,
   ...CONTINUITY_MIGRATIONS,
+  ...CONTROLLER_QUESTION_MIGRATIONS,
+  ...THREAD_NOTICE_MIGRATIONS,
+  ...UNSUPPORTED_INTERACTION_MIGRATIONS,
+  ...NOTICE_COOLDOWN_MIGRATIONS,
 ] as const;

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -23,6 +23,16 @@ import type {
   ControllerTurnRecord,
   ControllerTurnState,
 } from "../controller/models";
+import {
+  nextUnansweredQuestion,
+  questionOptionToken,
+  renderQuestion,
+  renderThreadInteraction,
+  threadDecisionToken,
+  type ControllerQuestion,
+  type ControllerQuestionAnswers,
+  type ThreadInteraction,
+} from "../controller/questions";
 
 type PluginStorage = BbPluginApi["storage"];
 type SqliteDatabase = Database.Database;
@@ -537,9 +547,67 @@ type ControllerTurnRow = {
   last_error: string | null;
   submitted_at: number | null;
   completed_at: number | null;
+  awaiting_interaction_id: string | null;
   created_at: number;
   updated_at: number;
 };
+type ControllerQuestionRow = {
+  interaction_id: string;
+  turn_id: string;
+  controller_key: string;
+  questions_json: string;
+  state: "pending" | "answered";
+  answers_json: string;
+  asked_at: number;
+  answered_at: number | null;
+};
+export type ControllerQuestionRecord = {
+  interactionId: string;
+  turnId: string;
+  controllerKey: string;
+  questions: ControllerQuestion[];
+  answers: ControllerQuestionAnswers;
+  askedAt: number;
+};
+type ObservedThreadRow = {
+  thread_id: string;
+  title: string;
+  last_status: string;
+  notified_status: string | null;
+  notified_at: number | null;
+  first_seen_at: number;
+  updated_at: number;
+};
+type ThreadInteractionRow = {
+  interaction_id: string;
+  thread_id: string;
+  title: string;
+  kind: ThreadInteraction["kind"];
+  payload_json: string;
+  state: "pending" | "answered" | "delivered";
+  answer_json: string | null;
+  asked_at: number;
+  answered_at: number | null;
+};
+export type ThreadInteractionAnswer =
+  | { ok: true; interactionId: string; threadId: string; title: string; label: string }
+  | { ok: false; reason: "stale" };
+export type ThreadInteractionDelivery = {
+  interactionId: string;
+  threadId: string;
+  title: string;
+  resolution: Record<string, unknown>;
+};
+export type ControllerQuestionAnswer =
+  | {
+    ok: true;
+    /** False while the same interaction still has questions the owner has not settled. */
+    complete: boolean;
+    turnId: string;
+    interactionId: string;
+    answers: ControllerQuestionAnswers;
+  }
+  | { ok: false; reason: "stale" };
 type ThreadOperationRow = {
   id: string;
   nonce_hash: string;
@@ -1533,6 +1601,52 @@ export interface TelegramAgentStore {
     turnId: string;
     sentBefore: number;
   }): boolean;
+  recordControllerQuestion(input: ControllerLeaseFence & {
+    turnId: string;
+    interactionId: string;
+    questions: readonly ControllerQuestion[];
+  }): boolean;
+  answerControllerQuestion(input: {
+    token: string;
+    userId: string;
+    chatId: string;
+    now: number;
+  }): ControllerQuestionAnswer;
+  answerControllerQuestionWithText(input: {
+    controllerKey: string;
+    text: string;
+    now: number;
+  }): ControllerQuestionAnswer;
+  observeThread(input: {
+    threadId: string;
+    title: string;
+    status: string;
+    chatId: string;
+    now: number;
+  }): "finished" | "failed" | null;
+  recordThreadInteraction(input: {
+    interactionId: string;
+    threadId: string;
+    title: string;
+    interaction: ThreadInteraction;
+    chatId: string;
+    now: number;
+  }): boolean;
+  answerThreadInteraction(input: {
+    token: string;
+    userId: string;
+    chatId: string;
+    now: number;
+  }): ThreadInteractionAnswer;
+  getAnsweredThreadInteraction(): ThreadInteractionDelivery | null;
+  markThreadInteractionDelivered(interactionId: string, now: number): boolean;
+  discardThreadInteractions(threadId: string, keep: readonly string[]): number;
+  getPendingControllerQuestion(controllerKey: string): ControllerQuestionRecord | null;
+  getAnsweredControllerQuestion(controllerKey: string): ControllerQuestionRecord | null;
+  markControllerQuestionDelivered(input: ControllerLeaseFence & { interactionId: string }): boolean;
+  getQueuedControllerTurn(controllerKey: string): ControllerTurnRecord | null;
+  recordControllerSteerFailure(input: ControllerLeaseFence & { turnId: string }): boolean;
+  foldControllerTurnIntoRunning(input: ControllerLeaseFence & { turnId: string }): boolean;
   resetControllerThread(input: ControllerLeaseFence & {
     controllerKey: string;
     expectedThreadId: string;
@@ -1546,6 +1660,7 @@ export interface TelegramAgentStore {
   failControllerTurn(input: ControllerLeaseFence & {
     turnId: string;
     error: string;
+    ownerMessage?: string;
     leaseMs?: number;
   }): boolean;
   listControllerTurns(controllerKey: string, limit: number): ControllerTurnRecord[];
@@ -1881,6 +1996,7 @@ function parseControllerTurn(row: ControllerTurnRow): ControllerTurnRecord {
     lastError: row.last_error,
     submittedAt: row.submitted_at,
     completedAt: row.completed_at,
+    awaitingInteractionId: row.awaiting_interaction_id ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -2012,12 +2128,50 @@ function parseMemory(row: MemoryRow): MemoryRecord {
   };
 }
 
-function controllerFailureOutbox(turnId: string, chatId: string): OutboxInput {
+/**
+ * Recovers which button was tapped. Callback data carries only a digest, so the
+ * candidates are re-derived from the stored interaction and compared.
+ */
+// Statuses a thread can stop working *from*. Reaching idle or error from
+// anything else is bookkeeping, not news.
+const WORKING_THREAD_STATUSES = new Set(["active", "starting", "stopping"]);
+const NOTICE_COOLDOWN_MS = 10 * 60_000;
+
+function matchThreadInteractionToken(
+  interaction: ThreadInteraction,
+  token: string,
+): { label: string; resolution: Record<string, unknown> } | null {
+  if (interaction.kind === "unsupported") return null;
+  if (interaction.kind === "approval") {
+    for (const decision of interaction.decisions) {
+      if (threadDecisionToken(interaction.interactionId, decision) !== token) continue;
+      return {
+        label: decision === "deny" ? "Denied" : "Allowed",
+        resolution: decision === "deny"
+          ? { decision }
+          : { decision, grantedPermissions: null },
+      };
+    }
+    return null;
+  }
+  for (const question of interaction.questions) {
+    for (const option of question.options) {
+      if (questionOptionToken(interaction.interactionId, question.id, option.value) !== token) continue;
+      return {
+        label: option.label,
+        resolution: { kind: "user_answer", answers: { [question.id]: { selected: [option.value] } } },
+      };
+    }
+  }
+  return null;
+}
+
+function controllerFailureOutbox(turnId: string, chatId: string, ownerMessage?: string): OutboxInput {
   return {
     logicalKey: `controller:${turnId}:reply`,
     chatId,
     payload: {
-      text: "I couldn't complete that controller turn safely. Please resend your request.",
+      text: ownerMessage ?? "I couldn't complete that controller turn safely. Please resend your request.",
       disable_web_page_preview: true,
     },
   };
@@ -2843,6 +2997,449 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
     }).immediate();
   }
 
+  /**
+   * Parks a submitted turn on a question only the owner can settle and asks it
+   * in Telegram. The turn stays submitted because the BB turn really is still
+   * open — it is waiting on a person, not on the model.
+   */
+  public recordControllerQuestion(input: ControllerLeaseFence & {
+    turnId: string;
+    interactionId: string;
+    questions: readonly ControllerQuestion[];
+  }): boolean {
+    this.assertControllerMutation(input);
+    assertControllerIdentifier(input.interactionId, "interactionId");
+    if (input.questions.length === 0) throw new TypeError("a controller question must have questions");
+    return this.db.transaction((): boolean => {
+      if (!this.executorLeaseIsCurrent(input.ownerId, input.generation, input.now)) return false;
+      const row = this.db.prepare(
+        `SELECT turn.*, controller.telegram_chat_id FROM controller_turns AS turn
+           JOIN controller_threads AS controller ON controller.controller_key = turn.controller_key
+          WHERE turn.id = ? AND turn.state = 'submitted'`,
+      ).get(input.turnId) as (ControllerTurnRow & { telegram_chat_id: string }) | undefined;
+      if (!row) return false;
+      // Seeing the same question again on a later poll must not re-ask it.
+      const known = this.db.prepare("SELECT 1 FROM controller_questions WHERE interaction_id = ?")
+        .get(input.interactionId);
+      if (known) return false;
+      this.db.prepare(
+        `INSERT INTO controller_questions
+           (interaction_id, turn_id, controller_key, questions_json, state, answers_json, asked_at, answered_at)
+         VALUES (?, ?, ?, ?, 'pending', '{}', ?, NULL)`,
+      ).run(
+        input.interactionId,
+        row.id,
+        row.controller_key,
+        JSON.stringify(input.questions),
+        input.now,
+      );
+      this.db.prepare(
+        `UPDATE controller_turns SET awaiting_interaction_id = ?, updated_at = ?
+          WHERE id = ? AND state = 'submitted'`,
+      ).run(input.interactionId, input.now, input.turnId);
+      this.askControllerQuestion(input.interactionId, row.telegram_chat_id, input.questions, {}, input.now);
+      return true;
+    }).immediate();
+  }
+
+  private askControllerQuestion(
+    interactionId: string,
+    chatId: string,
+    questions: readonly ControllerQuestion[],
+    answers: ControllerQuestionAnswers,
+    now: number,
+  ): void {
+    const next = nextUnansweredQuestion(questions, answers);
+    if (!next) return;
+    const rendered = renderQuestion(interactionId, next.question);
+    persistControllerOutbox(this.db, {
+      logicalKey: `controller-question:${interactionId}:${next.index}`,
+      chatId,
+      payload: {
+        ...formattedMessage(rendered.text),
+        reply_markup: rendered.reply_markup,
+        disable_web_page_preview: true,
+      },
+    }, now);
+  }
+
+  private settleControllerQuestion(
+    row: ControllerQuestionRow,
+    questionId: string,
+    answer: { selected: string[]; freeText?: string },
+    now: number,
+  ): ControllerQuestionAnswer {
+    const questions = JSON.parse(row.questions_json) as ControllerQuestion[];
+    const answers = { ...JSON.parse(row.answers_json) as ControllerQuestionAnswers, [questionId]: answer };
+    const complete = nextUnansweredQuestion(questions, answers) === null;
+    const updated = this.db.prepare(
+      `UPDATE controller_questions
+          SET answers_json = ?, state = ?, answered_at = ?
+        WHERE interaction_id = ? AND state = 'pending'`,
+    ).run(
+      JSON.stringify(answers),
+      complete ? "answered" : "pending",
+      complete ? now : null,
+      row.interaction_id,
+    );
+    if (updated.changes !== 1) return { ok: false, reason: "stale" };
+    if (complete) {
+      this.db.prepare(
+        `UPDATE controller_turns SET awaiting_interaction_id = NULL, updated_at = ?
+          WHERE id = ? AND awaiting_interaction_id = ?`,
+      ).run(now, row.turn_id, row.interaction_id);
+    } else {
+      const chatId = this.db.prepare(
+        "SELECT telegram_chat_id FROM controller_threads WHERE controller_key = ?",
+      ).get(row.controller_key) as { telegram_chat_id: string } | undefined;
+      if (chatId) this.askControllerQuestion(row.interaction_id, chatId.telegram_chat_id, questions, answers, now);
+    }
+    return {
+      ok: true,
+      complete,
+      turnId: row.turn_id,
+      interactionId: row.interaction_id,
+      answers,
+    };
+  }
+
+  /** Answers whichever question a tapped button stands for. */
+  public answerControllerQuestion(input: {
+    token: string;
+    userId: string;
+    chatId: string;
+    now: number;
+  }): ControllerQuestionAnswer {
+    assertCanonicalPositiveDecimal(input.userId, "userId");
+    assertCanonicalPositiveDecimal(input.chatId, "chatId");
+    assertNonNegativeInteger(input.now, "now");
+    return this.db.transaction((): ControllerQuestionAnswer => {
+      const row = this.db.prepare(
+        `SELECT question.* FROM controller_questions AS question
+           JOIN controller_threads AS controller ON controller.controller_key = question.controller_key
+           JOIN owners ON owners.singleton = 1 AND owners.revoked_at IS NULL
+            AND owners.telegram_user_id = controller.telegram_user_id
+            AND owners.telegram_chat_id = controller.telegram_chat_id
+           JOIN controller_turns AS turn ON turn.id = question.turn_id AND turn.state = 'submitted'
+          WHERE question.state = 'pending'
+            AND controller.telegram_user_id = ? AND controller.telegram_chat_id = ?
+          ORDER BY question.asked_at DESC LIMIT 1`,
+      ).get(input.userId, input.chatId) as ControllerQuestionRow | undefined;
+      if (!row) return { ok: false, reason: "stale" };
+      const questions = JSON.parse(row.questions_json) as ControllerQuestion[];
+      const answers = JSON.parse(row.answers_json) as ControllerQuestionAnswers;
+      for (const question of questions) {
+        if (question.id in answers) continue;
+        for (const option of question.options) {
+          if (questionOptionToken(row.interaction_id, question.id, option.value) !== input.token) continue;
+          return this.settleControllerQuestion(row, question.id, { selected: [option.value] }, input.now);
+        }
+      }
+      return { ok: false, reason: "stale" };
+    }).immediate();
+  }
+
+  /**
+   * A plain reply answers the open question. The owner is having a conversation,
+   * not filling in a form, so "in review i mean not in progress" is an answer.
+   */
+  public answerControllerQuestionWithText(input: {
+    controllerKey: string;
+    text: string;
+    now: number;
+  }): ControllerQuestionAnswer {
+    assertControllerKey(input.controllerKey);
+    assertControllerText(input.text, "controller question answer");
+    assertNonNegativeInteger(input.now, "now");
+    return this.db.transaction((): ControllerQuestionAnswer => {
+      const row = this.db.prepare(
+        `SELECT question.* FROM controller_questions AS question
+           JOIN controller_turns AS turn ON turn.id = question.turn_id AND turn.state = 'submitted'
+          WHERE question.controller_key = ? AND question.state = 'pending'
+          ORDER BY question.asked_at DESC LIMIT 1`,
+      ).get(input.controllerKey) as ControllerQuestionRow | undefined;
+      if (!row) return { ok: false, reason: "stale" };
+      const questions = JSON.parse(row.questions_json) as ControllerQuestion[];
+      const answers = JSON.parse(row.answers_json) as ControllerQuestionAnswers;
+      const next = nextUnansweredQuestion(questions, answers);
+      if (!next) return { ok: false, reason: "stale" };
+      return this.settleControllerQuestion(row, next.question.id, { selected: [], freeText: input.text }, input.now);
+    }).immediate();
+  }
+
+  /**
+   * Counts a steer BB would not take. The reconcile loop runs at draft speed
+   * while an answer streams, so an unbounded retry here would be a hot loop
+   * against BB rather than a recovery.
+   */
+  public recordControllerSteerFailure(input: ControllerLeaseFence & { turnId: string }): boolean {
+    this.assertControllerMutation(input);
+    return this.db.transaction((): boolean => {
+      if (!this.executorLeaseIsCurrent(input.ownerId, input.generation, input.now)) return false;
+      return this.db.prepare(
+        `UPDATE controller_turns SET retry_count = retry_count + 1, updated_at = ?
+          WHERE id = ? AND state = 'queued'`,
+      ).run(input.now, input.turnId).changes === 1;
+    }).immediate();
+  }
+
+  /** The oldest message still waiting behind an answer that is being written. */
+  public getQueuedControllerTurn(controllerKey: string): ControllerTurnRecord | null {
+    assertControllerKey(controllerKey);
+    const row = this.db.prepare(
+      `SELECT * FROM controller_turns WHERE controller_key = ? AND state = 'queued'
+        ORDER BY created_at ASC, ordinal ASC LIMIT 1`,
+    ).get(controllerKey) as ControllerTurnRow | undefined;
+    return row ? parseControllerTurn(row) : null;
+  }
+
+  /**
+   * Retires a queued message that was handed to the turn already running. It
+   * gets no reply of its own because the answer in flight now covers it —
+   * a correction like "I meant in review" wants the first answer fixed, not a
+   * second answer written.
+   */
+  public foldControllerTurnIntoRunning(input: ControllerLeaseFence & { turnId: string }): boolean {
+    this.assertControllerMutation(input);
+    return this.db.transaction((): boolean => {
+      if (!this.executorLeaseIsCurrent(input.ownerId, input.generation, input.now)) return false;
+      const row = this.db.prepare(
+        "SELECT * FROM controller_turns WHERE id = ? AND state = 'queued'",
+      ).get(input.turnId) as ControllerTurnRow | undefined;
+      if (!row) return false;
+      const folded = "(sent to the answer already in progress)";
+      const updated = this.db.prepare(
+        `UPDATE controller_turns
+            SET state = 'completed', response_text = ?, stream_phase = 'complete',
+                completed_at = ?, updated_at = ?
+          WHERE id = ? AND state = 'queued'`,
+      ).run(folded, input.now, input.now, input.turnId);
+      if (updated.changes !== 1) return false;
+      this.appendControllerDigestRow({
+        controllerKey: row.controller_key,
+        ordinal: row.ordinal,
+        ownerText: row.input_text,
+        agentText: folded,
+        now: input.now,
+      });
+      return true;
+    }).immediate();
+  }
+
+  /**
+   * Records where a watched thread stands and returns the notice the owner is
+   * owed, if any. A thread first seen already finished is recorded silently:
+   * the owner wants to hear about threads that finish while they are watching,
+   * not a backlog of every thread that ever ran.
+   */
+  public observeThread(input: {
+    threadId: string;
+    title: string;
+    status: string;
+    chatId: string;
+    now: number;
+  }): "finished" | "failed" | null {
+    assertControllerIdentifier(input.threadId, "threadId");
+    assertControllerText(input.title, "thread title");
+    assertNonNegativeInteger(input.now, "now");
+    return this.db.transaction((): "finished" | "failed" | null => {
+      const known = this.db.prepare("SELECT * FROM observed_threads WHERE thread_id = ?")
+        .get(input.threadId) as ObservedThreadRow | undefined;
+      if (!known) {
+        this.db.prepare(
+          `INSERT INTO observed_threads
+             (thread_id, title, last_status, notified_status, first_seen_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+        ).run(input.threadId, input.title, input.status, input.status, input.now, input.now);
+        return null;
+      }
+      this.db.prepare(
+        "UPDATE observed_threads SET title = ?, last_status = ?, updated_at = ? WHERE thread_id = ?",
+      ).run(input.title, input.status, input.now, input.threadId);
+      if (input.status === known.last_status) return null;
+      const notice = input.status === "idle" ? "finished" : input.status === "error" ? "failed" : null;
+      if (notice === null) return null;
+      // Only a thread that was working can stop working. A thread that finished
+      // and is marked failed afterwards has already had its say, and repeating
+      // it as a failure would contradict what the owner just read.
+      if (!WORKING_THREAD_STATUSES.has(known.last_status)) return null;
+      // A thread being steered turn by turn would otherwise narrate every reply.
+      if (known.notified_at !== null && input.now - known.notified_at < NOTICE_COOLDOWN_MS) return null;
+      this.db.prepare("UPDATE observed_threads SET notified_status = ?, notified_at = ? WHERE thread_id = ?")
+        .run(input.status, input.now, input.threadId);
+      persistControllerOutbox(this.db, {
+        logicalKey: `thread:${input.threadId}:${input.status}`,
+        chatId: input.chatId,
+        payload: {
+          ...formattedMessage(`*${input.title}* ${notice}.`),
+          disable_web_page_preview: true,
+        },
+      }, input.now);
+      return notice;
+    }).immediate();
+  }
+
+  /** Asks the owner to unblock a thread that is waiting on a decision. */
+  public recordThreadInteraction(input: {
+    interactionId: string;
+    threadId: string;
+    title: string;
+    interaction: ThreadInteraction;
+    chatId: string;
+    now: number;
+  }): boolean {
+    assertControllerIdentifier(input.interactionId, "interactionId");
+    assertControllerIdentifier(input.threadId, "threadId");
+    assertControllerText(input.title, "thread title");
+    assertNonNegativeInteger(input.now, "now");
+    return this.db.transaction((): boolean => {
+      const known = this.db.prepare("SELECT 1 FROM thread_interactions WHERE interaction_id = ?")
+        .get(input.interactionId);
+      if (known) return false;
+      this.db.prepare(
+        `INSERT INTO thread_interactions
+           (interaction_id, thread_id, title, kind, payload_json, state, answer_json, asked_at, answered_at)
+         VALUES (?, ?, ?, ?, ?, 'pending', NULL, ?, NULL)`,
+      ).run(
+        input.interactionId,
+        input.threadId,
+        input.title,
+        input.interaction.kind,
+        JSON.stringify(input.interaction),
+        input.now,
+      );
+      const rendered = renderThreadInteraction(input.title, input.interaction);
+      persistControllerOutbox(this.db, {
+        logicalKey: `thread-interaction:${input.interactionId}`,
+        chatId: input.chatId,
+        payload: {
+          ...formattedMessage(rendered.text),
+          ...("reply_markup" in rendered ? { reply_markup: rendered.reply_markup } : {}),
+          disable_web_page_preview: true,
+        },
+      }, input.now);
+      return true;
+    }).immediate();
+  }
+
+  /** Resolves a watched thread's block from a tapped button. */
+  public answerThreadInteraction(input: {
+    token: string;
+    userId: string;
+    chatId: string;
+    now: number;
+  }): ThreadInteractionAnswer {
+    assertCanonicalPositiveDecimal(input.userId, "userId");
+    assertCanonicalPositiveDecimal(input.chatId, "chatId");
+    assertNonNegativeInteger(input.now, "now");
+    return this.db.transaction((): ThreadInteractionAnswer => {
+      const owner = this.db.prepare(
+        `SELECT 1 FROM owners WHERE singleton = 1 AND revoked_at IS NULL
+          AND telegram_user_id = ? AND telegram_chat_id = ?`,
+      ).get(input.userId, input.chatId);
+      if (!owner) return { ok: false, reason: "stale" };
+      const rows = this.db.prepare(
+        "SELECT * FROM thread_interactions WHERE state = 'pending' ORDER BY asked_at DESC LIMIT 20",
+      ).all() as ThreadInteractionRow[];
+      for (const row of rows) {
+        const interaction = JSON.parse(row.payload_json) as ThreadInteraction;
+        const matched = matchThreadInteractionToken(interaction, input.token);
+        if (!matched) continue;
+        const updated = this.db.prepare(
+          `UPDATE thread_interactions SET state = 'answered', answer_json = ?, answered_at = ?
+            WHERE interaction_id = ? AND state = 'pending'`,
+        ).run(JSON.stringify(matched.resolution), input.now, row.interaction_id);
+        if (updated.changes !== 1) return { ok: false, reason: "stale" };
+        return {
+          ok: true,
+          interactionId: row.interaction_id,
+          threadId: row.thread_id,
+          title: row.title,
+          label: matched.label,
+        };
+      }
+      return { ok: false, reason: "stale" };
+    }).immediate();
+  }
+
+  public getAnsweredThreadInteraction(): ThreadInteractionDelivery | null {
+    const row = this.db.prepare(
+      "SELECT * FROM thread_interactions WHERE state = 'answered' ORDER BY answered_at ASC LIMIT 1",
+    ).get() as ThreadInteractionRow | undefined;
+    if (!row || row.answer_json === null) return null;
+    return {
+      interactionId: row.interaction_id,
+      threadId: row.thread_id,
+      title: row.title,
+      resolution: JSON.parse(row.answer_json) as Record<string, unknown>,
+    };
+  }
+
+  public markThreadInteractionDelivered(interactionId: string, now: number): boolean {
+    assertControllerIdentifier(interactionId, "interactionId");
+    assertNonNegativeInteger(now, "now");
+    return this.db.prepare(
+      "UPDATE thread_interactions SET state = 'delivered' WHERE interaction_id = ? AND state = 'answered'",
+    ).run(interactionId).changes === 1;
+  }
+
+  /** Forgets a block the thread resolved without the owner, so it stops being offered. */
+  public discardThreadInteractions(threadId: string, keep: readonly string[]): number {
+    assertControllerIdentifier(threadId, "threadId");
+    const placeholders = keep.map(() => "?").join(", ");
+    const sql = keep.length === 0
+      ? "DELETE FROM thread_interactions WHERE thread_id = ? AND state = 'pending'"
+      : `DELETE FROM thread_interactions WHERE thread_id = ? AND state = 'pending' AND interaction_id NOT IN (${placeholders})`;
+    return this.db.prepare(sql).run(threadId, ...keep).changes;
+  }
+
+  /** An answer the owner has given that BB has not been told about yet. */
+  public getAnsweredControllerQuestion(controllerKey: string): ControllerQuestionRecord | null {
+    return this.readControllerQuestion(controllerKey, "answered");
+  }
+
+  public getPendingControllerQuestion(controllerKey: string): ControllerQuestionRecord | null {
+    return this.readControllerQuestion(controllerKey, "pending");
+  }
+
+  // Delivery is recorded separately from the answer so a crash between the two
+  // re-sends the answer rather than losing it.
+  public markControllerQuestionDelivered(input: ControllerLeaseFence & { interactionId: string }): boolean {
+    assertControllerIdentifier(input.interactionId, "interactionId");
+    this.assertLeaseIdentity("controller-question", input.ownerId, input.generation, input.now);
+    return this.db.transaction((): boolean => {
+      if (!this.executorLeaseIsCurrent(input.ownerId, input.generation, input.now)) return false;
+      return this.db.prepare(
+        "UPDATE controller_questions SET state = 'delivered' WHERE interaction_id = ? AND state = 'answered'",
+      ).run(input.interactionId).changes === 1;
+    }).immediate();
+  }
+
+  // A question outlives its turn only on paper. Once that turn is gone the
+  // answer has nowhere to land, and reading the owner's next message as an
+  // answer to it would swallow the message outright.
+  private readControllerQuestion(
+    controllerKey: string,
+    state: ControllerQuestionRow["state"],
+  ): ControllerQuestionRecord | null {
+    assertControllerKey(controllerKey);
+    const row = this.db.prepare(
+      `SELECT question.* FROM controller_questions AS question
+         JOIN controller_turns AS turn ON turn.id = question.turn_id AND turn.state = 'submitted'
+        WHERE question.controller_key = ? AND question.state = ?
+        ORDER BY question.asked_at DESC LIMIT 1`,
+    ).get(controllerKey, state) as ControllerQuestionRow | undefined;
+    if (!row) return null;
+    return {
+      interactionId: row.interaction_id,
+      turnId: row.turn_id,
+      controllerKey: row.controller_key,
+      questions: JSON.parse(row.questions_json) as ControllerQuestion[],
+      answers: JSON.parse(row.answers_json) as ControllerQuestionAnswers,
+      askedAt: row.asked_at,
+    };
+  }
+
   public refreshControllerDraft(input: ControllerLeaseFence & {
     turnId: string;
     sentBefore: number;
@@ -2952,11 +3549,16 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
   public failControllerTurn(input: ControllerLeaseFence & {
     turnId: string;
     error: string;
+    ownerMessage?: string;
     leaseMs?: number;
   }): boolean {
     this.assertControllerMutation(input);
     assertSafeFailureSummary(input.error);
     assertNoRawMergeCallback(input.error, "controller error");
+    if (input.ownerMessage !== undefined) {
+      assertControllerText(input.ownerMessage, "controller failure message");
+      assertNoRawMergeCallback(input.ownerMessage, "controller failure message");
+    }
     return this.db.transaction((): boolean => {
       if (!this.executorLeaseIsCurrent(input.ownerId, input.generation, input.now)) return false;
       const row = this.db.prepare(
@@ -2978,7 +3580,7 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
         `UPDATE controller_threads SET pending_spawn_token = NULL, updated_at = ?
           WHERE controller_key = ? AND bb_thread_id IS NULL AND pending_spawn_token = ?`,
       ).run(input.now, row.controller_key, input.turnId);
-      const outbox = controllerFailureOutbox(input.turnId, row.telegram_chat_id);
+      const outbox = controllerFailureOutbox(input.turnId, row.telegram_chat_id, input.ownerMessage);
       persistControllerOutbox(this.db, outbox, input.now);
       return true;
     }).immediate();

--- a/src/telegram/ingress.ts
+++ b/src/telegram/ingress.ts
@@ -269,8 +269,20 @@ export class TelegramIngress {
       return;
     }
 
+    const controllerKey = stableControllerKey(identity.userId, identity.chatId);
+    // The agent asked something and is blocked on it. A reply now is the answer,
+    // not a new request to line up behind the answer it is waiting to give.
+    if (this.store.getPendingControllerQuestion(controllerKey)) {
+      const answered = this.store.answerControllerQuestionWithText({ controllerKey, text: normalized, now });
+      if (answered.ok) {
+        this.rememberStandingInstruction(normalized, answered.turnId, now);
+        this.onWorkAvailable();
+        return;
+      }
+    }
+
     const turn = this.store.enqueueControllerTurn({
-      controllerKey: stableControllerKey(identity.userId, identity.chatId),
+      controllerKey,
       telegramUserId: identity.userId,
       telegramChatId: identity.chatId,
       updateId,
@@ -346,6 +358,56 @@ export class TelegramIngress {
         result.outcome === "accepted" ? "Merge queued." : "Approval is stale or no longer valid.",
         now,
       );
+      return;
+    }
+    if (action.type === "thread_interaction") {
+      const answered = this.store.answerThreadInteraction({
+        token: action.token,
+        userId: identity.userId,
+        chatId: identity.chatId,
+        now,
+      });
+      const recorded = this.store.recordCallback(
+        callback.id,
+        null,
+        "thread_interaction",
+        answered.ok ? "accepted" : answered.reason,
+        now,
+      );
+      if (recorded) {
+        this.enqueueCallbackAnswer(
+          callback.id,
+          identity.chatId,
+          answered.ok ? answered.label : "That thread is no longer waiting on you.",
+          now,
+        );
+      }
+      if (answered.ok && recorded) this.onWorkAvailable();
+      return;
+    }
+    if (action.type === "question") {
+      const answered = this.store.answerControllerQuestion({
+        token: action.token,
+        userId: identity.userId,
+        chatId: identity.chatId,
+        now,
+      });
+      const recorded = this.store.recordCallback(
+        callback.id,
+        null,
+        "controller_question",
+        answered.ok ? "accepted" : answered.reason,
+        now,
+      );
+      if (recorded) {
+        this.enqueueCallbackAnswer(
+          callback.id,
+          identity.chatId,
+          answered.ok ? "Got it." : "That question is no longer open.",
+          now,
+        );
+      }
+      if (answered.ok && recorded) this.onWorkAvailable();
       return;
     }
     if (action.type === "operation") {

--- a/src/telegram/view.ts
+++ b/src/telegram/view.ts
@@ -26,7 +26,11 @@ export type CallbackAction =
   | { type: "retry"; jobId: string }
   | { type: "review"; jobId: string }
   | { type: "merge"; nonce: string }
-  | { type: "operation"; nonce: string };
+  | { type: "operation"; nonce: string }
+  /** One option of a question the controller thread is blocked on. */
+  | { type: "question"; token: string }
+  /** One choice offered for a watched thread that is waiting on the owner. */
+  | { type: "thread_interaction"; token: string };
 
 export type ReviewView = {
   verdict?: string;
@@ -253,6 +257,14 @@ export function encodeCallbackData(action: CallbackAction): string {
       if (!NONCE_PATTERN.test(action.nonce)) throw new TypeError("nonce is not valid callback data");
       encoded = `o:${action.nonce}`;
       break;
+    case "question":
+      if (!NONCE_PATTERN.test(action.token)) throw new TypeError("token is not valid callback data");
+      encoded = `q:${action.token}`;
+      break;
+    case "thread_interaction":
+      if (!NONCE_PATTERN.test(action.token)) throw new TypeError("token is not valid callback data");
+      encoded = `w:${action.token}`;
+      break;
     default:
       throw new TypeError("Unknown Telegram callback action");
   }
@@ -279,6 +291,10 @@ export function parseCallbackData(data: string): CallbackAction {
   if (match) return { type: "merge", nonce: match[1] };
   match = /^o:([A-Za-z0-9_-]{32})$/.exec(data);
   if (match) return { type: "operation", nonce: match[1] };
+  match = /^q:([A-Za-z0-9_-]{32})$/.exec(data);
+  if (match) return { type: "question", token: match[1] };
+  match = /^w:([A-Za-z0-9_-]{32})$/.exec(data);
+  if (match) return { type: "thread_interaction", token: match[1] };
   throw new TypeError("Telegram callback data is invalid");
 }
 

--- a/tests/controller-questions.test.ts
+++ b/tests/controller-questions.test.ts
@@ -1,0 +1,554 @@
+import { createFakePluginHost } from "@bb/plugin-sdk/testing";
+import type { BbPluginApi } from "@bb/plugin-sdk";
+import { expect, it, vi } from "vitest";
+import { hashSecret } from "../src/crypto";
+import { openStore } from "../src/storage/store";
+import { BbControllerAdapter, type ControllerAdapter } from "../src/controller/bb-controller";
+import { CONTROLLER_STALL_MS, LunaControllerService } from "../src/controller/service";
+import { DEFAULT_CONTROLLER_EXECUTION_PROFILE } from "../src/controller/execution-profile";
+import { questionOptionToken } from "../src/controller/questions";
+
+const INTERACTION_ID = "pint_4k97457aun";
+const QUESTION_ID = "toolu_abc:question-1";
+const OPTION_A = "toolu_abc:question-1:option-1";
+const OPTION_B = "toolu_abc:question-1:option-2";
+
+function questionPayload() {
+  return {
+    kind: "user_question",
+    questions: [{
+      id: QUESTION_ID,
+      prompt: "36 open issues in Cyndra. How should I run the fix threads?",
+      shortLabel: "Fix threads",
+      multiSelect: false,
+      allowFreeText: true,
+      options: [
+        { value: OPTION_A, label: "Cluster into ~8 threads", description: "Group issues by surface." },
+        { value: OPTION_B, label: "One thread per issue", description: "Maximum isolation." },
+      ],
+    }],
+  };
+}
+
+function lifecycleEvent(seq: number, status: string) {
+  return {
+    id: `e${seq}`,
+    threadId: "thr_controller",
+    seq,
+    createdAt: seq,
+    scope: { kind: "turn" },
+    type: "system/userQuestion/lifecycle",
+    data: {
+      interactionId: INTERACTION_ID,
+      providerId: "claude-code",
+      status,
+      resolution: null,
+      payload: questionPayload(),
+    },
+  };
+}
+
+function adapterFixture(options: { events?: unknown[] } = {}) {
+  const resolve = vi.fn(async () => ({ id: INTERACTION_ID, status: "resolving" }));
+  const send = vi.fn(async () => ({ ok: true }));
+  const eventsList = vi.fn(async () => options.events ?? []);
+  const sdk = {
+    projects: { list: vi.fn(async () => []) },
+    hosts: { list: vi.fn(async () => []) },
+    threads: {
+      spawn: vi.fn(),
+      send,
+      list: vi.fn(async () => []),
+      get: vi.fn(async () => ({
+        id: "thr_controller",
+        status: "active",
+        providerId: "claude-code",
+        archivedAt: null,
+        deletedAt: null,
+      })),
+      output: vi.fn(async () => ({ output: "" })),
+      timeline: vi.fn(async () => ({ maxSeq: 0 })),
+      events: { list: eventsList },
+      interactions: { resolve, list: vi.fn(async () => []), get: vi.fn(), cancel: vi.fn(), respond: vi.fn() },
+    },
+  } as unknown as BbPluginApi["sdk"];
+  const adapter = new BbControllerAdapter({
+    sdk,
+    pluginId: "telegram-agent",
+    executionProfile: () => DEFAULT_CONTROLLER_EXECUTION_PROFILE,
+  });
+  return { adapter, resolve, send, eventsList };
+}
+
+it("surfaces a pending user question from the controller event stream", async () => {
+  const { adapter } = adapterFixture({ events: [lifecycleEvent(5, "pending")] });
+
+  const observation = await adapter.events("thr_controller", 0, AbortSignal.timeout(1_000));
+
+  expect(observation.pendingQuestion).toEqual({
+    interactionId: INTERACTION_ID,
+    questions: [{
+      id: QUESTION_ID,
+      prompt: "36 open issues in Cyndra. How should I run the fix threads?",
+      shortLabel: "Fix threads",
+      multiSelect: false,
+      allowFreeText: true,
+      options: [
+        { value: OPTION_A, label: "Cluster into ~8 threads", description: "Group issues by surface." },
+        { value: OPTION_B, label: "One thread per issue", description: "Maximum isolation." },
+      ],
+    }],
+  });
+});
+
+it("clears the pending question once the interaction stops being pending", async () => {
+  const { adapter } = adapterFixture({
+    events: [lifecycleEvent(5, "pending"), lifecycleEvent(6, "resolved")],
+  });
+
+  const observation = await adapter.events("thr_controller", 0, AbortSignal.timeout(1_000));
+
+  expect(observation.pendingQuestion).toBeNull();
+});
+
+it("ignores a lifecycle event that carries no answerable question", async () => {
+  const bare = lifecycleEvent(5, "pending");
+  const { adapter } = adapterFixture({
+    events: [{ ...bare, data: { ...bare.data, payload: { kind: "user_question", questions: [] } } }],
+  });
+
+  await expect(adapter.events("thr_controller", 0, AbortSignal.timeout(1_000)))
+    .resolves.toMatchObject({ pendingQuestion: null });
+});
+
+it("answers a pending question through the BB interaction resolution", async () => {
+  const { adapter, resolve } = adapterFixture();
+
+  await adapter.answerQuestion(
+    "thr_controller",
+    INTERACTION_ID,
+    { [QUESTION_ID]: { selected: [OPTION_A] } },
+    AbortSignal.timeout(1_000),
+  );
+
+  expect(resolve).toHaveBeenCalledWith({
+    threadId: "thr_controller",
+    interactionId: INTERACTION_ID,
+    resolution: {
+      kind: "user_answer",
+      answers: { [QUESTION_ID]: { selected: [OPTION_A] } },
+    },
+  });
+});
+
+it("steers a busy controller thread instead of starting a competing turn", async () => {
+  const { adapter, send } = adapterFixture();
+
+  await adapter.steer("thr_controller", "in review i mean not in progress", AbortSignal.timeout(1_000));
+
+  expect(send).toHaveBeenCalledWith({
+    threadId: "thr_controller",
+    mode: "auto",
+    input: [{ type: "text", text: "in review i mean not in progress", mentions: [] }],
+  });
+});
+
+it("derives a stable, callback-sized token for each question option", () => {
+  const token = questionOptionToken(INTERACTION_ID, QUESTION_ID, OPTION_A);
+
+  expect(token).toBe(questionOptionToken(INTERACTION_ID, QUESTION_ID, OPTION_A));
+  expect(token).not.toBe(questionOptionToken(INTERACTION_ID, QUESTION_ID, OPTION_B));
+  expect(token).toMatch(/^[A-Za-z0-9_-]{32}$/);
+});
+
+function storeFixture(name: string) {
+  const { bb } = createFakePluginHost({ pluginId: `telegram-questions-${name}` });
+  const store = openStore(bb.storage, bb.storage.kv, () => 2_000);
+  store.createPairingCode(hashSecret("pair"), 1_000, 10_000);
+  expect(store.pairOwnerWithCode(hashSecret("pair"), "7", "7", 1_001)).toEqual({ ok: true });
+  // Long enough that the stall-watchdog clock in these tests stays inside it.
+  const lease = store.acquireExecutorLease("executor", 2_000, 60 * 60_000);
+  if (!lease.acquired) throw new Error("missing lease");
+  return { store, fence: { ownerId: "executor", generation: lease.generation } };
+}
+
+function submittedTurn(store: ReturnType<typeof storeFixture>["store"], fence: { ownerId: string; generation: number }) {
+  const turn = store.enqueueControllerTurn({
+    controllerKey: "owner-7-controller",
+    telegramUserId: "7",
+    telegramChatId: "7",
+    updateId: 91,
+    inputText: "review all open issues",
+    now: 2_000,
+  });
+  store.claimNextControllerTurn({ ...fence, now: 2_000 });
+  store.markControllerSpawned({
+    ...fence,
+    now: 2_000,
+    turnId: turn.id,
+    projectId: "proj_personal",
+    hostId: "host_personal",
+    threadId: "thr_controller",
+  });
+  store.markControllerTurnSubmitted({ ...fence, now: 2_000, turnId: turn.id });
+  return turn;
+}
+
+it("parks a submitted turn on its question and asks the owner in Telegram", () => {
+  const { store, fence } = storeFixture("park");
+  const turn = submittedTurn(store, fence);
+
+  expect(store.recordControllerQuestion({
+    ...fence,
+    now: 3_000,
+    turnId: turn.id,
+    interactionId: INTERACTION_ID,
+    questions: questionPayload().questions,
+  })).toBe(true);
+
+  const parked = store.getControllerTurn(turn.id);
+  expect(parked?.awaitingInteractionId).toBe(INTERACTION_ID);
+  expect(parked?.state).toBe("submitted");
+
+  const asked = store.getOutbox(`controller-question:${INTERACTION_ID}:0`);
+  expect(asked?.payload.text).toContain("How should I run the fix threads?");
+  expect(asked?.payload.reply_markup).toEqual({
+    inline_keyboard: [
+      [{ text: "Cluster into ~8 threads", callback_data: `q:${questionOptionToken(INTERACTION_ID, QUESTION_ID, OPTION_A)}` }],
+      [{ text: "One thread per issue", callback_data: `q:${questionOptionToken(INTERACTION_ID, QUESTION_ID, OPTION_B)}` }],
+    ],
+  });
+});
+
+it("resolves a parked question from a tapped option and releases the turn", () => {
+  const { store, fence } = storeFixture("tap");
+  const turn = submittedTurn(store, fence);
+  store.recordControllerQuestion({
+    ...fence,
+    now: 3_000,
+    turnId: turn.id,
+    interactionId: INTERACTION_ID,
+    questions: questionPayload().questions,
+  });
+
+  const answered = store.answerControllerQuestion({
+    token: questionOptionToken(INTERACTION_ID, QUESTION_ID, OPTION_A),
+    userId: "7",
+    chatId: "7",
+    now: 4_000,
+  });
+
+  expect(answered).toEqual({
+    ok: true,
+    complete: true,
+    turnId: turn.id,
+    interactionId: INTERACTION_ID,
+    answers: { [QUESTION_ID]: { selected: [OPTION_A] } },
+  });
+  expect(store.getControllerTurn(turn.id)?.awaitingInteractionId).toBeNull();
+});
+
+it("resolves a parked question from a plain Telegram reply", () => {
+  const { store, fence } = storeFixture("text");
+  const turn = submittedTurn(store, fence);
+  store.recordControllerQuestion({
+    ...fence,
+    now: 3_000,
+    turnId: turn.id,
+    interactionId: INTERACTION_ID,
+    questions: questionPayload().questions,
+  });
+
+  const answered = store.answerControllerQuestionWithText({
+    controllerKey: "owner-7-controller",
+    text: "in review i mean not in progress",
+    now: 4_000,
+  });
+
+  expect(answered).toEqual({
+    ok: true,
+    complete: true,
+    turnId: turn.id,
+    interactionId: INTERACTION_ID,
+    answers: { [QUESTION_ID]: { selected: [], freeText: "in review i mean not in progress" } },
+  });
+  expect(store.getControllerTurn(turn.id)?.awaitingInteractionId).toBeNull();
+});
+
+it("refuses a stale option token once the question is answered", () => {
+  const { store, fence } = storeFixture("stale");
+  const turn = submittedTurn(store, fence);
+  store.recordControllerQuestion({
+    ...fence,
+    now: 3_000,
+    turnId: turn.id,
+    interactionId: INTERACTION_ID,
+    questions: questionPayload().questions,
+  });
+  const token = questionOptionToken(INTERACTION_ID, QUESTION_ID, OPTION_A);
+  expect(store.answerControllerQuestion({ token, userId: "7", chatId: "7", now: 4_000 }).ok).toBe(true);
+
+  expect(store.answerControllerQuestion({ token, userId: "7", chatId: "7", now: 4_001 }))
+    .toEqual({ ok: false, reason: "stale" });
+});
+
+function serviceAdapter(overrides: Partial<ControllerAdapter> = {}): ControllerAdapter {
+  return {
+    spawn: vi.fn(async () => ({ threadId: "thr_controller", projectId: "proj_personal", hostId: "host_personal" })),
+    send: vi.fn(async () => undefined),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
+    status: vi.fn(async () => "active" as const),
+    latestSeq: vi.fn(async () => 0),
+    output: vi.fn(async () => "done"),
+    events: vi.fn(async () => ({
+      latestSeq: 0,
+      inputAccepted: false,
+      assistantDelta: "",
+      completed: false,
+      error: null,
+      pendingQuestion: null,
+    })),
+    findSpawnCandidate: vi.fn(async () => null),
+    ...overrides,
+  };
+}
+
+it("parks the turn and asks in Telegram when the thread blocks on a question", async () => {
+  const { store, fence } = storeFixture("service-park");
+  const turn = submittedTurn(store, fence);
+  const adapter = serviceAdapter({
+    events: vi.fn(async () => ({
+      latestSeq: 5,
+      inputAccepted: true,
+      assistantDelta: "Big job.",
+      completed: false,
+      error: null,
+      pendingQuestion: { interactionId: INTERACTION_ID, questions: questionPayload().questions },
+    })),
+  });
+  const service = new LunaControllerService({ store, adapter, clock: { now: () => 3_000 } });
+  const signal = AbortSignal.timeout(2_000);
+
+  await expect(service.reconcile({ ...fence, signal }, signal)).resolves.toBe(true);
+
+  expect(store.getControllerTurn(turn.id)?.awaitingInteractionId).toBe(INTERACTION_ID);
+  expect(store.getOutbox(`controller-question:${INTERACTION_ID}:0`)?.payload.text)
+    .toContain("How should I run the fix threads?");
+});
+
+it("delivers the owner's answer back to the blocked BB thread", async () => {
+  const { store, fence } = storeFixture("service-answer");
+  const turn = submittedTurn(store, fence);
+  store.recordControllerQuestion({
+    ...fence,
+    now: 3_000,
+    turnId: turn.id,
+    interactionId: INTERACTION_ID,
+    questions: questionPayload().questions,
+  });
+  expect(store.answerControllerQuestion({
+    token: questionOptionToken(INTERACTION_ID, QUESTION_ID, OPTION_A),
+    userId: "7",
+    chatId: "7",
+    now: 4_000,
+  }).ok).toBe(true);
+  const adapter = serviceAdapter();
+  const service = new LunaControllerService({ store, adapter, clock: { now: () => 4_100 } });
+  const signal = AbortSignal.timeout(2_000);
+
+  await expect(service.reconcile({ ...fence, signal }, signal)).resolves.toBe(true);
+
+  expect(adapter.answerQuestion).toHaveBeenCalledWith(
+    "thr_controller",
+    INTERACTION_ID,
+    { [QUESTION_ID]: { selected: [OPTION_A] } },
+    signal,
+  );
+  // Delivered once: a second pass must not answer the same interaction again.
+  const second = new LunaControllerService({ store, adapter, clock: { now: () => 4_200 } });
+  await second.reconcile({ ...fence, signal }, signal);
+  expect(adapter.answerQuestion).toHaveBeenCalledTimes(1);
+});
+
+it("gives up on a turn that stopped producing events and unblocks the queue", async () => {
+  const { store, fence } = storeFixture("service-stall");
+  const turn = submittedTurn(store, fence);
+  const service = new LunaControllerService({
+    store,
+    adapter: serviceAdapter(),
+    clock: { now: () => 2_000 + CONTROLLER_STALL_MS + 1 },
+  });
+  const signal = AbortSignal.timeout(2_000);
+
+  await expect(service.reconcile({ ...fence, signal }, signal)).resolves.toBe(true);
+
+  expect(store.getControllerTurn(turn.id)?.state).toBe("failed");
+  expect(store.getOutbox(`controller:${turn.id}:reply`)?.payload.text).toContain("stalled");
+});
+
+it("waits indefinitely while the owner still owes the thread an answer", async () => {
+  const { store, fence } = storeFixture("service-no-stall");
+  const turn = submittedTurn(store, fence);
+  store.recordControllerQuestion({
+    ...fence,
+    now: 2_500,
+    turnId: turn.id,
+    interactionId: INTERACTION_ID,
+    questions: questionPayload().questions,
+  });
+  const service = new LunaControllerService({
+    store,
+    adapter: serviceAdapter(),
+    clock: { now: () => 2_000 + CONTROLLER_STALL_MS + 1 },
+  });
+  const signal = AbortSignal.timeout(2_000);
+
+  await service.reconcile({ ...fence, signal }, signal);
+
+  expect(store.getControllerTurn(turn.id)?.state).toBe("submitted");
+});
+
+it("hands a message sent mid-answer to the thread already writing it", async () => {
+  const { store, fence } = storeFixture("service-steer");
+  const running = submittedTurn(store, fence);
+  const correction = store.enqueueControllerTurn({
+    controllerKey: "owner-7-controller",
+    telegramUserId: "7",
+    telegramChatId: "7",
+    updateId: 92,
+    inputText: "in review i mean not in progress",
+    now: 2_100,
+  });
+  const adapter = serviceAdapter();
+  const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_200 } });
+  const signal = AbortSignal.timeout(2_000);
+
+  await expect(service.reconcile({ ...fence, signal }, signal)).resolves.toBe(true);
+
+  expect(adapter.steer).toHaveBeenCalledWith("thr_controller", "in review i mean not in progress", signal);
+  expect(store.getControllerTurn(correction.id)?.state).toBe("completed");
+  // The running answer still owns the reply; the correction gets no second one.
+  expect(store.getOutbox(`controller:${correction.id}:reply`)).toBeNull();
+  expect(store.getControllerTurn(running.id)?.state).toBe("submitted");
+});
+
+it("leaves a mid-answer message queued when the thread will not take it", async () => {
+  const { store, fence } = storeFixture("service-steer-fails");
+  submittedTurn(store, fence);
+  const correction = store.enqueueControllerTurn({
+    controllerKey: "owner-7-controller",
+    telegramUserId: "7",
+    telegramChatId: "7",
+    updateId: 93,
+    inputText: "actually hold on",
+    now: 2_100,
+  });
+  const adapter = serviceAdapter({
+    steer: vi.fn(async () => { throw new Error("BB refused the steer"); }),
+  });
+  const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_200 } });
+  const signal = AbortSignal.timeout(2_000);
+
+  await service.reconcile({ ...fence, signal }, signal);
+
+  expect(store.getControllerTurn(correction.id)?.state).toBe("queued");
+});
+
+it("retires a parked question when its turn dies, so later messages are not swallowed", () => {
+  const { store, fence } = storeFixture("orphan");
+  const turn = submittedTurn(store, fence);
+  store.recordControllerQuestion({
+    ...fence,
+    now: 3_000,
+    turnId: turn.id,
+    interactionId: INTERACTION_ID,
+    questions: questionPayload().questions,
+  });
+
+  expect(store.failControllerTurn({
+    ...fence,
+    now: 4_000,
+    turnId: turn.id,
+    error: "Controller provider turn failed",
+  })).toBe(true);
+
+  expect(store.getPendingControllerQuestion("owner-7-controller")).toBeNull();
+  expect(store.answerControllerQuestionWithText({
+    controllerKey: "owner-7-controller",
+    text: "cluster them",
+    now: 4_100,
+  })).toEqual({ ok: false, reason: "stale" });
+});
+
+it("does not deliver an answer whose turn died before BB heard it", async () => {
+  const { store, fence } = storeFixture("orphan-answer");
+  const turn = submittedTurn(store, fence);
+  store.recordControllerQuestion({
+    ...fence,
+    now: 3_000,
+    turnId: turn.id,
+    interactionId: INTERACTION_ID,
+    questions: questionPayload().questions,
+  });
+  store.answerControllerQuestion({
+    token: questionOptionToken(INTERACTION_ID, QUESTION_ID, OPTION_A),
+    userId: "7",
+    chatId: "7",
+    now: 3_500,
+  });
+  store.failControllerTurn({ ...fence, now: 4_000, turnId: turn.id, error: "Controller provider turn failed" });
+  const adapter = serviceAdapter();
+  const service = new LunaControllerService({ store, adapter, clock: { now: () => 4_100 } });
+  const signal = AbortSignal.timeout(2_000);
+
+  await service.reconcile({ ...fence, signal }, signal);
+
+  expect(adapter.answerQuestion).not.toHaveBeenCalled();
+});
+
+it("stops re-steering a message the thread keeps refusing", async () => {
+  const { store, fence } = storeFixture("steer-bounded");
+  submittedTurn(store, fence);
+  const correction = store.enqueueControllerTurn({
+    controllerKey: "owner-7-controller",
+    telegramUserId: "7",
+    telegramChatId: "7",
+    updateId: 94,
+    inputText: "actually hold on",
+    now: 2_100,
+  });
+  const steer = vi.fn(async () => { throw new Error("BB refused the steer"); });
+  const adapter = serviceAdapter({ steer });
+  const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_200 } });
+  const signal = AbortSignal.timeout(2_000);
+
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    await service.reconcile({ ...fence, signal }, signal);
+  }
+
+  // Bounded: the reconcile loop runs every 250ms while streaming, so an
+  // unbounded retry here would hammer BB for as long as the answer takes.
+  expect(steer.mock.calls.length).toBeLessThanOrEqual(3);
+  expect(store.getControllerTurn(correction.id)?.state).toBe("queued");
+});
+
+it("retires the wedged thread when a turn stalls, so the next message is not stuck behind it", async () => {
+  const { store, fence } = storeFixture("stall-retires");
+  const turn = submittedTurn(store, fence);
+  const service = new LunaControllerService({
+    store,
+    adapter: serviceAdapter(),
+    clock: { now: () => 2_000 + CONTROLLER_STALL_MS + 1 },
+  });
+  const signal = AbortSignal.timeout(2_000);
+
+  await service.reconcile({ ...fence, signal }, signal);
+
+  expect(store.getControllerTurn(turn.id)?.state).toBe("failed");
+  // Failing the turn while leaving the thread wedged means every later message
+  // waits out the busy timeout instead of getting a fresh thread.
+  const controller = store.getControllerForOwner("7", "7");
+  expect(controller?.threadId).toBeNull();
+  expect(controller?.state).toBe("pending_spawn");
+});

--- a/tests/controller-service.test.ts
+++ b/tests/controller-service.test.ts
@@ -72,6 +72,7 @@ function turnRecord(overrides: Record<string, unknown> = {}) {
     lastError: null,
     submittedAt: null,
     completedAt: null,
+    awaitingInteractionId: null,
     createdAt: 1_000,
     updatedAt: 1_000,
     ...overrides,
@@ -191,6 +192,7 @@ it("reduces BB controller events after the durable sequence without exposing rea
     assistantDelta: "Hello",
     completed: true,
     error: null,
+    pendingQuestion: null,
   });
   expect(eventsList).toHaveBeenCalledWith({
     threadId: "thr_controller",
@@ -372,7 +374,9 @@ it("dispatches FIFO, waits for idle output, and then sends the next turn with mo
     status: async () => status,
     latestSeq: vi.fn(async () => 0),
     output: vi.fn(async () => "First answer."),
-    events: vi.fn(async () => ({ latestSeq: 0, inputAccepted: false, assistantDelta: "", completed: false, error: null })),
+    events: vi.fn(async () => ({ latestSeq: 0, inputAccepted: false, assistantDelta: "", completed: false, error: null, pendingQuestion: null })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
     findSpawnCandidate: vi.fn(async () => null),
   };
   const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_000 } });
@@ -442,7 +446,9 @@ it("requeues a turn while the controller thread is still busy instead of failing
     status: vi.fn(async () => status),
     latestSeq: vi.fn(async () => 4),
         output: vi.fn(async () => "unused"),
-    events: vi.fn(async () => ({ latestSeq: 4, inputAccepted: false, assistantDelta: "", completed: false, error: null })),
+    events: vi.fn(async () => ({ latestSeq: 4, inputAccepted: false, assistantDelta: "", completed: false, error: null, pendingQuestion: null })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
     findSpawnCandidate: vi.fn(async () => null),
   };
   const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_002 } });
@@ -496,7 +502,9 @@ it("gives up on a turn the busy controller never accepts within its bounded wait
     status: vi.fn(async () => "active" as const),
     latestSeq: vi.fn(async () => 0),
         output: vi.fn(async () => "unused"),
-    events: vi.fn(async () => ({ latestSeq: 0, inputAccepted: false, assistantDelta: "", completed: false, error: null })),
+    events: vi.fn(async () => ({ latestSeq: 0, inputAccepted: false, assistantDelta: "", completed: false, error: null, pendingQuestion: null })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
     findSpawnCandidate: vi.fn(async () => null),
   };
   const wedgedAt = 2_001 + 15 * 60_000;
@@ -549,7 +557,10 @@ it("delivers a completed answer even when the controller thread ends in error", 
       assistantDelta: "Here is the answer.",
       completed: true,
       error: null,
+      pendingQuestion: null,
     })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
     findSpawnCandidate: vi.fn(async () => null),
   };
   const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_002 } });
@@ -572,7 +583,9 @@ it("reports a streaming turn only while its answer is still arriving", async () 
     status: vi.fn(async () => "idle" as const),
     latestSeq: vi.fn(async () => 0),
     output: vi.fn(async () => "unused"),
-    events: vi.fn(async () => ({ latestSeq: 0, inputAccepted: false, assistantDelta: "", completed: false, error: null })),
+    events: vi.fn(async () => ({ latestSeq: 0, inputAccepted: false, assistantDelta: "", completed: false, error: null, pendingQuestion: null })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
     findSpawnCandidate: vi.fn(async () => null),
   };
   const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_000 } });
@@ -611,7 +624,9 @@ it("fails an uncertain send closed and never submits it twice", async () => {
     status: vi.fn(async () => "idle" as const),
     latestSeq: vi.fn(async () => 0),
     output: vi.fn(async () => "unused"),
-    events: vi.fn(async () => ({ latestSeq: 22, inputAccepted: true, assistantDelta: "", completed: false, error: "Controller provider turn failed" })),
+    events: vi.fn(async () => ({ latestSeq: 22, inputAccepted: true, assistantDelta: "", completed: false, error: "Controller provider turn failed", pendingQuestion: null })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
     findSpawnCandidate: vi.fn(async () => ({ threadId: "thr_controller", projectId: "proj_personal", hostId: "host_personal" })),
   };
   const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_000 } });
@@ -670,7 +685,9 @@ it("keeps an idle submitted turn durable when BB output retrieval fails transien
     status: vi.fn(async () => "idle" as const),
     latestSeq: vi.fn(async () => 0),
     output: vi.fn(async () => { throw new Error("temporary BB output failure"); }),
-    events: vi.fn(async () => ({ latestSeq: 0, inputAccepted: false, assistantDelta: "", completed: false, error: null })),
+    events: vi.fn(async () => ({ latestSeq: 0, inputAccepted: false, assistantDelta: "", completed: false, error: null, pendingQuestion: null })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
     findSpawnCandidate: vi.fn(async () => null),
   };
   const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_000 } });
@@ -722,7 +739,10 @@ it("projects active Luna assistant deltas into the durable controller reply", as
       assistantDelta: "Working on it",
       completed: false,
       error: null,
+      pendingQuestion: null,
     })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
     findSpawnCandidate: vi.fn(async () => null),
   };
   const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_001 } });
@@ -780,7 +800,10 @@ it("refreshes an unchanged active Luna draft before Telegram expires it", async 
       assistantDelta: "",
       completed: false,
       error: null,
+      pendingQuestion: null,
     })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
     findSpawnCandidate: vi.fn(async () => null),
   };
   const service = new LunaControllerService({ store, adapter, clock: { now: () => 22_000 } });
@@ -835,7 +858,9 @@ it("retires an errored controller so a later queued message can start a fresh ge
     status: vi.fn(async (threadId: string) => threadId === "thr_poisoned" ? "error" : "active"),
     latestSeq: vi.fn(async () => 0),
     output: vi.fn(async () => "unused"),
-    events: vi.fn(async () => ({ latestSeq: 22, inputAccepted: true, assistantDelta: "", completed: false, error: "Controller provider turn failed" })),
+    events: vi.fn(async () => ({ latestSeq: 22, inputAccepted: true, assistantDelta: "", completed: false, error: "Controller provider turn failed", pendingQuestion: null })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
     findSpawnCandidate: vi.fn(async () => null),
   };
   const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_002 } });
@@ -896,7 +921,9 @@ it("recovers from the 2026-08-10 poisoned controller before dispatching the next
     status: vi.fn(async (threadId: string) => threadId === "thr_poisoned_idle" ? "error" : "active"),
     latestSeq: vi.fn(async () => 0),
     output: vi.fn(async () => "unused"),
-    events: vi.fn(async () => ({ latestSeq: 0, inputAccepted: false, assistantDelta: "", completed: false, error: null })),
+    events: vi.fn(async () => ({ latestSeq: 0, inputAccepted: false, assistantDelta: "", completed: false, error: null, pendingQuestion: null })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
     findSpawnCandidate: vi.fn(async () => null),
   };
   const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_003 } });
@@ -943,7 +970,9 @@ it("retires an errored controller generation even when no turn remains submitted
     status: vi.fn(async () => "error" as const),
     latestSeq: vi.fn(async () => 0),
     output: vi.fn(async () => "unused"),
-    events: vi.fn(async () => ({ latestSeq: 0, inputAccepted: false, assistantDelta: "", completed: false, error: null })),
+    events: vi.fn(async () => ({ latestSeq: 0, inputAccepted: false, assistantDelta: "", completed: false, error: null, pendingQuestion: null })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
     findSpawnCandidate: vi.fn(async () => null),
   };
   const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_002 } });
@@ -999,7 +1028,10 @@ it("retries one controller generation when BB proves the input was never accepte
       assistantDelta: "",
       completed: false,
       error: "Controller provider turn failed",
+      pendingQuestion: null,
     })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
     findSpawnCandidate: vi.fn(async () => null),
   };
   const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_002 } });

--- a/tests/controller-store.test.ts
+++ b/tests/controller-store.test.ts
@@ -34,7 +34,7 @@ function acquire(store: ReturnType<typeof openStore>) {
 // Applied migrations are immutable history: each release appends, so these are
 // indexed from the start and a new migration only ever extends the tail.
 it("keeps every shipped migration at its original position and appends new ones", () => {
-  expect(ALL_MIGRATIONS).toHaveLength(12);
+  expect(ALL_MIGRATIONS).toHaveLength(16);
   expect(ALL_MIGRATIONS[3]).toContain("CREATE TABLE controller_threads");
   expect(ALL_MIGRATIONS[3]).toContain("CREATE TABLE controller_turns");
   expect(ALL_MIGRATIONS[4]).toContain("dispatch_after_seq");
@@ -49,6 +49,12 @@ it("keeps every shipped migration at its original position and appends new ones"
   expect(ALL_MIGRATIONS[10]).toContain("CREATE TABLE monitors");
   expect(ALL_MIGRATIONS[11]).toContain("CREATE TABLE tool_receipts");
   expect(ALL_MIGRATIONS[11]).toContain("CREATE TABLE controller_generations");
+  expect(ALL_MIGRATIONS[12]).toContain("awaiting_interaction_id");
+  expect(ALL_MIGRATIONS[12]).toContain("CREATE TABLE controller_questions");
+  expect(ALL_MIGRATIONS[13]).toContain("CREATE TABLE observed_threads");
+  expect(ALL_MIGRATIONS[13]).toContain("CREATE TABLE thread_interactions");
+  expect(ALL_MIGRATIONS[14]).toContain("'unsupported'");
+  expect(ALL_MIGRATIONS[15]).toContain("notified_at");
 });
 
 it("enqueues Telegram controller turns idempotently and rejects changed replay input", () => {

--- a/tests/controller-stream.test.ts
+++ b/tests/controller-stream.test.ts
@@ -9,6 +9,7 @@ describe("controller stream projection", () => {
       assistantDelta: "Hello world",
       completed: false,
       error: null,
+      pendingQuestion: null,
     }, {
       cursor: 10,
       text: "",
@@ -29,6 +30,7 @@ describe("controller stream projection", () => {
       assistantDelta: " duplicate",
       completed: false,
       error: null,
+      pendingQuestion: null,
     }, {
       cursor: 13,
       text: "Hello world",
@@ -49,6 +51,7 @@ describe("controller stream projection", () => {
       assistantDelta: `${"a".repeat(3_900)}🙂tail`,
       completed: false,
       error: null,
+      pendingQuestion: null,
     }, {
       cursor: 0,
       text: "",

--- a/tests/thread-notices.test.ts
+++ b/tests/thread-notices.test.ts
@@ -1,0 +1,355 @@
+import { createFakePluginHost } from "@bb/plugin-sdk/testing";
+import { expect, it, vi } from "vitest";
+import { hashSecret } from "../src/crypto";
+import { openStore } from "../src/storage/store";
+import {
+  ThreadNoticeService,
+  type PendingThreadInteraction,
+  type WatchedThread,
+} from "../src/services/thread-notice-service";
+import { questionOptionToken, threadDecisionToken } from "../src/controller/questions";
+
+const APPROVAL_ID = "pint_approval1";
+const QUESTION_ID = "pint_question1";
+
+let fixtureNumber = 0;
+
+function fixture() {
+  const { bb } = createFakePluginHost({ pluginId: `telegram-notices-${fixtureNumber++}` });
+  const store = openStore(bb.storage, bb.storage.kv, () => 2_000);
+  store.createPairingCode(hashSecret("pair"), 1_000, 10_000);
+  expect(store.pairOwnerWithCode(hashSecret("pair"), "7", "7", 1_001)).toEqual({ ok: true });
+  return store;
+}
+
+function watched(overrides: Partial<WatchedThread> = {}): WatchedThread {
+  return { id: "thr_work", title: "Fix the login bug", status: "active", parentThreadId: null, ...overrides };
+}
+
+function approvalInteraction(): PendingThreadInteraction {
+  return {
+    id: APPROVAL_ID,
+    status: "pending",
+    payload: {
+      kind: "approval",
+      subject: { kind: "command", itemId: "i1", command: "rm -rf build", cwd: "/repo", actions: [] },
+      decisions: ["allow_once", "allow_for_session", "deny"],
+    },
+  };
+}
+
+function questionInteraction(): PendingThreadInteraction {
+  return {
+    id: QUESTION_ID,
+    status: "pending",
+    payload: {
+      kind: "user_question",
+      questions: [{
+        id: "q1",
+        prompt: "Which database should I migrate first?",
+        multiSelect: false,
+        allowFreeText: true,
+        options: [
+          { value: "primary", label: "Primary", description: null },
+          { value: "replica", label: "Replica", description: null },
+        ],
+      }],
+    },
+  };
+}
+
+function service(store: ReturnType<typeof fixture>, options: {
+  threads?: WatchedThread[];
+  interactions?: PendingThreadInteraction[];
+  resolve?: ReturnType<typeof vi.fn>;
+  now?: () => number;
+} = {}) {
+  const resolve = options.resolve ?? vi.fn(async () => undefined);
+  const listWatchable = vi.fn(async () => options.threads ?? []);
+  const interactions = vi.fn(async () => options.interactions ?? []);
+  return {
+    resolve,
+    listWatchable,
+    interactions,
+    service: new ThreadNoticeService({
+      store,
+      threads: { listWatchable, interactions, resolve },
+      clock: { now: options.now ?? (() => 3_000) },
+    }),
+  };
+}
+
+it("says nothing about a thread that was already finished when it first looked", async () => {
+  const store = fixture();
+  const { service: notices } = service(store, { threads: [watched({ status: "idle" })] });
+
+  await expect(notices.processDue()).resolves.toBe(false);
+
+  expect(store.getOutbox("thread:thr_work:idle")).toBeNull();
+});
+
+it("tells the owner when a watched thread finishes", async () => {
+  const store = fixture();
+  const running = service(store, { threads: [watched({ status: "active" })] });
+  await running.service.processDue();
+
+  const finished = service(store, { threads: [watched({ status: "idle" })] });
+  await expect(finished.service.processDue()).resolves.toBe(true);
+
+  expect(store.getOutbox("thread:thr_work:idle")?.payload.text).toContain("Fix the login bug");
+  expect(store.getOutbox("thread:thr_work:idle")?.payload.text).toContain("finished");
+});
+
+it("tells the owner when a watched thread fails", async () => {
+  const store = fixture();
+  await service(store, { threads: [watched({ status: "active" })] }).service.processDue();
+
+  await service(store, { threads: [watched({ status: "error" })] }).service.processDue();
+
+  expect(store.getOutbox("thread:thr_work:error")?.payload.text).toContain("failed");
+});
+
+it("announces a finish once rather than on every sweep", async () => {
+  const store = fixture();
+  await service(store, { threads: [watched({ status: "active" })] }).service.processDue();
+  await service(store, { threads: [watched({ status: "idle" })] }).service.processDue();
+
+  const again = service(store, { threads: [watched({ status: "idle" })] });
+  await expect(again.service.processDue()).resolves.toBe(false);
+});
+
+it("ignores a sub-agent's thread, which is the parent's business", async () => {
+  const store = fixture();
+  const child = watched({ id: "thr_child", parentThreadId: "thr_work", status: "active" });
+  const { service: notices, interactions } = service(store, { threads: [child] });
+
+  await notices.processDue();
+
+  expect(interactions).not.toHaveBeenCalled();
+  expect(store.getOutbox("thread:thr_child:idle")).toBeNull();
+});
+
+it("asks the owner to approve a command a thread is blocked on", async () => {
+  const store = fixture();
+  const { service: notices } = service(store, {
+    threads: [watched()],
+    interactions: [approvalInteraction()],
+  });
+
+  await expect(notices.processDue()).resolves.toBe(true);
+
+  const asked = store.getOutbox(`thread-interaction:${APPROVAL_ID}`);
+  expect(asked?.payload.text).toContain("rm -rf build");
+  expect(asked?.payload.reply_markup).toEqual({
+    inline_keyboard: [
+      [{ text: "Allow once", callback_data: `w:${threadDecisionToken(APPROVAL_ID, "allow_once")}` }],
+      [{ text: "Allow all session", callback_data: `w:${threadDecisionToken(APPROVAL_ID, "allow_for_session")}` }],
+      [{ text: "Deny", callback_data: `w:${threadDecisionToken(APPROVAL_ID, "deny")}` }],
+    ],
+  });
+});
+
+it("carries an approval decision back to the blocked thread", async () => {
+  const store = fixture();
+  const asked = service(store, { threads: [watched()], interactions: [approvalInteraction()] });
+  await asked.service.processDue();
+
+  const answer = store.answerThreadInteraction({
+    token: threadDecisionToken(APPROVAL_ID, "allow_once"),
+    userId: "7",
+    chatId: "7",
+    now: 4_000,
+  });
+  expect(answer).toEqual({
+    ok: true,
+    interactionId: APPROVAL_ID,
+    threadId: "thr_work",
+    title: "Fix the login bug",
+    label: "Allowed",
+  });
+
+  const delivering = service(store, { threads: [], now: () => 4_100 });
+  await expect(delivering.service.processDue()).resolves.toBe(true);
+  expect(delivering.resolve).toHaveBeenCalledWith("thr_work", APPROVAL_ID, {
+    decision: "allow_once",
+    grantedPermissions: null,
+  });
+
+  // Delivered once, even though the sweep runs continuously.
+  const again = service(store, { threads: [], now: () => 4_200 });
+  await again.service.processDue();
+  expect(again.resolve).not.toHaveBeenCalled();
+});
+
+it("carries a question answer back to the blocked thread", async () => {
+  const store = fixture();
+  await service(store, { threads: [watched()], interactions: [questionInteraction()] }).service.processDue();
+
+  const answer = store.answerThreadInteraction({
+    token: questionOptionToken(QUESTION_ID, "q1", "replica"),
+    userId: "7",
+    chatId: "7",
+    now: 4_000,
+  });
+  expect(answer.ok).toBe(true);
+
+  const delivering = service(store, { threads: [], now: () => 4_100 });
+  await delivering.service.processDue();
+
+  expect(delivering.resolve).toHaveBeenCalledWith("thr_work", QUESTION_ID, {
+    kind: "user_answer",
+    answers: { q1: { selected: ["replica"] } },
+  });
+});
+
+it("refuses a decision from anyone who is not the paired owner", () => {
+  const store = fixture();
+
+  expect(store.answerThreadInteraction({
+    token: threadDecisionToken(APPROVAL_ID, "deny"),
+    userId: "8",
+    chatId: "8",
+    now: 4_000,
+  })).toEqual({ ok: false, reason: "stale" });
+});
+
+it("stops offering a decision the thread resolved without the owner", async () => {
+  const store = fixture();
+  await service(store, { threads: [watched()], interactions: [approvalInteraction()] }).service.processDue();
+
+  // The next sweep sees the thread no longer waiting on anything.
+  await service(store, { threads: [watched()], interactions: [] }).service.processDue();
+
+  expect(store.answerThreadInteraction({
+    token: threadDecisionToken(APPROVAL_ID, "allow_once"),
+    userId: "7",
+    chatId: "7",
+    now: 4_000,
+  })).toEqual({ ok: false, reason: "stale" });
+});
+
+it("asks once for a block it has already reported", async () => {
+  const store = fixture();
+  await service(store, { threads: [watched()], interactions: [approvalInteraction()] }).service.processDue();
+
+  const again = service(store, { threads: [watched()], interactions: [approvalInteraction()] });
+  await expect(again.service.processDue()).resolves.toBe(false);
+});
+
+it("keeps sweeping when one thread's interactions cannot be read", async () => {
+  const store = fixture();
+  await service(store, { threads: [watched({ status: "active" })] }).service.processDue();
+  const warn = vi.fn();
+  const listWatchable = vi.fn(async () => [watched({ status: "idle" })]);
+  const notices = new ThreadNoticeService({
+    store,
+    threads: {
+      listWatchable,
+      interactions: vi.fn(async () => { throw new Error("BB is unreachable"); }),
+      resolve: vi.fn(async () => undefined),
+    },
+    clock: { now: () => 3_000 },
+    warn,
+  });
+
+  await expect(notices.processDue()).resolves.toBe(true);
+  expect(store.getOutbox("thread:thr_work:idle")?.payload.text).toContain("finished");
+});
+
+it("sweeps on its own cadence rather than on every executor tick", async () => {
+  const store = fixture();
+  let now = 3_000;
+  const listWatchable = vi.fn(async () => [watched({ status: "active" })]);
+  const notices = new ThreadNoticeService({
+    store,
+    threads: { listWatchable, interactions: vi.fn(async () => []), resolve: vi.fn(async () => undefined) },
+    clock: { now: () => now },
+  });
+
+  // The executor loop runs as often as every 250ms while an answer streams.
+  for (let tick = 0; tick < 20; tick += 1) {
+    now += 250;
+    await notices.processDue();
+  }
+
+  expect(listWatchable.mock.calls.length).toBeLessThanOrEqual(2);
+});
+
+it("delivers a tapped answer without waiting for the next sweep", async () => {
+  const store = fixture();
+  await service(store, { threads: [watched()], interactions: [approvalInteraction()] }).service.processDue();
+  store.answerThreadInteraction({
+    token: threadDecisionToken(APPROVAL_ID, "deny"),
+    userId: "7",
+    chatId: "7",
+    now: 3_100,
+  });
+  const resolve = vi.fn(async () => undefined);
+  const notices = new ThreadNoticeService({
+    store,
+    threads: { listWatchable: vi.fn(async () => []), interactions: vi.fn(async () => []), resolve },
+    clock: { now: () => 3_200 },
+  });
+
+  await expect(notices.processDue()).resolves.toBe(true);
+
+  expect(resolve).toHaveBeenCalledWith("thr_work", APPROVAL_ID, { decision: "deny" });
+});
+
+it("still reports a block it cannot render, instead of leaving the thread silent", async () => {
+  const store = fixture();
+  const { service: notices } = service(store, {
+    threads: [watched()],
+    interactions: [{ id: "pint_plugin1", status: "pending", payload: { kind: "plugin", detail: "something new" } }],
+  });
+
+  await expect(notices.processDue()).resolves.toBe(true);
+
+  const asked = store.getOutbox("thread-interaction:pint_plugin1");
+  expect(asked?.payload.text).toContain("Fix the login bug");
+  expect(asked?.payload.reply_markup).toBeUndefined();
+});
+
+it("does not contradict a finish it already reported when the thread errors later", async () => {
+  const store = fixture();
+  await service(store, { threads: [watched({ status: "active" })] }).service.processDue();
+  await service(store, { threads: [watched({ status: "idle" })], now: () => 4_000 }).service.processDue();
+  expect(store.getOutbox("thread:thr_work:idle")?.payload.text).toContain("finished");
+
+  // A thread that has already finished can still be marked failed afterwards.
+  // Its work is done; saying "failed" now would contradict what the owner read.
+  const later = service(store, { threads: [watched({ status: "error" })], now: () => 5_000 });
+  await expect(later.service.processDue()).resolves.toBe(false);
+
+  expect(store.getOutbox("thread:thr_work:error")).toBeNull();
+});
+
+it("does not narrate every turn of a thread that keeps being given more work", async () => {
+  const store = fixture();
+  let clock = 3_000;
+  const tick = (status: string) => {
+    clock += 30_000;
+    return service(store, { threads: [watched({ status })], now: () => clock });
+  };
+  await tick("active").service.processDue();
+  await tick("idle").service.processDue();
+  expect(store.getOutbox("thread:thr_work:idle")?.status).toBe("pending");
+
+  await tick("active").service.processDue();
+  const second = tick("idle");
+  await expect(second.service.processDue()).resolves.toBe(false);
+});
+
+it("reports a later finish once the quiet period has passed", async () => {
+  const store = fixture();
+  let clock = 3_000;
+  const tick = (status: string, jump = 30_000) => {
+    clock += jump;
+    return service(store, { threads: [watched({ status })], now: () => clock });
+  };
+  await tick("active").service.processDue();
+  await tick("idle").service.processDue();
+
+  await tick("active", 20 * 60_000).service.processDue();
+  await expect(tick("idle").service.processDue()).resolves.toBe(true);
+});


### PR DESCRIPTION
## Why

The owner runs BB entirely from Telegram and does not open the app. Anything that waits for a click there waits forever.

That was not hypothetical. The agent called `AskUserQuestion`, BB raised a pending interaction only the app could answer, and the bot showed "typing" for twenty minutes while every later message queued silently behind it — including the correction the owner sent eight seconds later.

## What changed

**Questions reach Telegram.** Detected on the `system/userQuestion/lifecycle` event the reconcile loop already polls, so detection costs no extra API calls. Asked with tappable options; answered by a tap or a plain typed reply. Multi-question interactions are asked one at a time and resolved once all are settled.

**Threads report themselves.** Visible top-level threads announce finished, failed, or blocked. A blocked thread's question or permission prompt is rendered with buttons — *Allow once* / *Allow all session* / *Deny* for a command or file change — and the tap is carried back through `threads.interactions.resolve`. A sub-agent's thread belongs to its parent, so it stays quiet.

**Silence is bounded.** A submitted turn producing no BB event for eight minutes is treated as wedged: the turn fails with a message to the owner *and the thread is retired*, so the next message opens a fresh session. That deadline sits below the ten-minute queued-message limit, so recovery happens before the queue starts failing behind it. A turn parked on a question is exempt — waiting on a person is not a stall.

**Corrections land in time.** A message sent mid-answer is steered into the running thread rather than queued behind the answer it means to correct.

## Design notes

- Notices go straight to the durable outbox rather than through the agent, so they still arrive when the agent is the stuck part.
- The sweep is paced at 15s independently of the executor loop, which runs as often as every 250ms while an answer streams. An owner's tap is delivered immediately; only polling is paced.
- A block that cannot be rendered faithfully is reported without buttons rather than skipped. Guessing would answer it wrongly; silence is the failure this exists to remove.
- Callback data carries a 32-char digest because BB option values alone exceed Telegram's 64-byte limit.
- Notices fire only on a move *out of* a working status, at most once per thread per ten minutes — otherwise a thread that finished and was later marked failed reported both, and a steered thread narrated every reply.

## Security

Tapping *Allow once* in Telegram now authorizes a command or file write in that thread. This moves where the decision is made, not who may make it: the paired chat already holds operator-level control. `SECURITY.md` is updated, including the limit that the controller's own permission prompts under `auto`/`accept-edits` are still answered in BB only.

## Verification

- `npm run typecheck` — clean
- `npx vitest run` — 715 passed (43 files), up from 677
- Four appended migrations; verified against the live plugin database
- Live: the watchdog fired in production and delivered its message; the question bridge and notices were exercised against the real bot