### PR TITLE
fix: give each implementation attempt its own ordinal

### DIFF
--- a/src/controller/tools.ts
+++ b/src/controller/tools.ts
@@ -581,6 +581,15 @@ function jobProjection(job: Job, admission?: { state: string } | null) {
   };
 }
 
+/** Whether the failure brake is holding this job's project, and so its queue. */
+function projectAdmissionIsPaused(
+  store: Pick<TelegramAgentStore, "listPausedProjectAdmissions">,
+  job: Job,
+): boolean {
+  return job.projectId !== null &&
+    store.listPausedProjectAdmissions().some((paused) => paused.projectId === job.projectId);
+}
+
 type JobResolution =
   | { outcome: "job"; job: Job }
   | { outcome: "none" }
@@ -916,6 +925,28 @@ function json(value: unknown): string {
 
 const TERMINAL_JOB_STATES = new Set(["merged", "cancelled", "blocked", "complete", "production_failed"]);
 
+/**
+ * Scheduling observations a retry reports beside the job itself. They describe
+ * the queue rather than the job, so the evidence binding checks them separately
+ * instead of hashing them into the bound projection.
+ */
+const RETRY_SCHEDULING_FLAGS = ["cleaningUp"] as const;
+
+/**
+ * What a retry actually did. A retry that only queues the job leaves it
+ * byte-identical, so without naming the three cases apart the caller cannot
+ * tell work that restarted from work that is waiting from work that nothing
+ * will ever pick up.
+ */
+const RETRY_OUTCOMES = new Set([
+  /** The state machine re-entered the stage during this call. */
+  "resumed",
+  /** Requeued; the executor applies it when the job is next admitted. */
+  "queued",
+  /** Requeued, but the failure brake is holding the project, so the queue is not being served. */
+  "queued_project_paused",
+]);
+
 function recordValue(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -1212,16 +1243,28 @@ function jobProjectionEvidence(
   else if (jobResolution?.outcome === "none" || jobResolution?.outcome === "choose_job") {
     expectedDomain = resolutionProjection(jobResolution);
   }
-  // Resuming a blocked plan or review reports whether the previous attempt is
-  // still cleaning up. That flag is a scheduling observation on top of the
-  // bound projection, so it is compared separately rather than hashed with it.
-  const cleaningUp = mutation === "retry" ? domain.cleaningUp : undefined;
-  if (cleaningUp !== undefined && typeof cleaningUp !== "boolean") {
-    throw new Error("job projection carries a non-boolean cleaningUp flag");
+  // Retrying reports scheduling observations alongside the job: whether the
+  // previous attempt is still cleaning up, whether the state machine actually
+  // resumed, and whether the failure brake is holding the project. These sit on
+  // top of the bound projection, so they are checked separately rather than
+  // hashed with it.
+  const schedulingKeys = new Set<string>();
+  if (mutation === "retry") {
+    for (const key of RETRY_SCHEDULING_FLAGS) {
+      if (domain[key] === undefined) continue;
+      if (typeof domain[key] !== "boolean") throw new Error(`job projection carries a non-boolean ${key} flag`);
+      schedulingKeys.add(key);
+    }
+    if (domain.retryOutcome !== undefined) {
+      if (typeof domain.retryOutcome !== "string" || !RETRY_OUTCOMES.has(domain.retryOutcome)) {
+        throw new Error("job projection carries an unknown retryOutcome");
+      }
+      schedulingKeys.add("retryOutcome");
+    }
   }
-  const boundDomain = cleaningUp === undefined
+  const boundDomain = schedulingKeys.size === 0
     ? domain
-    : Object.fromEntries(Object.entries(domain).filter(([key]) => key !== "cleaningUp"));
+    : Object.fromEntries(Object.entries(domain).filter(([key]) => !schedulingKeys.has(key)));
   if (expectedDomain === null || sha256ControllerJson(expectedDomain) !== sha256ControllerJson(boundDomain)) {
     throw new Error("job projection is not bound to the authorized resolution");
   }
@@ -1636,7 +1679,7 @@ export function registerControllerTools(bb: BbPluginApi, dependencies: ToolDepen
 
   registerTool({
     name: CONTROLLER_TOOL_NAMES[3],
-    description: "Resume a recoverable Telegram Agent job: retry a failed or stuck step, continue a blocked plan or review, finish a reviewed PR when production is not configured, or pick up from review when a PR already exists.",
+    description: "Resume a recoverable Telegram Agent job: retry a failed or stuck step, continue a blocked plan or review, finish a reviewed PR when production is not configured, or pick up from review when a PR already exists. Read `retryOutcome` before answering and say which happened: `resumed` restarted the job now, `queued` restarts it when the job is next admitted, and `queued_project_paused` will not restart at all until the project's failure brake is lifted. A queued retry deliberately leaves the job unchanged, so never read an unchanged job as the retry having failed.",
     parameters: z.object({ jobId: z.string().min(1).max(256).optional() }).strict(),
     execute: (_params, context, resolution) => {
       authorizedController(dependencies.store, context);
@@ -1669,7 +1712,17 @@ export function registerControllerTools(bb: BbPluginApi, dependencies: ToolDepen
         throw new Error("The requested job is not retryable");
       }
       dependencies.notify();
-      return jobProjection(retryResult.job, retryResult.admission);
+      // A retry that only requeues admission leaves the job byte-identical, so
+      // the caller has no way to read what happened out of the job itself. Name
+      // the case instead of leaving it to be inferred from an unchanged row.
+      return {
+        ...jobProjection(retryResult.job, retryResult.admission),
+        retryOutcome: retryResult.outcome === "retried"
+          ? "resumed"
+          : projectAdmissionIsPaused(dependencies.store, retryResult.job)
+            ? "queued_project_paused"
+            : "queued",
+      };
     },
   });
 

--- a/src/services/effect-runner.ts
+++ b/src/services/effect-runner.ts
@@ -252,7 +252,7 @@ const KNOWN_EFFECT_KINDS = new Set<string>([
 
 function attemptFor(effect: StoredEffect, job: Job, kind: AttemptRecord["kind"]): {
   id: string;
-  ordinal: number;
+  ordinal: number | "next";
   headSha: string | null;
 } {
   const payload = recordPayload(effect);
@@ -260,7 +260,11 @@ function attemptFor(effect: StoredEffect, job: Job, kind: AttemptRecord["kind"])
   const id = typeof suppliedId === "string" && suppliedId.length > 0
     ? suppliedId
     : `attempt:${effect.idempotencyKey}`;
-  const ordinal = kind === "review" ? Math.max(1, job.reviewCycle + 1) : 1;
+  // A review ordinal is the review cycle, which sibling lenses share. Every
+  // other kind is a plain sequence the store allocates, because each recovery
+  // requeues the stage under a new effect key and so needs a new ordinal; a
+  // constant here silently collided with the attempt the dead worker left.
+  const ordinal = kind === "review" ? Math.max(1, job.reviewCycle + 1) : "next";
   const headSha = fullSha(payload.headSha) ? payload.headSha : job.prHeadSha;
   return { id, ordinal, headSha };
 }
@@ -905,12 +909,11 @@ export class EffectRunner {
       ...(reviewAttemptId ? { id: reviewAttemptId } : {}),
       ...(reviewOrdinal ? { ordinal: reviewOrdinal } : {}),
     };
-    const existingAttempt = this.dependencies.store.getAttempt(attemptInput.id);
     const attempt = this.dependencies.store.createExecutorAttempt({
       id: attemptInput.id,
       jobId: job.id,
       kind,
-      ordinal: existingAttempt?.ordinal ?? attemptInput.ordinal,
+      ordinal: attemptInput.ordinal,
       headSha: attemptInput.headSha,
       reviewLens: kind === "review" ? reviewLens : null,
       reviewStage: kind === "review" ? (finalReview ? "final_review" : "review") : null,

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -637,7 +637,14 @@ export type ExecutorAttemptInput = ExecutorFence & Readonly<{
   id: string;
   jobId: string;
   kind: AttemptRecord["kind"];
-  ordinal: number;
+  /**
+   * `"next"` allocates the next free ordinal for this job and kind inside the
+   * insert's own transaction. Review attempts pass a number because their
+   * ordinal is the review cycle and sibling lenses deliberately share it;
+   * implementation attempts have no such meaning to carry, so they must not
+   * pick a number outside the transaction that enforces its uniqueness.
+   */
+  ordinal: number | "next";
   headSha?: string | null;
   reviewLens?: AttemptRecord["reviewLens"];
   reviewStage?: AttemptRecord["reviewStage"];
@@ -11369,7 +11376,7 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
   public createExecutorAttempt(input: ExecutorAttemptInput): AttemptRecord | null {
     this.assertExecutorFence(input);
     if (!input.id || !input.jobId) throw new TypeError("attempt identity is required");
-    if (!Number.isInteger(input.ordinal) || input.ordinal < 1) {
+    if (input.ordinal !== "next" && (!Number.isInteger(input.ordinal) || input.ordinal < 1)) {
       throw new TypeError("attempt ordinal must be a positive integer");
     }
     if (input.headSha !== undefined && input.headSha !== null) assertFullSha(input.headSha, "headSha");
@@ -11382,6 +11389,11 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
       : null;
     const create = this.db.transaction((): AttemptRecord | null => {
       if (!this.executorLeaseIsCurrent(input.ownerId, input.generation, input.now)) return null;
+      // Replaying one effect must reuse its own row rather than claim a second
+      // ordinal, so an existing id settles the ordinal before allocation does.
+      const replayed = this.getAttempt(input.id);
+      const ordinal = replayed?.ordinal
+        ?? (input.ordinal === "next" ? this.nextAttemptOrdinal(input.jobId, input.kind) : input.ordinal);
       this.db
         .prepare(
           `INSERT OR IGNORE INTO attempts (
@@ -11394,17 +11406,21 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
           input.kind,
           reviewLens,
           reviewStage,
-          input.ordinal,
+          ordinal,
           input.headSha ?? null,
           input.now,
         );
       const stored = this.getAttempt(input.id);
-      if (!stored) throw new Error("Attempt was not stored");
+      // The insert is ignored when another row already holds this ordinal, so a
+      // missing row means a conflicting attempt owns it. That can never be
+      // resolved by trying again: report it as the permanent conflict it is
+      // rather than as a transient failure worth twenty more minutes of retries.
+      if (!stored) throw new IdempotencyConflictError(ordinal);
       if (
-        stored.jobId !== input.jobId || stored.kind !== input.kind || stored.ordinal !== input.ordinal ||
+        stored.jobId !== input.jobId || stored.kind !== input.kind || stored.ordinal !== ordinal ||
         stored.reviewLens !== reviewLens || stored.reviewStage !== reviewStage
       ) {
-        throw new IdempotencyConflictError(input.ordinal);
+        throw new IdempotencyConflictError(ordinal);
       }
       return stored;
     });

--- a/tests/controller-tools.test.ts
+++ b/tests/controller-tools.test.ts
@@ -285,7 +285,10 @@ it("preserves the exact Task 6 metadata and adds the bounded evidence-index sche
   // watch now distinguishes tool-created watches from evidence-backed CLI work.
   // Re-pinned again when send_to_thread gained the required `ask`: the owner
   // cannot see the threads, so messaging one now carries the line he is told.
-  expect(digest).toBe("82ba814cc6a30b0b338a7f02df6793cf40e21e3cfbf06e7a218583a0be937eee");
+  // Re-pinned again when retry_job began reporting `retryOutcome`: a queued
+  // retry leaves the job unchanged, so the description now tells the agent to
+  // read the outcome rather than read an unchanged job as a failed retry.
+  expect(digest).toBe("0f5e560ddd7a1a65ef70cb16f5341a41173eb53317e7bdf5222e5a9958bd7d18");
   expect(metadata[21]).toEqual({
     name: "telegram_agent_turn_evidence",
     description: "List bounded evidence for the current authorized controller turn after reconciling BB-native work.",
@@ -2736,4 +2739,107 @@ it("retries a blocked plan and cancels a blocked job from the controller", async
     controllerToolContext,
   )) as { job: { state: string; cancelRequested: boolean } };
   expect(cancelled.job.cancelRequested).toBe(true);
+});
+
+it("tells the controller a retry is parked behind the failure brake, not resumed", async () => {
+  const { bb, harness, store } = fixture({ active: true });
+  registerControllerTools(bb, {
+    store,
+    sdk: bb.sdk,
+    threadOperations: { request: vi.fn() },
+    health: () => ({ ok: true }),
+    notify: vi.fn(),
+    now: () => 10_300,
+  });
+  const created = parseToolJson(await harness.behavior.callAgentTool(
+    "telegram_agent_start_job",
+    { projectId: "proj_1", task: "finish the adopted pull request" },
+    controllerToolContext,
+  )) as { job: { id: string } };
+  const db = bb.storage.database();
+  db.prepare(
+    `UPDATE jobs SET state = 'blocked', blocked_reason = 'permanent_effect_failure',
+       resume_state = 'creating_implementation', last_error = 'spawn_implementation gave up' WHERE id = ?`,
+  ).run(created.job.id);
+  db.prepare("UPDATE job_admissions SET state = 'released', released_at = ?, release_reason = 'blocked' WHERE job_id = ?")
+    .run(10_250, created.job.id);
+  expect(store.pauseProjectAdmission({
+    projectId: "proj_1",
+    reason: "four jobs failed the same way",
+    fingerprint: "proj_1:permanent_effect_failure",
+    now: 10_260,
+  })).toBe(true);
+  const before = store.getJob(created.job.id)!;
+
+  const retried = parseToolJson(await harness.behavior.callAgentTool(
+    "telegram_agent_retry_job",
+    { jobId: created.job.id },
+    controllerToolContext,
+  )) as { job: { state: string; updatedAt: number }; retryOutcome: string };
+
+  // The job is deliberately untouched here, which is exactly why the caller has
+  // to be told the difference between "resumed" and "queued behind a brake".
+  expect(retried.job).toMatchObject({ state: before.state, updatedAt: before.updatedAt });
+  expect(retried.retryOutcome).toBe("queued_project_paused");
+  expect(store.getAdmission(created.job.id)?.resumeEvent).toBe("RETRY");
+});
+
+it("distinguishes a retry merely queued from one held by the failure brake", async () => {
+  const { bb, harness, store } = fixture({ active: true });
+  registerControllerTools(bb, {
+    store,
+    sdk: bb.sdk,
+    threadOperations: { request: vi.fn() },
+    health: () => ({ ok: true }),
+    notify: vi.fn(),
+    now: () => 10_300,
+  });
+  const created = parseToolJson(await harness.behavior.callAgentTool(
+    "telegram_agent_start_job",
+    { projectId: "proj_1", task: "finish the adopted pull request" },
+    controllerToolContext,
+  )) as { job: { id: string } };
+  const db = bb.storage.database();
+  db.prepare(
+    `UPDATE jobs SET state = 'blocked', blocked_reason = 'permanent_effect_failure',
+       resume_state = 'creating_implementation', last_error = 'Attempt was not stored' WHERE id = ?`,
+  ).run(created.job.id);
+  db.prepare("UPDATE job_admissions SET state = 'released', released_at = ?, release_reason = 'blocked' WHERE job_id = ?")
+    .run(10_250, created.job.id);
+
+  const retried = parseToolJson(await harness.behavior.callAgentTool(
+    "telegram_agent_retry_job",
+    { jobId: created.job.id },
+    controllerToolContext,
+  )) as { retryOutcome: string };
+
+  // No brake here, so this retry is genuinely waiting its turn rather than
+  // parked forever. Reporting it as paused would send the owner after a brake
+  // that does not exist.
+  expect(retried.retryOutcome).toBe("queued");
+  expect(store.getAdmission(created.job.id)?.resumeEvent).toBe("RETRY");
+});
+
+it("reports a retry the state machine actually applied as resumed", async () => {
+  const { bb, harness, store, activate, deactivate } = fixture({ active: true });
+  deactivate();
+  queueControllerCandidate(store, "job_resumed_retry", "proj_resumed", "failed");
+  activate();
+  registerControllerTools(bb, {
+    store,
+    sdk: bb.sdk,
+    threadOperations: { request: vi.fn() },
+    health: () => ({ ok: true }),
+    notify: vi.fn(),
+    now: () => 10_300,
+  });
+
+  const retried = parseToolJson(await harness.behavior.callAgentTool(
+    "telegram_agent_retry_job",
+    { jobId: "job_resumed_retry" },
+    controllerToolContext,
+  )) as { job: { state: string }; retryOutcome: string };
+
+  expect(retried.retryOutcome).toBe("resumed");
+  expect(retried.job.state).not.toBe("failed");
 });

--- a/tests/effect-runner.test.ts
+++ b/tests/effect-runner.test.ts
@@ -196,6 +196,98 @@ describe("leased effect execution", () => {
       candidate.kind === "spawn_implementation" && candidate.status === "pending")).toBe(true);
   });
 
+  it("spawns a replacement implementation after a worker recovery requeues the stage", async () => {
+    // Every spawn_implementation effect carries a fresh idempotency key, so the
+    // attempt it creates has a fresh id. The second spawn must still be storable:
+    // a job whose first worker died can only be rebuilt by a second attempt.
+    const { store, db } = storeFixture();
+    const job = selectedJobForRecovery(store, db, "job_respawn", "creating_implementation");
+    if (!job) throw new Error("job missing");
+    const lease = store.acquireExecutorLease("owner-a", 1_001, 30_000);
+    if (!lease.acquired) throw new Error("lease missing");
+    addProductionAdmissionAndClaims(db, job.id, policyFixture(), "owner-a", lease.generation, 1_001, 31_000);
+    const fenceFor = (now: number) => ({
+      store,
+      fence: { ownerId: "owner-a", generation: lease.generation, signal: new AbortController().signal },
+      now: () => now,
+    });
+    const spawnImplementation = vi.fn(async () => ({ id: "thr_first", environmentId: "env_1" }));
+    const runSpawn = async (idempotencyKey: string, now: number): Promise<void> => {
+      const claimed = leaseEffectsForTest(store, "owner-a", lease.generation, now, 10, 30_000)
+        .find((candidate) => candidate.idempotencyKey === idempotencyKey);
+      if (!claimed) throw new Error(`spawn effect ${idempotencyKey} missing`);
+      await new EffectRunner({ ...fenceFor(now), bb: { spawnImplementation } }).run(claimed);
+    };
+
+    addPendingEffectForRecovery(db, {
+      idempotencyKey: `${job.id}:2:spawn_implementation`,
+      jobId: job.id,
+      kind: "spawn_implementation",
+      payload: {},
+    });
+    await runSpawn(`${job.id}:2:spawn_implementation`, 1_002);
+    expect(store.getJob(job.id)).toMatchObject({ state: "implementing", implementationThreadId: "thr_first" });
+
+    // The worker dies silently. Recovery clears the thread and requeues the
+    // stage under a new effect key, exactly as `transitionRecoveringWorker` does.
+    const implementing = store.getJob(job.id)!;
+    store.registerExecutorWorkerRecovery({
+      id: "recovery_respawn",
+      jobId: job.id,
+      expectedVersion: implementing.version,
+      projectId: "proj_1",
+      jobState: "implementing",
+      workerKind: "implementation",
+      resourceId: "thr_first",
+      workerGeneration: 7,
+      classification: "no_progress",
+      signature: "no_progress:implementation:active",
+      retryLimit: 2,
+      ownerId: "owner-a",
+      generation: lease.generation,
+      now: 1_003,
+    });
+    const recovering = store.applyExecutorJobEvent({
+      jobId: job.id,
+      expectedVersion: implementing.version,
+      event: {
+        type: "WORKER_RECOVERY_REQUESTED",
+        recoveryId: "recovery_respawn",
+        workerKind: "implementation",
+        resourceId: "thr_first",
+        classification: "no_progress",
+        signature: "no_progress:implementation:active",
+      },
+      ownerId: "owner-a",
+      generation: lease.generation,
+      now: 1_004,
+    });
+    expect(recovering?.state).toBe("recovering_worker");
+    db.prepare("UPDATE effects SET status = 'done' WHERE job_id = ? AND kind <> 'recover_worker'").run(job.id);
+    const recoverEffect = store.leaseNextJobEffect({
+      jobId: job.id,
+      ownerId: "owner-a",
+      generation: lease.generation,
+      now: 1_005,
+      leaseMs: 30_000,
+    });
+    if (!recoverEffect || recoverEffect.kind !== "recover_worker") throw new Error("recovery effect missing");
+    await new EffectRunner({ ...fenceFor(1_006), bb: { retireWorker: vi.fn(async () => undefined) } })
+      .run(recoverEffect);
+    const requeued = store.listEffectsForJob(job.id)
+      .find((candidate) => candidate.kind === "spawn_implementation" && candidate.status === "pending");
+    if (!requeued) throw new Error("requeued spawn effect missing");
+
+    spawnImplementation.mockResolvedValue({ id: "thr_second", environmentId: "env_1" });
+    await runSpawn(requeued.idempotencyKey, 1_007);
+
+    expect(store.getJob(job.id)).toMatchObject({ state: "implementing", implementationThreadId: "thr_second" });
+    const ordinals = db
+      .prepare("SELECT ordinal FROM attempts WHERE job_id = ? AND kind = 'implementation' ORDER BY ordinal")
+      .all(job.id) as { ordinal: number }[];
+    expect(ordinals.map((row) => row.ordinal)).toEqual([1, 2]);
+  });
+
   it("recovers an ordinary implementation thread by the centralized title bytes", async () => {
     const { store, db } = storeFixture();
     const job = selectedJobForRecovery(store, db, "job_ordinary_recovery", "creating_implementation");

--- a/tests/effect-runner.test.ts
+++ b/tests/effect-runner.test.ts
@@ -1743,3 +1743,81 @@ describe("late managed worktree", () => {
     });
   });
 });
+
+describe("recovering the jobs this bug already blocked", () => {
+  it("carries a blocked permanent_effect_failure job back through a plain retry", async () => {
+    // The exact shape the four dead adopted-PR jobs are in: blocked on a
+    // dead-lettered spawn_implementation, admission released, and the first
+    // attempt still holding ordinal 1. Nothing here is repaired by hand.
+    const { store, db } = storeFixture();
+    const job = selectedJobForRecovery(store, db, "job_blocked_recovery", "creating_implementation");
+    if (!job) throw new Error("job missing");
+    const lease = store.acquireExecutorLease("owner-a", 1_001, 30_000);
+    if (!lease.acquired) throw new Error("lease missing");
+    addProductionAdmissionAndClaims(db, job.id, policyFixture(), "owner-a", lease.generation, 1_001, 31_000);
+    const spawnImplementation = vi.fn(async () => ({ id: "thr_first", environmentId: "env_1" }));
+    const runSpawn = async (idempotencyKey: string, now: number): Promise<void> => {
+      const claimed = leaseEffectsForTest(store, "owner-a", lease.generation, now, 10, 30_000)
+        .find((candidate) => candidate.idempotencyKey === idempotencyKey);
+      if (!claimed) throw new Error(`spawn effect ${idempotencyKey} missing`);
+      await new EffectRunner({
+        store,
+        fence: { ownerId: "owner-a", generation: lease.generation, signal: new AbortController().signal },
+        bb: { spawnImplementation },
+        now: () => now,
+      }).run(claimed);
+    };
+    addPendingEffectForRecovery(db, {
+      idempotencyKey: `${job.id}:2:spawn_implementation`,
+      jobId: job.id,
+      kind: "spawn_implementation",
+      payload: {},
+    });
+    await runSpawn(`${job.id}:2:spawn_implementation`, 1_002);
+    expect(store.getJob(job.id)?.implementationThreadId).toBe("thr_first");
+
+    db.prepare(
+      `UPDATE jobs SET state = 'blocked', blocked_reason = 'permanent_effect_failure',
+         resume_state = 'creating_implementation', implementation_thread_id = NULL,
+         last_error = 'Attempt was not stored', version = version + 1 WHERE id = ?`,
+    ).run(job.id);
+    db.prepare("UPDATE effects SET status = 'dead' WHERE job_id = ?").run(job.id);
+    db.prepare("UPDATE job_admissions SET state = 'released', released_at = ?, release_reason = 'blocked' WHERE job_id = ?")
+      .run(1_003, job.id);
+    // Releasing an admission releases the job's resource claims with it; without
+    // that the project still reads as busy and nothing could ever be readmitted.
+    db.prepare("UPDATE job_resource_claims SET state = 'released', released_at = ? WHERE job_id = ?")
+      .run(1_003, job.id);
+    const blocked = store.getJob(job.id)!;
+
+    // Step one: the owner's retry. It queues rather than transitions, which is
+    // why the job looks untouched at this point.
+    const queued = store.retryFailedJob(blocked.id, blocked.version, 1_004);
+    expect(queued.outcome).toBe("queued");
+    expect(store.getJob(job.id)).toMatchObject({ state: "blocked", updatedAt: blocked.updatedAt });
+
+    // Step two: the scheduler admits it and the RETRY lands.
+    expect(store.tryAdmit({
+      jobId: job.id,
+      maxConcurrentJobs: 8,
+      ownerId: "owner-a",
+      generation: lease.generation,
+      now: 1_005,
+      leaseMs: 30_000,
+    }).outcome).toBe("admitted");
+    expect(store.getJob(job.id)).toMatchObject({ state: "creating_implementation", blockedReason: null });
+
+    // Step three: the requeued stage spawns, which is the step that used to die.
+    const requeued = store.listEffectsForJob(job.id)
+      .find((candidate) => candidate.kind === "spawn_implementation" && candidate.status === "pending");
+    if (!requeued) throw new Error("retry did not requeue the implementation stage");
+    spawnImplementation.mockResolvedValue({ id: "thr_second", environmentId: "env_1" });
+    await runSpawn(requeued.idempotencyKey, 1_006);
+
+    expect(store.getJob(job.id)).toMatchObject({ state: "implementing", implementationThreadId: "thr_second" });
+    const ordinals = db
+      .prepare("SELECT ordinal FROM attempts WHERE job_id = ? AND kind = 'implementation' ORDER BY ordinal")
+      .all(job.id) as { ordinal: number }[];
+    expect(ordinals.map((row) => row.ordinal)).toEqual([1, 2]);
+  });
+});


### PR DESCRIPTION
Every adopted-PR job died at the same step: blocked, `permanent_effect_failure`, `Attempt was not stored`, after twenty retries of `spawn_implementation`. Four for four, including one PR that was cancelled and re-adopted twice and died the same way each time.

## What was wrong

Attempts are numbered per job. Implementation attempts were handed the constant `1` instead of counting up.

That was harmless until a worker stalled. Recovering a stalled worker clears the thread and requeues the implementation stage, which emits a fresh `spawn_implementation` effect under a new idempotency key, and so a fresh attempt id. The ordinal stayed `1`, so the replacement attempt collided with the attempt the dead worker had left behind on the unique `(job_id, kind, ordinal)` index. `INSERT OR IGNORE` dropped the row without a word, and the read that followed found nothing.

The error raised there was a plain `Error`, which the executor treats as transient. So a collision that could never come good was retried twenty times across the next nine to twenty-five minutes before the effect was dead-lettered and the job blocked.

A job could survive its first worker. It could never survive its second. A freshly adopted PR worked right up until its first worker recovery, which is why re-adopting looked like a fix and then wasn't.

## What changed

Non-review attempt ordinals are now allocated by the store inside the same transaction that inserts the row, so a replayed effect reuses its own row and a genuinely new one takes the next number. Review ordinals are untouched: theirs is the review cycle, and sibling lenses share it deliberately.

A collision that somehow survives that is now reported as the permanent conflict it is, rather than as a transient failure worth another twenty minutes.

Retrying also now says which of three things it did, because a retry that only requeues leaves the job byte-identical and could not be told apart from a retry that did nothing:

| `retryOutcome` | Meaning |
|---|---|
| `resumed` | The job restarted during the call. |
| `queued` | It restarts when the job is next admitted. |
| `queued_project_paused` | It will not restart until the project's failure brake is lifted. |

## Two corrections to the earlier diagnosis

There was no half-written or orphaned attempt row, and nothing needs clearing. The first attempt is a complete, legitimate record of a real worker. Deleting it, as first proposed, would have destroyed that history without fixing the collision.

Retry was never a silent no-op. It was requeuing the job honestly. Four identical failures in one project trip the failure brake, which pauses the project, so the queue it joined was not being served. Real work, invisible from outside. That is what the new `retryOutcome` exists to say out loud.

## What to do with the jobs already blocked

**Retry them. Nothing needs re-queuing by hand and nothing needs editing in the database.**

`tests/effect-runner.test.ts` walks a job through the exact shape these are in — blocked on a dead-lettered `spawn_implementation`, admission released, ordinal 1 still taken — and through retry, admission, and the requeued spawn, reaching `implementing` on a second attempt at ordinal 2. Run against the code before this change it fails on the same `Attempt was not stored`, so it is a regression test for the fix rather than a description of it.

This applies to the two jobs blocked on `Attempt was not stored`. The project is not currently paused, so retry will report `queued` and the scheduler picks it up; an unchanged job at that moment is expected, not a failure.

## Not in scope

PR 895 is a different failure and this branch does not touch it. Its error is now `Active job has no implementation thread`, having earlier been `BB environment observation is unavailable`. That string is raised when a review spawn or a remediation send needs the implementation thread and finds it null, which is a state worker recovery also produces — a lead worth pulling, not a claim. It fails fast rather than spinning, which matches it failing again within seconds of a clean retry. Left alone deliberately to keep this change narrow.

## Review notes

Based on `trunk`, not `main`; `main` is 325 commits behind and does not contain the adopted-PR path at all. Rebased onto the pushed `trunk` so this contains only its own three commits.
