### PR TITLE
Drop the node_modules symlink committed in #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .worktrees/
-node_modules/
+node_modules
 dist/
 coverage/
 .env

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/root/github_projects/telegram-bb-agent-plugin/node_modules


### PR DESCRIPTION
## What

`#1` committed a **symlink** named `node_modules` (mode `120000`) pointing at `/root/github_projects/telegram-bb-agent-plugin/node_modules`. It is meaningless to anyone cloning the repo and leaks a local absolute path.

I created it to run the test suite against the PR branch and it should never have been staged.

## Why it got through

`.gitignore` read `node_modules/`. A trailing slash matches a **directory only** — a symlink of the same name is a file to git, so the pattern missed it and `git add -A` staged it.

Dropping the slash matches all three shapes. Verified with `git check-ignore -v` against both a symlink and a real directory:

```
.gitignore:2:node_modules    node_modules
.gitignore:2:node_modules    node_modules/x
```

## Scope

Two changes: remove the symlink, drop the trailing slash. No source or test files touched.