### PR TITLE
Fix Telegram image delivery to controller agents

### DIFF
--- a/src/controller/bb-controller.ts
+++ b/src/controller/bb-controller.ts
@@ -1,5 +1,10 @@
 import type { BbPluginApi } from "@bb/plugin-sdk";
-import type { ControllerThreadRecord, ControllerTurnRecord } from "./models";
+import {
+  MAX_CONTROLLER_IMAGE_BYTES,
+  type ControllerImage,
+  type ControllerThreadRecord,
+  type ControllerTurnRecord,
+} from "./models";
 import { buildInitialControllerPrompt } from "./instructions";
 import {
   controllerExecutionArguments,
@@ -38,9 +43,18 @@ export type ControllerAdapter = {
     controller: ControllerThreadRecord,
     signal: AbortSignal,
   ): Promise<ControllerLocation>;
-  send(threadId: string, text: string, signal: AbortSignal): Promise<void>;
+  send(
+    threadId: string,
+    text: string,
+    signal: AbortSignal,
+    image?: ControllerImage | null,
+  ): Promise<void>;
   /** Redirects a thread that is already working, rather than queueing behind it. */
-  steer(threadId: string, text: string, signal: AbortSignal): Promise<void>;
+  steer(
+    threadId: string,
+    text: string,
+    signal: AbortSignal,
+  ): Promise<void>;
   answerQuestion(
     threadId: string,
     interactionId: string,
@@ -58,6 +72,14 @@ const EVENT_PAGE_LIMIT = 100;
 const MAX_EVENT_PAGES = 50;
 
 type BbSdk = BbPluginApi["sdk"];
+type ControllerPromptInput = Parameters<BbSdk["threads"]["send"]>[0]["input"];
+
+export class ControllerImagePreparationError extends Error {
+  public constructor(public readonly retryable: boolean) {
+    super("Controller image could not be prepared");
+    this.name = "ControllerImagePreparationError";
+  }
+}
 
 function controllerTitle(controllerKey: string): string {
   return `Telegram Codex controller ${controllerKey}`;
@@ -73,6 +95,11 @@ export class BbControllerAdapter implements ControllerAdapter {
     sdk: BbSdk;
     pluginId: string;
     executionProfile: () => ControllerExecutionProfile;
+    downloadImage?: (
+      fileId: string,
+      maxBytes: number,
+      signal: AbortSignal,
+    ) => Promise<Uint8Array>;
   }) {}
 
   public async spawn(
@@ -80,13 +107,25 @@ export class BbControllerAdapter implements ControllerAdapter {
     controller: ControllerThreadRecord,
     signal: AbortSignal,
   ): Promise<ControllerLocation> {
-    const personal = await this.resolvePersonalProject(signal);
+    let personal: { projectId: string; hostId: string };
+    try {
+      personal = await this.resolvePersonalProject(signal);
+    } catch (error) {
+      if (turn.image) throw new ControllerImagePreparationError(true);
+      throw error;
+    }
     const execution = this.dependencies.executionProfile();
+    const input = await this.promptInput(
+      personal.projectId,
+      buildInitialControllerPrompt(turn.inputText),
+      turn.image,
+      signal,
+    );
     const thread = await this.dependencies.sdk.threads.spawn({
       projectId: personal.projectId,
       title: controllerTitle(controller.controllerKey),
       visibility: "hidden",
-      input: [{ type: "text", text: buildInitialControllerPrompt(turn.inputText), mentions: [] }],
+      input,
       environment: {
         type: "host",
         hostId: personal.hostId,
@@ -97,22 +136,41 @@ export class BbControllerAdapter implements ControllerAdapter {
     return { threadId: thread.id, ...personal };
   }
 
-  public async send(threadId: string, text: string, signal: AbortSignal): Promise<void> {
+  public async send(
+    threadId: string,
+    text: string,
+    signal: AbortSignal,
+    image: ControllerImage | null = null,
+  ): Promise<void> {
     const execution = this.dependencies.executionProfile();
+    let personal: { projectId: string; hostId: string } | null = null;
+    if (image) {
+      try {
+        personal = await this.resolvePersonalProject(signal);
+      } catch {
+        throw new ControllerImagePreparationError(true);
+      }
+    }
+    const input = await this.promptInput(personal?.projectId ?? null, text, image, signal);
     await this.dependencies.sdk.threads.send({
       threadId,
       mode: "start",
       ...controllerExecutionArguments(execution, { includeProvider: false }),
-      input: [{ type: "text", text, mentions: [] }],
+      input,
     });
   }
 
-  // "auto" lets BB fold the message into the running turn instead of starting a
-  // second one, so a correction the owner sends mid-answer still lands.
-  public async steer(threadId: string, text: string, signal: AbortSignal): Promise<void> {
+  // Images deliberately do not use this path: preparing one can outlive the
+  // active turn and BB may then start a new, untracked turn. The service leaves
+  // image turns queued for the ordinary idle-thread dispatch instead.
+  public async steer(
+    threadId: string,
+    text: string,
+    signal: AbortSignal,
+  ): Promise<void> {
     await this.dependencies.sdk.threads.send({
       threadId,
-      mode: "auto",
+      mode: "steer-if-active",
       input: [{ type: "text", text, mentions: [] }],
     });
   }
@@ -218,6 +276,47 @@ export class BbControllerAdapter implements ControllerAdapter {
     if (candidates.length > 1) throw new Error("Multiple ambiguous BB controller spawn candidates exist");
     const candidate = candidates[0];
     return candidate ? { threadId: candidate.id, ...personal } : null;
+  }
+
+  private async promptInput(
+    projectId: string | null,
+    text: string,
+    image: ControllerImage | null,
+    signal: AbortSignal,
+  ): Promise<ControllerPromptInput> {
+    const input: ControllerPromptInput = [{ type: "text", text, mentions: [] }];
+    if (!image) return input;
+    if (!projectId || !this.dependencies.downloadImage) {
+      throw new ControllerImagePreparationError(false);
+    }
+    let bytes: Uint8Array;
+    try {
+      bytes = await this.dependencies.downloadImage(
+        image.fileId,
+        MAX_CONTROLLER_IMAGE_BYTES,
+        signal,
+      );
+    } catch (error) {
+      if (error instanceof ControllerImagePreparationError) throw error;
+      throw new ControllerImagePreparationError(true);
+    }
+    if (bytes.byteLength > MAX_CONTROLLER_IMAGE_BYTES) {
+      throw new ControllerImagePreparationError(false);
+    }
+    try {
+      const uploaded = await this.dependencies.sdk.projects.attachments.upload({
+        projectId,
+        clientFile: bytes,
+        filename: image.fileName,
+        mimeType: image.mimeType,
+      });
+      if (uploaded.type !== "localImage") throw new ControllerImagePreparationError(false);
+      input.push({ type: "localImage", path: uploaded.path });
+      return input;
+    } catch (error) {
+      if (error instanceof ControllerImagePreparationError) throw error;
+      throw new ControllerImagePreparationError(true);
+    }
   }
 
   private async resolvePersonalProject(signal: AbortSignal): Promise<{ projectId: string; hostId: string }> {

--- a/src/controller/models.ts
+++ b/src/controller/models.ts
@@ -1,5 +1,19 @@
 export type ControllerThreadState = "pending_spawn" | "active" | "failed" | "revoked";
 export type ControllerTurnState = "queued" | "dispatching" | "submitted" | "completed" | "failed";
+export const CONTROLLER_IMAGE_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+] as const;
+export const MAX_CONTROLLER_IMAGE_BYTES = 10 * 1024 * 1024;
+export type ControllerImageMimeType = (typeof CONTROLLER_IMAGE_MIME_TYPES)[number];
+export type ControllerImage = {
+  fileId: string;
+  fileName: string;
+  mimeType: ControllerImageMimeType;
+  sizeBytes: number | null;
+};
 export type ControllerStreamPhase =
   | "queued"
   | "connecting"
@@ -29,6 +43,7 @@ export type ControllerTurnRecord = {
   controllerKey: string;
   ordinal: number;
   inputText: string;
+  image: ControllerImage | null;
   state: ControllerTurnState;
   leaseOwner: string | null;
   leaseGeneration: number | null;

--- a/src/controller/service.ts
+++ b/src/controller/service.ts
@@ -1,6 +1,11 @@
 import type { TelegramAgentStore } from "../storage/store";
 import type { EffectFence } from "../services/effect-runner";
-import type { ControllerAdapter, ControllerLocation, ControllerStatus } from "./bb-controller";
+import {
+  ControllerImagePreparationError,
+  type ControllerAdapter,
+  type ControllerLocation,
+  type ControllerStatus,
+} from "./bb-controller";
 import type { ControllerThreadRecord, ControllerTurnRecord } from "./models";
 import { projectControllerStream } from "./stream";
 import { buildTurnContext, composeTurnInput } from "./context";
@@ -15,6 +20,8 @@ const CONTROLLER_DRAFT_REFRESH_MS = 20_000;
 // How long a queued message may wait for a busy controller thread before the
 // owner is told it will not be answered.
 const CONTROLLER_BUSY_WAIT_MS = 10 * 60_000;
+const CONTROLLER_IMAGE_FAILURE_MESSAGE =
+  "I couldn't read that image safely. Please resend a smaller JPEG, PNG, WebP, or GIF.";
 /**
  * How long a submitted turn may go without producing a single BB event before
  * it is treated as wedged. Any event at all — reasoning, a tool call, output —
@@ -24,6 +31,7 @@ const CONTROLLER_BUSY_WAIT_MS = 10 * 60_000;
  */
 export const CONTROLLER_STALL_MS = 8 * 60_000;
 const MAX_STEER_ATTEMPTS = 3;
+const MAX_IMAGE_PREPARATION_ATTEMPTS = 3;
 
 function boundedResponse(value: string): string | null {
   const text = value.trim();
@@ -95,12 +103,14 @@ export class LunaControllerService {
           return true;
         }
         try {
-          await this.dependencies.adapter.send(
-            controller.threadId,
-            this.composeInput(turn, { includeDigest: false }),
-            signal,
-          );
-        } catch {
+          const input = this.composeInput(turn, { includeDigest: false });
+          if (turn.image) {
+            await this.dependencies.adapter.send(controller.threadId, input, signal, turn.image);
+          } else {
+            await this.dependencies.adapter.send(controller.threadId, input, signal);
+          }
+        } catch (error) {
+          if (this.handleImagePreparationError(error, turn, fence, signal)) return true;
           this.fail(turn, fence, "Controller send outcome is uncertain");
           return true;
         }
@@ -248,7 +258,7 @@ export class LunaControllerService {
       const waiting = parked === null
         ? this.dependencies.store.getQueuedControllerTurn(controller.controllerKey)
         : null;
-      if (waiting && waiting.retryCount < MAX_STEER_ATTEMPTS) {
+      if (waiting && !waiting.image && waiting.retryCount < MAX_STEER_ATTEMPTS) {
         try {
           await this.dependencies.adapter.steer(controller.threadId, waiting.inputText, signal);
         } catch {
@@ -366,12 +376,18 @@ export class LunaControllerService {
     fence: EffectFence,
     signal: AbortSignal,
   ): Promise<ControllerLocation | null> {
-    let candidate: ControllerLocation | null;
-    try {
-      candidate = await this.dependencies.adapter.findSpawnCandidate(controller.controllerKey, signal);
-    } catch {
-      this.fail(turn, fence, "Controller spawn candidates are ambiguous");
-      return null;
+    let candidate: ControllerLocation | null = null;
+    // Image turns never adopt by title before attempting their own spawn. A
+    // title match cannot prove that the image was attached, and adopting it
+    // would silently drop the image. Recovery after an uncertain actual spawn
+    // remains available in the catch block below.
+    if (!turn.image) {
+      try {
+        candidate = await this.dependencies.adapter.findSpawnCandidate(controller.controllerKey, signal);
+      } catch {
+        this.fail(turn, fence, "Controller spawn candidates are ambiguous");
+        return null;
+      }
     }
     if (candidate) return candidate;
     // A replacement thread opens with the conversation so far, so retiring a
@@ -379,7 +395,8 @@ export class LunaControllerService {
     const seeded = { ...turn, inputText: this.composeInput(turn, { includeDigest: true }) };
     try {
       return await this.dependencies.adapter.spawn(seeded, controller, signal);
-    } catch {
+    } catch (error) {
+      if (this.handleImagePreparationError(error, turn, fence, signal)) return null;
       try {
         candidate = await this.dependencies.adapter.findSpawnCandidate(controller.controllerKey, signal);
       } catch {
@@ -410,6 +427,37 @@ export class LunaControllerService {
       return;
     }
     this.dependencies.store.requeueControllerTurn({ ...fenceAt(fence, now), turnId: turn.id });
+  }
+
+  private failImage(turn: ControllerTurnRecord, fence: EffectFence): void {
+    this.fail(
+      turn,
+      fence,
+      "Controller image preparation failed",
+      CONTROLLER_IMAGE_FAILURE_MESSAGE,
+    );
+  }
+
+  private handleImagePreparationError(
+    error: unknown,
+    turn: ControllerTurnRecord,
+    fence: EffectFence,
+    signal: AbortSignal,
+  ): boolean {
+    if (!(error instanceof ControllerImagePreparationError)) return false;
+    if (!error.retryable || turn.retryCount + 1 >= MAX_IMAGE_PREPARATION_ATTEMPTS) {
+      this.failImage(turn, fence);
+      return true;
+    }
+    const now = this.dependencies.clock.now();
+    const requeued = signal.aborted
+      ? this.dependencies.store.requeueControllerTurn({ ...fenceAt(fence, now), turnId: turn.id })
+      : this.dependencies.store.recordControllerImagePreparationFailure({
+        ...fenceAt(fence, now),
+        turnId: turn.id,
+      });
+    if (!requeued) throw new Error("Controller image retry could not be recorded");
+    return true;
   }
 
   private fail(

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,7 +3,7 @@ import { controllerExecutionProfile, parseGlobalConfig } from "./config";
 import { BbRunner } from "./bb/runner";
 import { resolvePrHead, runValidation } from "./bb/validation";
 import { TerminalCommandRunner } from "./bb/terminal-command";
-import { TelegramClient } from "./telegram/client";
+import { TelegramClient, TelegramFileTooLargeError } from "./telegram/client";
 import { TelegramIngress } from "./telegram/ingress";
 import { openStore } from "./storage/store";
 import { EffectRunner } from "./services/effect-runner";
@@ -23,7 +23,7 @@ import {
 import { runTelegramAgentCli } from "./cli";
 import { ExecutorNudge } from "./services/executor-nudge";
 import { registerControllerTools } from "./controller/tools";
-import { BbControllerAdapter } from "./controller/bb-controller";
+import { BbControllerAdapter, ControllerImagePreparationError } from "./controller/bb-controller";
 import {
   CONTROLLER_MODELS,
   CONTROLLER_PERMISSION_MODES,
@@ -351,6 +351,17 @@ export async function createPlugin(bb: BbPluginApi): Promise<void> {
       executionProfile: () => {
         if (!config.ok) throw new Error(config.message);
         return controllerExecutionProfile(config.value);
+      },
+      downloadImage: async (fileId, maxBytes, signal) => {
+        if (!config.ok) throw new Error(config.message);
+        try {
+          return await telegramForToken(config.value.botToken).downloadFile(fileId, maxBytes, signal);
+        } catch (error) {
+          if (error instanceof TelegramFileTooLargeError) {
+            throw new ControllerImagePreparationError(false);
+          }
+          throw error;
+        }
       },
     }),
     clock: { now: clock },

--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -518,6 +518,13 @@ export const NOTICE_COOLDOWN_MIGRATIONS = [String.raw`
 ALTER TABLE observed_threads ADD COLUMN notified_at INTEGER;
 `] as const;
 
+export const CONTROLLER_IMAGE_MIGRATIONS = [String.raw`
+ALTER TABLE controller_turns ADD COLUMN image_file_id TEXT;
+ALTER TABLE controller_turns ADD COLUMN image_file_name TEXT;
+ALTER TABLE controller_turns ADD COLUMN image_mime_type TEXT;
+ALTER TABLE controller_turns ADD COLUMN image_size_bytes INTEGER;
+`] as const;
+
 export const ALL_MIGRATIONS = [
   ...INITIAL_MIGRATIONS,
   ...TASK_3_MIGRATIONS,
@@ -535,4 +542,5 @@ export const ALL_MIGRATIONS = [
   ...THREAD_NOTICE_MIGRATIONS,
   ...UNSUPPORTED_INTERACTION_MIGRATIONS,
   ...NOTICE_COOLDOWN_MIGRATIONS,
+  ...CONTROLLER_IMAGE_MIGRATIONS,
 ] as const;

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -16,12 +16,15 @@ import { formattedMessage } from "../telegram/markdown";
 import { ftsQuery, memoryScore } from "./memory-ranking";
 import { assertSafeFailureSummary, containsCredentialLikeText, transition } from "../domain/state-machine";
 import { ALL_MIGRATIONS } from "./migrations";
-import type {
-  ControllerLeaseFence,
-  ControllerThreadRecord,
-  ControllerThreadState,
-  ControllerTurnRecord,
-  ControllerTurnState,
+import {
+  CONTROLLER_IMAGE_MIME_TYPES,
+  MAX_CONTROLLER_IMAGE_BYTES,
+  type ControllerImage,
+  type ControllerLeaseFence,
+  type ControllerThreadRecord,
+  type ControllerThreadState,
+  type ControllerTurnRecord,
+  type ControllerTurnState,
 } from "../controller/models";
 import {
   nextUnansweredQuestion,
@@ -534,6 +537,10 @@ type ControllerTurnRow = {
   controller_key: string;
   ordinal: number;
   input_text: string;
+  image_file_id: string | null;
+  image_file_name: string | null;
+  image_mime_type: string | null;
+  image_size_bytes: number | null;
   state: ControllerTurnState;
   lease_owner: string | null;
   lease_generation: number | null;
@@ -772,6 +779,25 @@ function assertControllerIdentifier(value: string, field: string): void {
 function assertControllerText(value: string, field: string): void {
   if (typeof value !== "string" || value.trim().length === 0 || value.length > 4_000) {
     throw new TypeError(`${field} must be between 1 and 4000 characters`);
+  }
+}
+
+function assertControllerImage(value: ControllerImage): void {
+  if (typeof value.fileId !== "string" || value.fileId.length === 0 || value.fileId.length > 1_024) {
+    throw new TypeError("controller image fileId must be between 1 and 1024 characters");
+  }
+  if (!/^[A-Za-z0-9._-]{1,255}$/.test(value.fileName)) {
+    throw new TypeError("controller image fileName is invalid");
+  }
+  if (!CONTROLLER_IMAGE_MIME_TYPES.includes(value.mimeType)) {
+    throw new TypeError("controller image mimeType is invalid");
+  }
+  if (value.sizeBytes !== null && (
+    !Number.isSafeInteger(value.sizeBytes) ||
+    value.sizeBytes < 0 ||
+    value.sizeBytes > MAX_CONTROLLER_IMAGE_BYTES
+  )) {
+    throw new TypeError("controller image sizeBytes is invalid");
   }
 }
 const CREDENTIAL_QUERY_KEY = /^(?:access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|api[_-]?key|auth(?:orization)?|auth[_-]?(?:token|key)|session[_-]?token|private[_-]?key|credentials?|password|passwd|secret|token|key|jwt|signature|sig)$/i;
@@ -1566,6 +1592,7 @@ export interface TelegramAgentStore {
     telegramChatId: string;
     updateId: number;
     inputText: string;
+    image?: ControllerImage | null;
     now: number;
   }): ControllerTurnRecord;
   getControllerByThreadId(threadId: string): ControllerThreadRecord | null;
@@ -1573,6 +1600,7 @@ export interface TelegramAgentStore {
   getControllerTurn(turnId: string): ControllerTurnRecord | null;
   claimNextControllerTurn(fence: ControllerLeaseFence & { leaseMs?: number }): ControllerTurnRecord | null;
   requeueControllerTurn(input: ControllerLeaseFence & { turnId: string }): boolean;
+  recordControllerImagePreparationFailure(input: ControllerLeaseFence & { turnId: string }): boolean;
   failStaleControllerDispatches(fence: ControllerLeaseFence): boolean;
   markControllerSpawned(input: ControllerLeaseFence & {
     turnId: string;
@@ -1977,12 +2005,14 @@ function parseControllerThread(row: ControllerThreadRow): ControllerThreadRecord
 }
 
 function parseControllerTurn(row: ControllerTurnRow): ControllerTurnRecord {
+  const image = parseControllerImage(row);
   return {
     id: row.id,
     updateId: row.telegram_update_id,
     controllerKey: row.controller_key,
     ordinal: row.ordinal,
     inputText: row.input_text,
+    image,
     state: row.state,
     leaseOwner: row.lease_owner,
     leaseGeneration: row.lease_generation,
@@ -2000,6 +2030,26 @@ function parseControllerTurn(row: ControllerTurnRow): ControllerTurnRecord {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+}
+
+function parseControllerImage(row: ControllerTurnRow): ControllerImage | null {
+  if (
+    row.image_file_id === null &&
+    row.image_file_name === null &&
+    row.image_mime_type === null &&
+    row.image_size_bytes === null
+  ) return null;
+  if (row.image_file_id === null || row.image_file_name === null || row.image_mime_type === null) {
+    throw new Error("Persisted controller image is incomplete");
+  }
+  const image = {
+    fileId: row.image_file_id,
+    fileName: row.image_file_name,
+    mimeType: row.image_mime_type,
+    sizeBytes: row.image_size_bytes,
+  } as ControllerImage;
+  assertControllerImage(image);
+  return image;
 }
 
 function parseThreadOperation(row: ThreadOperationRow): ThreadOperation {
@@ -2643,6 +2693,7 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
     telegramChatId: string;
     updateId: number;
     inputText: string;
+    image?: ControllerImage | null;
     now: number;
   }): ControllerTurnRecord {
     assertControllerKey(input.controllerKey);
@@ -2650,6 +2701,8 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
     assertCanonicalPositiveDecimal(input.telegramChatId, "telegramChatId");
     assertNonNegativeInteger(input.updateId, "updateId");
     assertControllerText(input.inputText, "controller input");
+    const image = input.image ?? null;
+    if (image) assertControllerImage(image);
     assertNonNegativeInteger(input.now, "now");
 
     return this.db.transaction((): ControllerTurnRecord => {
@@ -2664,7 +2717,11 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
       if (existing) {
         if (
           existing.controller_key !== input.controllerKey ||
-          existing.input_text !== input.inputText
+          existing.input_text !== input.inputText ||
+          existing.image_file_id !== (image?.fileId ?? null) ||
+          existing.image_file_name !== (image?.fileName ?? null) ||
+          existing.image_mime_type !== (image?.mimeType ?? null) ||
+          existing.image_size_bytes !== (image?.sizeBytes ?? null)
         ) {
           throw new IdempotencyConflictError(input.updateId);
         }
@@ -2703,9 +2760,23 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
       const id = `controller-turn-${input.updateId}`;
       this.db.prepare(
         `INSERT INTO controller_turns (
-           id, telegram_update_id, controller_key, ordinal, input_text, state, created_at, updated_at
-         ) VALUES (?, ?, ?, ?, ?, 'queued', ?, ?)`,
-      ).run(id, input.updateId, input.controllerKey, next.ordinal, input.inputText, input.now, input.now);
+           id, telegram_update_id, controller_key, ordinal, input_text,
+           image_file_id, image_file_name, image_mime_type, image_size_bytes,
+           state, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?)`,
+      ).run(
+        id,
+        input.updateId,
+        input.controllerKey,
+        next.ordinal,
+        input.inputText,
+        image?.fileId ?? null,
+        image?.fileName ?? null,
+        image?.mimeType ?? null,
+        image?.sizeBytes ?? null,
+        input.now,
+        input.now,
+      );
       const stored = this.db.prepare("SELECT * FROM controller_turns WHERE id = ?").get(id) as ControllerTurnRow;
       return parseControllerTurn(stored);
     }).immediate();
@@ -2792,6 +2863,28 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
       const requeued = this.db.prepare(
         `UPDATE controller_turns
             SET state = 'queued', lease_owner = NULL, lease_generation = NULL, updated_at = ?
+          WHERE id = ? AND state = 'dispatching' AND lease_owner = ? AND lease_generation = ?`,
+      ).run(input.now, input.turnId, input.ownerId, input.generation);
+      if (requeued.changes !== 1) return false;
+      this.db.prepare(
+        `UPDATE controller_threads SET pending_spawn_token = NULL, updated_at = ?
+          WHERE controller_key = (SELECT controller_key FROM controller_turns WHERE id = ?)
+            AND bb_thread_id IS NULL AND pending_spawn_token = ?`,
+      ).run(input.now, input.turnId, input.turnId);
+      return true;
+    }).immediate();
+  }
+
+  public recordControllerImagePreparationFailure(
+    input: ControllerLeaseFence & { turnId: string },
+  ): boolean {
+    this.assertControllerMutation(input);
+    return this.db.transaction((): boolean => {
+      if (!this.executorLeaseIsCurrent(input.ownerId, input.generation, input.now)) return false;
+      const requeued = this.db.prepare(
+        `UPDATE controller_turns
+            SET state = 'queued', retry_count = retry_count + 1,
+                lease_owner = NULL, lease_generation = NULL, updated_at = ?
           WHERE id = ? AND state = 'dispatching' AND lease_owner = ? AND lease_generation = ?`,
       ).run(input.now, input.turnId, input.ownerId, input.generation);
       if (requeued.changes !== 1) return false;

--- a/src/telegram/client.ts
+++ b/src/telegram/client.ts
@@ -1,6 +1,7 @@
 import { abortableSleep } from "../async";
 import {
   telegramGetMeSchema,
+  telegramFileSchema,
   telegramSentMessageSchema,
   telegramUpdateSchema,
   type SendMessagePayload,
@@ -16,6 +17,7 @@ const MAX_ATTEMPTS = 4;
 const MAX_RETRY_DELAY_MS = 30_000;
 const RETRY_BASE_DELAY_MS = 250;
 const TELEGRAM_API_ROOT = "https://api.telegram.org/bot";
+const TELEGRAM_FILE_ROOT = "https://api.telegram.org/file/bot";
 
 type Sleep = (milliseconds: number, signal: AbortSignal) => Promise<void>;
 type TelegramFetch = typeof fetch;
@@ -57,6 +59,13 @@ export class TelegramRequestError extends Error {
   public constructor(message: "Telegram request aborted" | "Telegram request failed") {
     super(message);
     this.name = "TelegramRequestError";
+  }
+}
+
+export class TelegramFileTooLargeError extends Error {
+  public constructor() {
+    super("Telegram file exceeds the configured size limit");
+    this.name = "TelegramFileTooLargeError";
   }
 }
 
@@ -127,6 +136,61 @@ function parseIdentity(apiResult: unknown): { id: number; username: string } {
   const parsedIdentity = telegramGetMeSchema.safeParse(apiResult);
   if (!parsedIdentity.success) throw new TelegramResponseValidationError();
   return { id: parsedIdentity.data.id, username: parsedIdentity.data.username };
+}
+
+function parseFile(apiResult: unknown): {
+  filePath: string;
+  fileSize: number | null;
+} {
+  const parsedFile = telegramFileSchema.safeParse(apiResult);
+  if (!parsedFile.success) throw new TelegramResponseValidationError();
+  return {
+    filePath: parsedFile.data.file_path,
+    fileSize: parsedFile.data.file_size ?? null,
+  };
+}
+
+function safeFilePath(value: string): string {
+  const segments = value.split("/");
+  if (segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")) {
+    throw new TelegramResponseValidationError();
+  }
+  return segments.map((segment) => encodeURIComponent(segment)).join("/");
+}
+
+function responseContentLength(response: Response): number | null {
+  const raw = response.headers.get("content-length");
+  if (raw === null || !/^[0-9]+$/.test(raw)) return null;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+async function readBoundedBytes(response: Response, maxBytes: number): Promise<Uint8Array> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength > maxBytes) throw new TelegramFileTooLargeError();
+    return bytes;
+  }
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > maxBytes) {
+      await reader.cancel().catch(() => undefined);
+      throw new TelegramFileTooLargeError();
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
 }
 
 function parseSuccessfulResult<T>(parseResult: (apiResult: unknown) => T, apiResult: unknown): T {
@@ -235,6 +299,54 @@ export class TelegramClient {
       timeoutMs: ORDINARY_REQUEST_TIMEOUT_MS,
       parseResult: parseIdentity,
     });
+  }
+
+  public async downloadFile(fileId: string, maxBytes: number, signal: AbortSignal): Promise<Uint8Array> {
+    if (typeof fileId !== "string" || fileId.length === 0 || fileId.length > 1_024) {
+      throw new TypeError("fileId must be between 1 and 1024 characters");
+    }
+    if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+      throw new TypeError("maxBytes must be a positive safe integer");
+    }
+    const file = await this.request({
+      method: "getFile",
+      payload: { file_id: fileId },
+      callerSignal: signal,
+      timeoutMs: ORDINARY_REQUEST_TIMEOUT_MS,
+      parseResult: parseFile,
+    });
+    if (file.fileSize !== null && file.fileSize > maxBytes) {
+      throw new TelegramFileTooLargeError();
+    }
+    const requestSignal = composeRequestSignal(signal, ORDINARY_REQUEST_TIMEOUT_MS);
+    let response: Response;
+    try {
+      response = await this.fetchFn(
+        `${TELEGRAM_FILE_ROOT}${this.token}/${safeFilePath(file.filePath)}`,
+        {
+          method: "GET",
+          redirect: "error",
+          cache: "no-store",
+          signal: requestSignal,
+        },
+      );
+    } catch (error) {
+      if (error instanceof TelegramResponseValidationError) throw error;
+      throw safeRequestError(requestSignal, signal);
+    }
+    if (requestSignal.aborted) throw safeRequestError(requestSignal, signal);
+    if (!response.ok) throw new TelegramRequestError("Telegram request failed");
+    const contentLength = responseContentLength(response);
+    if (contentLength !== null && contentLength > maxBytes) {
+      await response.body?.cancel().catch(() => undefined);
+      throw new TelegramFileTooLargeError();
+    }
+    try {
+      return await readBoundedBytes(response, maxBytes);
+    } catch (error) {
+      if (error instanceof TelegramFileTooLargeError) throw error;
+      throw safeRequestError(requestSignal, signal);
+    }
   }
 
   private async request<T>(request: TelegramRequest<T>): Promise<T> {

--- a/src/telegram/image.ts
+++ b/src/telegram/image.ts
@@ -1,0 +1,61 @@
+import {
+  CONTROLLER_IMAGE_MIME_TYPES,
+  type ControllerImage,
+  type ControllerImageMimeType,
+} from "../controller/models";
+import type { TelegramMessage } from "./types";
+
+export const CAPTIONLESS_IMAGE_PROMPT = "Please inspect this image.";
+
+const MIME_TYPE_EXTENSIONS: Record<ControllerImageMimeType, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/gif": "gif",
+};
+
+function imageMimeType(value: string | undefined): ControllerImageMimeType | null {
+  const normalized = value?.toLowerCase();
+  return CONTROLLER_IMAGE_MIME_TYPES.find((candidate) => candidate === normalized) ?? null;
+}
+
+function safeUniqueId(value: string): string {
+  const normalized = value.replace(/[^A-Za-z0-9_-]/g, "-").slice(0, 160);
+  return normalized.length > 0 ? normalized : "image";
+}
+
+function fileName(fileUniqueId: string, mimeType: ControllerImageMimeType): string {
+  return `telegram-${safeUniqueId(fileUniqueId)}.${MIME_TYPE_EXTENSIONS[mimeType]}`;
+}
+
+function largestPhoto(message: TelegramMessage): NonNullable<TelegramMessage["photo"]>[number] | null {
+  if (!message.photo) return null;
+  return message.photo.reduce((largest, candidate) => {
+    const largestArea = largest.width * largest.height;
+    const candidateArea = candidate.width * candidate.height;
+    if (candidateArea !== largestArea) return candidateArea > largestArea ? candidate : largest;
+    return (candidate.file_size ?? 0) > (largest.file_size ?? 0) ? candidate : largest;
+  });
+}
+
+export function controllerImageFromMessage(message: TelegramMessage): ControllerImage | null {
+  const photo = largestPhoto(message);
+  if (photo) {
+    return {
+      fileId: photo.file_id,
+      fileName: fileName(photo.file_unique_id, "image/jpeg"),
+      mimeType: "image/jpeg",
+      sizeBytes: photo.file_size ?? null,
+    };
+  }
+
+  const document = message.document;
+  const mimeType = imageMimeType(document?.mime_type);
+  if (!document || !mimeType) return null;
+  return {
+    fileId: document.file_id,
+    fileName: fileName(document.file_unique_id, mimeType),
+    mimeType,
+    sizeBytes: document.file_size ?? null,
+  };
+}

--- a/src/telegram/ingress.ts
+++ b/src/telegram/ingress.ts
@@ -28,6 +28,8 @@ import {
 } from "./view";
 import { TelegramRequestError } from "./client";
 import { TelegramApiError } from "./errors";
+import { MAX_CONTROLLER_IMAGE_BYTES } from "../controller/models";
+import { CAPTIONLESS_IMAGE_PROMPT, controllerImageFromMessage } from "./image";
 
 export type TelegramIngressTransport = {
   sendMessage(chatId: string, payload: SendMessagePayload): Promise<{ message_id: number }>;
@@ -202,7 +204,8 @@ export class TelegramIngress {
 
   private async handleMessage(message: TelegramMessage, updateId: number, now: number): Promise<void> {
     const identity = privateHumanIdentity(message.from, message.chat);
-    const text = message.text;
+    const image = controllerImageFromMessage(message);
+    const text = message.text ?? (image ? message.caption ?? CAPTIONLESS_IMAGE_PROMPT : undefined);
     if (text === undefined) return;
 
     const pairingCode = this.pairingCode(text);
@@ -228,6 +231,10 @@ export class TelegramIngress {
 
     if (!identity || !ownerMatches(this.store, identity)) {
       this.audit("unauthorized_message", updateId, message.from, message.chat);
+      return;
+    }
+    if (image && image.sizeBytes !== null && image.sizeBytes > MAX_CONTROLLER_IMAGE_BYTES) {
+      await this.sendPlain(identity.chatId, "That image is larger than BB's 10 MB image limit. Please resend a smaller copy.");
       return;
     }
     const normalized = boundedText(text);
@@ -287,6 +294,7 @@ export class TelegramIngress {
       telegramChatId: identity.chatId,
       updateId,
       inputText: normalized,
+      image,
       now,
     });
     this.rememberStandingInstruction(normalized, turn.id, now);

--- a/src/telegram/types.ts
+++ b/src/telegram/types.ts
@@ -14,12 +14,35 @@ const telegramChatSchema = z
   })
   .passthrough();
 
+const telegramPhotoSizeSchema = z
+  .object({
+    file_id: z.string().min(1).max(1_024),
+    file_unique_id: z.string().min(1).max(1_024),
+    width: z.number().int().nonnegative(),
+    height: z.number().int().nonnegative(),
+    file_size: z.number().int().nonnegative().optional(),
+  })
+  .passthrough();
+
+const telegramDocumentSchema = z
+  .object({
+    file_id: z.string().min(1).max(1_024),
+    file_unique_id: z.string().min(1).max(1_024),
+    file_name: z.string().max(1_024).optional(),
+    mime_type: z.string().max(255).optional(),
+    file_size: z.number().int().nonnegative().optional(),
+  })
+  .passthrough();
+
 export const telegramMessageSchema = z
   .object({
     message_id: z.number().int(),
     from: telegramUserSchema,
     chat: telegramChatSchema,
     text: z.string().optional(),
+    caption: z.string().optional(),
+    photo: z.array(telegramPhotoSizeSchema).min(1).optional(),
+    document: telegramDocumentSchema.optional(),
     reply_to_message: z
       .object({ message_id: z.number().int() })
       .passthrough()
@@ -61,6 +84,15 @@ export const telegramGetMeSchema = z
 
 export const telegramSentMessageSchema = z
   .object({ message_id: z.number().int() })
+  .passthrough();
+
+export const telegramFileSchema = z
+  .object({
+    file_id: z.string().min(1).max(1_024),
+    file_unique_id: z.string().min(1).max(1_024),
+    file_size: z.number().int().nonnegative().optional(),
+    file_path: z.string().min(1).max(2_048),
+  })
   .passthrough();
 
 export type TelegramMessage = z.infer<typeof telegramMessageSchema>;

--- a/tests/controller-questions.test.ts
+++ b/tests/controller-questions.test.ts
@@ -148,7 +148,7 @@ it("steers a busy controller thread instead of starting a competing turn", async
 
   expect(send).toHaveBeenCalledWith({
     threadId: "thr_controller",
-    mode: "auto",
+    mode: "steer-if-active",
     input: [{ type: "text", text: "in review i mean not in progress", mentions: [] }],
   });
 });

--- a/tests/controller-service.test.ts
+++ b/tests/controller-service.test.ts
@@ -5,6 +5,7 @@ import { hashSecret } from "../src/crypto";
 import { openStore } from "../src/storage/store";
 import {
   BbControllerAdapter,
+  ControllerImagePreparationError,
   type ControllerAdapter,
 } from "../src/controller/bb-controller";
 import {
@@ -59,6 +60,7 @@ function turnRecord(overrides: Record<string, unknown> = {}) {
     controllerKey: "owner-7-controller",
     ordinal: 1,
     inputText: "What projects can you work on?",
+    image: null,
     state: "dispatching",
     leaseOwner: "executor",
     leaseGeneration: 1,
@@ -88,9 +90,21 @@ function sdkFixture(options: {
   maxSeq?: number;
   threadProvider?: string;
   executionProfile?: ControllerExecutionProfile;
+  downloadImage?: (fileId: string, maxBytes: number, signal: AbortSignal) => Promise<Uint8Array>;
 } = {}) {
   const spawn = vi.fn(async () => ({ id: "thr_controller", environmentId: "env_personal" }));
   const send = vi.fn(async () => ({ ok: true }));
+  const upload = vi.fn(async (input: {
+    clientFile: Uint8Array;
+    filename: string;
+    mimeType?: string;
+  }) => ({
+    type: "localImage" as const,
+    path: `/attachments/${input.filename}`,
+    name: input.filename,
+    mimeType: input.mimeType,
+    sizeBytes: input.clientFile.byteLength,
+  }));
   const list = vi.fn(async () => options.threads ?? []);
   const get = vi.fn(async () => ({
     id: "thr_controller",
@@ -105,7 +119,10 @@ function sdkFixture(options: {
   const eventsList = vi.fn(async () => pages[page++] ?? []);
   const timeline = vi.fn(async () => ({ maxSeq: options.maxSeq ?? 0 }));
   const sdk = {
-    projects: { list: vi.fn(async () => options.projects ?? [personalProject()]) },
+    projects: {
+      list: vi.fn(async () => options.projects ?? [personalProject()]),
+      attachments: { upload },
+    },
     hosts: { list: vi.fn(async () => options.hosts ?? [{ id: "host_personal", status: "connected" }]) },
     threads: { spawn, send, list, get, output, timeline, events: { list: eventsList } },
   } as unknown as BbPluginApi["sdk"];
@@ -113,8 +130,9 @@ function sdkFixture(options: {
     sdk,
     pluginId: "telegram-agent",
     executionProfile: () => options.executionProfile ?? DEFAULT_CONTROLLER_EXECUTION_PROFILE,
+    downloadImage: options.downloadImage,
   };
-  return { adapter: new BbControllerAdapter(dependencies), spawn, send, list, eventsList, timeline };
+  return { adapter: new BbControllerAdapter(dependencies), spawn, send, upload, list, eventsList, timeline };
 }
 
 function agentDelta(seq: number, delta: string) {
@@ -156,6 +174,35 @@ it("spawns the hidden personal controller on the configured model and provider",
   }));
 });
 
+it("uploads a Telegram image and attaches it when spawning the controller", async () => {
+  const bytes = new Uint8Array([1, 2, 3, 4]);
+  const downloadImage = vi.fn(async () => bytes);
+  const { adapter, spawn, upload } = sdkFixture({ downloadImage });
+  const image = {
+    fileId: "telegram-file-id",
+    fileName: "telegram-screenshot.jpg",
+    mimeType: "image/jpeg" as const,
+    sizeBytes: 4,
+  };
+  const signal = AbortSignal.timeout(1_000);
+
+  await adapter.spawn(turnRecord({ image }), controllerRecord(), signal);
+
+  expect(downloadImage).toHaveBeenCalledWith("telegram-file-id", 10 * 1024 * 1024, signal);
+  expect(upload).toHaveBeenCalledWith({
+    projectId: "proj_personal",
+    clientFile: bytes,
+    filename: "telegram-screenshot.jpg",
+    mimeType: "image/jpeg",
+  });
+  expect(spawn).toHaveBeenCalledWith(expect.objectContaining({
+    input: [
+      { type: "text", text: expect.stringContaining("What projects can you work on?"), mentions: [] },
+      { type: "localImage", path: "/attachments/telegram-screenshot.jpg" },
+    ],
+  }));
+});
+
 it("keeps the configured execution tuple on later controller turns", async () => {
   const { adapter, send } = sdkFixture();
 
@@ -174,6 +221,73 @@ it("keeps the configured execution tuple on later controller turns", async () =>
     },
     input: [{ type: "text", text: "Show active threads", mentions: [] }],
   });
+});
+
+it("attaches a Telegram image to a later controller turn", async () => {
+  const bytes = new Uint8Array([1, 2, 3, 4]);
+  const downloadImage = vi.fn(async () => bytes);
+  const { adapter, send, upload } = sdkFixture({ downloadImage });
+  const image = {
+    fileId: "telegram-file-id",
+    fileName: "telegram-screenshot.png",
+    mimeType: "image/png" as const,
+    sizeBytes: 4,
+  };
+
+  await adapter.send(
+    "thr_controller",
+    "Fix this overlap",
+    AbortSignal.timeout(1_000),
+    image,
+  );
+
+  expect(upload).toHaveBeenCalledWith({
+    projectId: "proj_personal",
+    clientFile: bytes,
+    filename: "telegram-screenshot.png",
+    mimeType: "image/png",
+  });
+  expect(send).toHaveBeenCalledWith(expect.objectContaining({
+    threadId: "thr_controller",
+    input: [
+      { type: "text", text: "Fix this overlap", mentions: [] },
+      { type: "localImage", path: "/attachments/telegram-screenshot.png" },
+    ],
+  }));
+});
+
+it("uses BB's active-steer mode for a text correction", async () => {
+  const { adapter, send } = sdkFixture();
+
+  await adapter.steer("thr_controller", "Use the second option instead", AbortSignal.timeout(1_000));
+
+  expect(send).toHaveBeenCalledWith(expect.objectContaining({
+    threadId: "thr_controller",
+    mode: "steer-if-active",
+    input: [{ type: "text", text: "Use the second option instead", mentions: [] }],
+  }));
+});
+
+it("classifies a pre-submit image download failure as retryable", async () => {
+  const downloadImage = vi.fn(async () => { throw new Error("temporary Telegram outage"); });
+  const { adapter, send } = sdkFixture({ downloadImage });
+  const image = {
+    fileId: "telegram-file-id",
+    fileName: "telegram-screenshot.png",
+    mimeType: "image/png" as const,
+    sizeBytes: null,
+  };
+
+  await expect(adapter.send(
+    "thr_controller",
+    "Inspect this",
+    AbortSignal.timeout(1_000),
+    image,
+  )).rejects.toMatchObject({
+    name: "ControllerImagePreparationError",
+    retryable: true,
+  });
+  expect(send).not.toHaveBeenCalled();
 });
 
 it("reduces BB controller events after the durable sequence without exposing reasoning", async () => {
@@ -391,6 +505,210 @@ it("dispatches FIFO, waits for idle output, and then sends the next turn with mo
   await expect(service.processOne(fence, fence.signal)).resolves.toBe(true);
   expect(adapter.send).toHaveBeenCalledWith("thr_controller", "second", fence.signal);
   expect(store.listControllerTurns("owner-7-controller", 10).map((turn) => turn.state)).toEqual(["completed", "submitted"]);
+});
+
+it("passes a persisted image into a later controller dispatch", async () => {
+  const { store, fence } = serviceFixture();
+  const bootstrap = store.enqueueControllerTurn({
+    ...turnRecord({ updateId: 13, inputText: "bootstrap" }),
+    telegramUserId: "7",
+    telegramChatId: "7",
+    now: 2_000,
+  });
+  const leaseFence = { ownerId: fence.ownerId, generation: fence.generation, now: 2_000 };
+  expect(store.claimNextControllerTurn(leaseFence)?.id).toBe(bootstrap.id);
+  expect(store.markControllerSpawned({
+    ...leaseFence,
+    turnId: bootstrap.id,
+    projectId: "proj_personal",
+    hostId: "host_personal",
+    threadId: "thr_controller",
+  })).toBe(true);
+  expect(store.markControllerTurnSubmitted({ ...leaseFence, turnId: bootstrap.id })).toBe(true);
+  expect(store.completeControllerTurn({
+    ...leaseFence,
+    turnId: bootstrap.id,
+    responseText: "Ready.",
+  })).toBe(true);
+  const image = {
+    fileId: "telegram-file-id",
+    fileName: "telegram-screenshot.png",
+    mimeType: "image/png" as const,
+    sizeBytes: 4,
+  };
+  store.enqueueControllerTurn({
+    ...turnRecord({ updateId: 14, inputText: "Fix this overlap", image }),
+    telegramUserId: "7",
+    telegramChatId: "7",
+    now: 2_001,
+  });
+  const adapter: ControllerAdapter = {
+    spawn: vi.fn(async () => ({ threadId: "unused", projectId: "proj_personal", hostId: "host_personal" })),
+    send: vi.fn(async () => undefined),
+    status: vi.fn(async (): Promise<"idle"> => "idle"),
+    latestSeq: vi.fn(async () => 12),
+    output: vi.fn(async () => "unused"),
+    events: vi.fn(async () => ({ latestSeq: 0, inputAccepted: false, assistantDelta: "", completed: false, error: null, pendingQuestion: null })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
+    findSpawnCandidate: vi.fn(async () => null),
+  };
+  const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_001 } });
+
+  await expect(service.processOne(fence, fence.signal)).resolves.toBe(true);
+
+  expect(adapter.send).toHaveBeenCalledWith("thr_controller", "Fix this overlap", fence.signal, image);
+  expect(store.getControllerTurn("controller-turn-14")).toMatchObject({
+    state: "submitted",
+    image,
+    dispatchAfterSeq: 12,
+  });
+});
+
+it("keeps a queued image durable until the active turn finishes", async () => {
+  const { store, fence } = serviceFixture();
+  const running = store.enqueueControllerTurn({
+    ...turnRecord({ updateId: 15, inputText: "first request" }),
+    telegramUserId: "7",
+    telegramChatId: "7",
+    now: 2_000,
+  });
+  const leaseFence = { ownerId: fence.ownerId, generation: fence.generation, now: 2_000 };
+  expect(store.claimNextControllerTurn(leaseFence)?.id).toBe(running.id);
+  expect(store.markControllerSpawned({
+    ...leaseFence,
+    turnId: running.id,
+    projectId: "proj_personal",
+    hostId: "host_personal",
+    threadId: "thr_controller",
+  })).toBe(true);
+  expect(store.markControllerTurnSubmitted({ ...leaseFence, turnId: running.id })).toBe(true);
+  const image = {
+    fileId: "replacement-file-id",
+    fileName: "telegram-replacement.webp",
+    mimeType: "image/webp" as const,
+    sizeBytes: 8,
+  };
+  store.enqueueControllerTurn({
+    ...turnRecord({ updateId: 16, inputText: "Use this screenshot instead", image }),
+    telegramUserId: "7",
+    telegramChatId: "7",
+    now: 2_001,
+  });
+  let status: "active" | "idle" = "active";
+  const adapter: ControllerAdapter = {
+    spawn: vi.fn(async () => ({ threadId: "unused", projectId: "proj_personal", hostId: "host_personal" })),
+    send: vi.fn(async () => undefined),
+    status: vi.fn(async () => status),
+    latestSeq: vi.fn(async () => 0),
+    output: vi.fn(async () => "unused"),
+    events: vi.fn(async () => ({ latestSeq: 1, inputAccepted: true, assistantDelta: "", completed: false, error: null, pendingQuestion: null })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
+    findSpawnCandidate: vi.fn(async () => null),
+  };
+  const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_001 } });
+
+  await expect(service.reconcile(fence, fence.signal)).resolves.toBe(true);
+
+  expect(adapter.steer).not.toHaveBeenCalled();
+  expect(store.getControllerTurn("controller-turn-16")).toMatchObject({
+    state: "queued",
+    image,
+  });
+
+  status = "idle";
+  await expect(service.reconcile(fence, fence.signal)).resolves.toBe(true);
+  await expect(service.processOne(fence, fence.signal)).resolves.toBe(true);
+  expect(adapter.send).toHaveBeenCalledWith(
+    "thr_controller",
+    "Use this screenshot instead",
+    fence.signal,
+    image,
+  );
+  expect(store.getControllerTurn("controller-turn-16")).toMatchObject({ state: "submitted" });
+});
+
+it("requeues a transient image preparation failure without adopting a late spawn candidate", async () => {
+  const { store, fence } = serviceFixture();
+  const image = {
+    fileId: "telegram-file-id",
+    fileName: "telegram-screenshot.jpg",
+    mimeType: "image/jpeg" as const,
+    sizeBytes: null,
+  };
+  const turn = store.enqueueControllerTurn({
+    ...turnRecord({ updateId: 17, inputText: "Read this", image }),
+    telegramUserId: "7",
+    telegramChatId: "7",
+    now: 2_000,
+  });
+  const findSpawnCandidate = vi.fn()
+    .mockResolvedValueOnce(null)
+    .mockResolvedValueOnce({ threadId: "thr_unrelated", projectId: "proj_personal", hostId: "host_personal" });
+  const adapter: ControllerAdapter = {
+    spawn: vi.fn(async () => { throw new ControllerImagePreparationError(true); }),
+    send: vi.fn(async () => undefined),
+    status: vi.fn(async () => "idle" as const),
+    latestSeq: vi.fn(async () => 0),
+    output: vi.fn(async () => "unused"),
+    events: vi.fn(async () => ({ latestSeq: 0, inputAccepted: false, assistantDelta: "", completed: false, error: null, pendingQuestion: null })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
+    findSpawnCandidate,
+  };
+  const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_001 } });
+
+  await expect(service.processOne(fence, fence.signal)).resolves.toBe(true);
+  await expect(service.processOne(fence, fence.signal)).resolves.toBe(true);
+
+  expect(findSpawnCandidate).not.toHaveBeenCalled();
+  expect(store.getControllerTurn(turn.id)).toMatchObject({ state: "queued", retryCount: 2 });
+  expect(store.getControllerForOwner("7", "7")?.threadId).toBeNull();
+});
+
+it("requeues an aborted image preparation without consuming a retry", async () => {
+  const { store, fence } = serviceFixture();
+  const turn = store.enqueueControllerTurn({
+    ...turnRecord({
+      updateId: 18,
+      inputText: "Read this",
+      image: {
+        fileId: "telegram-file-id",
+        fileName: "telegram-screenshot.jpg",
+        mimeType: "image/jpeg" as const,
+        sizeBytes: null,
+      },
+    }),
+    telegramUserId: "7",
+    telegramChatId: "7",
+    now: 2_000,
+  });
+  const controller = new AbortController();
+  controller.abort();
+  const findSpawnCandidate = vi.fn(async () => ({
+    threadId: "thr_unrelated",
+    projectId: "proj_personal",
+    hostId: "host_personal",
+  }));
+  const adapter: ControllerAdapter = {
+    spawn: vi.fn(async () => { throw new ControllerImagePreparationError(true); }),
+    send: vi.fn(async () => undefined),
+    status: vi.fn(async () => "idle" as const),
+    latestSeq: vi.fn(async () => 0),
+    output: vi.fn(async () => "unused"),
+    events: vi.fn(async () => ({ latestSeq: 0, inputAccepted: false, assistantDelta: "", completed: false, error: null, pendingQuestion: null })),
+    steer: vi.fn(async () => undefined),
+    answerQuestion: vi.fn(async () => undefined),
+    findSpawnCandidate,
+  };
+  const service = new LunaControllerService({ store, adapter, clock: { now: () => 2_001 } });
+
+  await expect(service.processOne(fence, controller.signal)).resolves.toBe(true);
+  await expect(service.processOne(fence, controller.signal)).resolves.toBe(true);
+
+  expect(findSpawnCandidate).not.toHaveBeenCalled();
+  expect(store.getControllerTurn(turn.id)).toMatchObject({ state: "queued", retryCount: 0 });
 });
 
 it("retires a thread whose provider no longer matches the configured model", async () => {

--- a/tests/controller-store.test.ts
+++ b/tests/controller-store.test.ts
@@ -34,7 +34,7 @@ function acquire(store: ReturnType<typeof openStore>) {
 // Applied migrations are immutable history: each release appends, so these are
 // indexed from the start and a new migration only ever extends the tail.
 it("keeps every shipped migration at its original position and appends new ones", () => {
-  expect(ALL_MIGRATIONS).toHaveLength(16);
+  expect(ALL_MIGRATIONS).toHaveLength(17);
   expect(ALL_MIGRATIONS[3]).toContain("CREATE TABLE controller_threads");
   expect(ALL_MIGRATIONS[3]).toContain("CREATE TABLE controller_turns");
   expect(ALL_MIGRATIONS[4]).toContain("dispatch_after_seq");
@@ -55,18 +55,26 @@ it("keeps every shipped migration at its original position and appends new ones"
   expect(ALL_MIGRATIONS[13]).toContain("CREATE TABLE thread_interactions");
   expect(ALL_MIGRATIONS[14]).toContain("'unsupported'");
   expect(ALL_MIGRATIONS[15]).toContain("notified_at");
+  expect(ALL_MIGRATIONS[16]).toContain("image_file_id");
 });
 
 it("enqueues Telegram controller turns idempotently and rejects changed replay input", () => {
   const { store } = fixture();
+  const image = {
+    fileId: "telegram-file-id",
+    fileName: "telegram-screenshot.jpg",
+    mimeType: "image/jpeg" as const,
+    sizeBytes: 125_000,
+  };
 
-  const first = store.enqueueControllerTurn(turnInput(101));
+  const first = store.enqueueControllerTurn({ ...turnInput(101), image });
 
   expect(first).toMatchObject({
     controllerKey: "owner-7-controller",
     updateId: 101,
     ordinal: 1,
     inputText: "What can you do?",
+    image,
     state: "queued",
     dispatchAfterSeq: 0,
     retryCount: 0,
@@ -75,8 +83,12 @@ it("enqueues Telegram controller turns idempotently and rejects changed replay i
     telegramMessageId: null,
     streamPhase: "queued",
   });
-  expect(store.enqueueControllerTurn(turnInput(101))).toEqual(first);
+  expect(store.enqueueControllerTurn({ ...turnInput(101), image })).toEqual(first);
   expect(() => store.enqueueControllerTurn(turnInput(101, "different"))).toThrow(IdempotencyConflictError);
+  expect(() => store.enqueueControllerTurn({
+    ...turnInput(101),
+    image: { ...image, fileId: "different-file-id" },
+  })).toThrow(IdempotencyConflictError);
 });
 
 it("claims exactly one FIFO turn while a controller turn is dispatching or submitted", () => {
@@ -98,6 +110,25 @@ it("claims exactly one FIFO turn while a controller turn is dispatching or submi
   expect(store.claimNextControllerTurn(fence)).toBeNull();
   expect(store.completeControllerTurn({ turnId: first.id, ...fence, responseText: "Hello." })).toBe(true);
   expect(store.claimNextControllerTurn(fence)).toMatchObject({ updateId: 202, ordinal: 2 });
+});
+
+it("counts a retryable image preparation failure while returning the turn to the queue", () => {
+  const { store } = fixture();
+  const turn = store.enqueueControllerTurn({
+    ...turnInput(203, "inspect this image"),
+    image: {
+      fileId: "telegram-file-id",
+      fileName: "telegram-screenshot.png",
+      mimeType: "image/png",
+      sizeBytes: null,
+    },
+  });
+  const fence = acquire(store);
+  expect(store.claimNextControllerTurn(fence)?.id).toBe(turn.id);
+
+  expect(store.recordControllerImagePreparationFailure({ ...fence, turnId: turn.id })).toBe(true);
+
+  expect(store.getControllerTurn(turn.id)).toMatchObject({ state: "queued", retryCount: 1 });
 });
 
 it("fences controller mutations against a stale executor generation", () => {

--- a/tests/telegram-client.test.ts
+++ b/tests/telegram-client.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   TelegramClient,
   TelegramConflictError,
+  TelegramFileTooLargeError,
 } from "../src/telegram/client";
 import { classifyTelegramError, TelegramApiError } from "../src/telegram/errors";
 import { abortableSleep } from "../src/async";
@@ -12,6 +13,119 @@ import {
 } from "./helpers";
 
 describe("Telegram Bot API client", () => {
+  it("resolves and downloads a bounded Telegram file without returning a token-bearing URL", async () => {
+    const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (url.endsWith("/getFile")) {
+        return new Response(JSON.stringify({
+          ok: true,
+          result: {
+            file_id: "photo-file-id",
+            file_unique_id: "photo-unique-id",
+            file_size: 4,
+            file_path: "photos/screenshot.jpg",
+          },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response(new Uint8Array([1, 2, 3, 4]), {
+        status: 200,
+        headers: { "content-length": "4", "content-type": "image/jpeg" },
+      });
+    });
+    const client = new TelegramClient("123:secret", fetchMock);
+
+    await expect(client.downloadFile(
+      "photo-file-id",
+      10_000,
+      AbortSignal.timeout(1_000),
+    )).resolves.toEqual(new Uint8Array([1, 2, 3, 4]));
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.url.endsWith("/bot123:secret/getFile")).toBe(true);
+    expect(calls[0]?.init?.body).toBe('{"file_id":"photo-file-id"}');
+    expect(calls[1]).toMatchObject({
+      url: "https://api.telegram.org/file/bot123:secret/photos/screenshot.jpg",
+      init: { method: "GET", redirect: "error", cache: "no-store" },
+    });
+  });
+
+  it("rejects an oversized Telegram file before downloading its bytes", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      ok: true,
+      result: {
+        file_id: "photo-file-id",
+        file_unique_id: "photo-unique-id",
+        file_size: 10_001,
+        file_path: "photos/too-large.jpg",
+      },
+    }), { status: 200, headers: { "content-type": "application/json" } }));
+    const client = new TelegramClient("123:secret", fetchMock);
+
+    await expect(client.downloadFile(
+      "photo-file-id",
+      10_000,
+      AbortSignal.timeout(1_000),
+    )).rejects.toBeInstanceOf(TelegramFileTooLargeError);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("stops a file download when the received bytes cross the size limit", async () => {
+    let call = 0;
+    const fetchMock = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        return new Response(JSON.stringify({
+          ok: true,
+          result: {
+            file_id: "photo-file-id",
+            file_unique_id: "photo-unique-id",
+            file_path: "photos/unknown-size.jpg",
+          },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response(new Uint8Array(10_001), { status: 200 });
+    });
+    const client = new TelegramClient("123:secret", fetchMock);
+
+    await expect(client.downloadFile(
+      "photo-file-id",
+      10_000,
+      AbortSignal.timeout(1_000),
+    )).rejects.toBeInstanceOf(TelegramFileTooLargeError);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("redacts the bot token when the private file download fails", async () => {
+    let call = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      call += 1;
+      if (call === 1) {
+        return new Response(JSON.stringify({
+          ok: true,
+          result: {
+            file_id: "photo-file-id",
+            file_unique_id: "photo-unique-id",
+            file_path: "photos/screenshot.jpg",
+          },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      throw new Error(`network failure for ${String(input)}`);
+    });
+    const client = new TelegramClient("123:secret", fetchMock);
+
+    const error = await client.downloadFile(
+      "photo-file-id",
+      10_000,
+      AbortSignal.timeout(1_000),
+    ).catch((value: unknown) => value);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(String(error)).not.toContain("123:secret");
+    expect(String(error)).toContain("Telegram request failed");
+  });
+
   it("long-polls with an offset and validates the returned update", async () => {
     const fetchMock = telegramFetch([
       { ok: true, result: [{ update_id: 42, message: privateMessage("fix it") }] },

--- a/tests/telegram-ingress.test.ts
+++ b/tests/telegram-ingress.test.ts
@@ -1,6 +1,6 @@
 import { createFakePluginHost } from "@bb/plugin-sdk/testing";
 import type Database from "better-sqlite3";
-import { expect, it } from "vitest";
+import { expect, it, vi } from "vitest";
 import { createHash } from "node:crypto";
 import { hashSecret } from "../src/crypto";
 import type { ProjectPolicy } from "../src/domain/models";
@@ -222,6 +222,102 @@ it("queues authorized standalone text for Luna without creating a software job",
     updateId: 9,
     state: "queued",
     inputText: "What projects can you work on?",
+  }]);
+});
+
+it("durably queues the largest Telegram photo with its caption for Luna", async () => {
+  const onWorkAvailable = vi.fn();
+  const fixture = ingressFixture({
+    owner: { userId: "7", chatId: "70" },
+    onWorkAvailable,
+  });
+
+  await fixture.ingress.handleClaimed(messageUpdate(10, 7, 70, undefined, {
+    caption: "Fix what is overlapping in this screenshot",
+    photo: [
+      {
+        file_id: "small-file-id",
+        file_unique_id: "small-unique-id",
+        width: 90,
+        height: 90,
+        file_size: 1_024,
+      },
+      {
+        file_id: "large-file-id",
+        file_unique_id: "large-unique-id",
+        width: 1_280,
+        height: 960,
+        file_size: 250_000,
+      },
+    ],
+  }), 1_901);
+
+  const controller = fixture.store.getControllerForOwner("7", "70");
+  expect(controller).not.toBeNull();
+  expect(fixture.store.listControllerTurns(controller!.controllerKey, 10)).toMatchObject([{
+    updateId: 10,
+    state: "queued",
+    inputText: "Fix what is overlapping in this screenshot",
+    image: {
+      fileId: "large-file-id",
+      fileName: "telegram-large-unique-id.jpg",
+      mimeType: "image/jpeg",
+      sizeBytes: 250_000,
+    },
+  }]);
+  expect(onWorkAvailable).toHaveBeenCalledOnce();
+});
+
+it("queues a captionless image document with a default inspection prompt", async () => {
+  const fixture = ingressFixture({ owner: { userId: "7", chatId: "70" } });
+
+  await fixture.ingress.handleClaimed(messageUpdate(11, 7, 70, undefined, {
+    document: {
+      file_id: "document-file-id",
+      file_unique_id: "document-unique-id",
+      file_name: "original screenshot.png",
+      mime_type: "image/png",
+      file_size: 125_000,
+    },
+  }), 1_902);
+
+  const controller = fixture.store.getControllerForOwner("7", "70");
+  expect(controller).not.toBeNull();
+  expect(fixture.store.listControllerTurns(controller!.controllerKey, 10)).toMatchObject([{
+    updateId: 11,
+    inputText: "Please inspect this image.",
+    image: {
+      fileId: "document-file-id",
+      fileName: "telegram-document-unique-id.png",
+      mimeType: "image/png",
+      sizeBytes: 125_000,
+    },
+  }]);
+});
+
+it("rejects a known oversized image before queueing controller work", async () => {
+  const onWorkAvailable = vi.fn();
+  const fixture = ingressFixture({
+    owner: { userId: "7", chatId: "70" },
+    onWorkAvailable,
+  });
+
+  await fixture.ingress.handleClaimed(messageUpdate(12, 7, 70, undefined, {
+    caption: "Inspect this",
+    photo: [{
+      file_id: "oversized-file-id",
+      file_unique_id: "oversized-unique-id",
+      width: 2_000,
+      height: 2_000,
+      file_size: 10 * 1024 * 1024 + 1,
+    }],
+  }), 1_903);
+
+  expect(fixture.store.getControllerForOwner("7", "70")).toBeNull();
+  expect(onWorkAvailable).not.toHaveBeenCalled();
+  expect(fixture.telegram.sent).toMatchObject([{
+    chatId: "70",
+    payload: { text: expect.stringContaining("10 MB") },
   }]);
 });
 


### PR DESCRIPTION
## What changed

- accept Telegram photos and supported image documents, with caption-aware and captionless prompts
- download image bytes through Telegram's file API with bounded streaming and safe error handling
- upload bytes to the BB personal project and send agents a `localImage` input
- persist image metadata durably and preserve idempotency across retries
- keep image turns queued behind active answers to avoid misattributed turns
- classify terminal versus retryable pre-submit failures and close spawn-candidate races

## Root cause

Telegram images arrive in `message.photo`/`message.document` with text in `caption`, but ingress only accepted `message.text`. Even if an image reached the controller, the adapter emitted text-only BB prompts.

## Impact

The Telegram controller can now inspect screenshots instead of replying that the image was unavailable. JPEG, PNG, WebP, and GIF inputs are supported up to BB's 10 MB limit.

## Validation

- `npm run check`: 43 files, 731 tests, typecheck, plugin build
- focused ingress/client/controller/store regressions
- independent review: no remaining findings, ready to ship
- live-history lineage: 57 files, 925 tests, typecheck, plugin build