### PR TITLE
Stop a dead schedule from failing in silence

### DIFF
--- a/src/controller/tools.ts
+++ b/src/controller/tools.ts
@@ -718,12 +718,59 @@ function monitorProjection(monitor: MonitorRecord) {
     cron: monitor.cron,
     instruction: monitor.instruction,
     state: monitor.state,
+    // Why a monitor stopped, so a dead schedule reads as dead rather than as
+    // one that has simply not come round yet.
+    lastError: monitor.lastError,
     // A thread watch carries a due time only as its settling window, which is
     // plumbing rather than a schedule. Reporting it as a next-due time would
     // read as "this fires then", which is exactly what a thread watch does not do.
     nextDueAt: monitor.kind === "schedule" ? monitor.dueAt : null,
     fireCount: monitor.fireCount,
   };
+}
+
+/**
+ * A monitor's instruction is a paragraph the agent wrote to itself, and this
+ * result has a hard byte limit. Sixty-odd of them overran it, and an overrun
+ * fails the whole call — so asking to see finished monitors, the only way to
+ * find a schedule that had died, returned nothing at all.
+ *
+ * Rows are packed newest-first within a budget, with anything still armed or
+ * failed placed first and given room for its full instruction; settled history
+ * keeps a recognisable opening. At least one row always survives, and whatever
+ * did not fit is counted rather than quietly dropped.
+ */
+const MONITOR_LIST_BUDGET_BYTES = 6_000;
+const LIVE_INSTRUCTION_CHARS = 400;
+const SETTLED_INSTRUCTION_CHARS = 120;
+
+function needsAttention(monitor: MonitorRecord): boolean {
+  return monitor.state === "armed" || monitor.state === "failed";
+}
+
+function clipInstruction(text: string, limit: number): string {
+  return text.length <= limit ? text : `${text.slice(0, limit).trimEnd()}…`;
+}
+
+function packMonitorList(monitors: MonitorRecord[]) {
+  const ordered = [...monitors].sort((left, right) =>
+    Number(needsAttention(right)) - Number(needsAttention(left)) || right.createdAt - left.createdAt);
+  const packed: ReturnType<typeof monitorProjection>[] = [];
+  let bytes = 0;
+  for (const monitor of ordered) {
+    const row = {
+      ...monitorProjection(monitor),
+      instruction: clipInstruction(
+        monitor.instruction,
+        needsAttention(monitor) ? LIVE_INSTRUCTION_CHARS : SETTLED_INSTRUCTION_CHARS,
+      ),
+    };
+    const size = Buffer.byteLength(JSON.stringify(row), "utf8");
+    if (packed.length > 0 && bytes + size > MONITOR_LIST_BUDGET_BYTES) break;
+    packed.push(row);
+    bytes += size;
+  }
+  return { monitors: packed, omitted: ordered.length - packed.length };
 }
 
 /**
@@ -2211,11 +2258,7 @@ export function registerControllerTools(bb: BbPluginApi, dependencies: ToolDepen
     parameters: z.object({ includeFinished: z.boolean().default(false) }).strict(),
     execute: (params, context) => {
       const controller = authorizedController(dependencies.store, context);
-      return {
-        monitors: dependencies.store
-          .listMonitors(controller.controllerKey, params.includeFinished)
-          .map(monitorProjection),
-      };
+      return packMonitorList(dependencies.store.listMonitors(controller.controllerKey, params.includeFinished));
     },
   });
 

--- a/src/services/monitor-service.ts
+++ b/src/services/monitor-service.ts
@@ -75,10 +75,17 @@ const MONITOR_CLOCK_EPOCH_MS = 1_700_000_000_000;
 const CAPABILITY_NOTICE_POLICY =
   "For capability routing, notify only for a denial, material escalation, substitute use, exhausted recovery, missing mandatory evidence, or an owner decision.";
 
-function firedPrompt(monitor: MonitorRecord, reason: string): string {
-  const cleanup = monitor.kind === "schedule"
-    ? "\nThis schedule repeats. Cancel it now if its purpose is complete, obsolete, or polling live work; use a thread_idle monitor for live work instead.\n"
-    : "";
+/**
+ * `stopped` marks a schedule's final firing. The wake-up still carries the
+ * instruction, but the agent is told the schedule is over, so it reports that
+ * rather than leaving the owner waiting on a run that will never come.
+ */
+function firedPrompt(monitor: MonitorRecord, reason: string, stopped: boolean): string {
+  const cleanup = monitor.kind !== "schedule"
+    ? ""
+    : stopped
+      ? `\nThis is this schedule's last firing. Its next run time could not be worked out from \`${monitor.cron}\`, so it is now marked failed and will not fire again. Do the work below, then tell the owner the schedule stopped, and arm a fresh one if it still matters.\n`
+      : "\nThis schedule repeats. Cancel it now if its purpose is complete, obsolete, or polling live work; use a thread_idle monitor for live work instead.\n";
   return `A monitor you set has fired.\n\nMonitor id: ${monitor.id}\nMonitor kind: ${monitor.kind}\n` +
     `Why: ${reason}\nWhat you said to do: ${monitor.instruction}\n${cleanup}\n` +
     `Do it now. ${CAPABILITY_NOTICE_POLICY} Message the owner only if something needs their decision or a job finished or failed. If nothing meaningful changed, stay silent.`;
@@ -402,18 +409,24 @@ export class MonitorService {
     const nextDueAt = monitor.kind === "schedule" && monitor.cron
       ? nextCronOccurrence(monitor.cron, now)
       : null;
-    if (monitor.kind === "schedule" && nextDueAt === null) {
-      this.dependencies.store.failMonitor({ id: monitor.id, error: "Schedule could not be advanced", now });
-      return false;
-    }
+    // A schedule whose next run cannot be worked out is over — but it is over
+    // *now*, at the moment it was due. Failing it without firing swallowed the
+    // one wake-up the owner was waiting on: the work never ran, and nothing
+    // said so, so from the outside the schedule simply stopped existing. Mark
+    // it failed first, because that is what stops the replay, then still
+    // deliver its last firing.
+    const stopped = monitor.kind === "schedule" && nextDueAt === null;
     // Claiming the monitor first means a crash mid-fire cannot replay it.
-    if (!this.dependencies.store.recordMonitorFired({ id: monitor.id, nextDueAt, now })) return false;
+    const claimed = stopped
+      ? this.dependencies.store.failMonitor({ id: monitor.id, error: "Schedule could not be advanced", now })
+      : this.dependencies.store.recordMonitorFired({ id: monitor.id, nextDueAt, now });
+    if (!claimed) return false;
     this.dependencies.store.enqueueControllerTurn({
       controllerKey: monitor.controllerKey,
       telegramUserId: owner.userId,
       telegramChatId: owner.chatId,
       updateId: this.issueUpdateId(now),
-      inputText: firedPrompt(monitor, reason),
+      inputText: firedPrompt(monitor, reason, stopped),
       origin: "system",
       now,
     });

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -9831,11 +9831,18 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
     }).immediate();
   }
 
+  /**
+   * A failed monitor shows in the default view alongside the armed ones. It is
+   * the state that most needs acting on and the one the owner cannot see any
+   * other way: filtering it out left a dead schedule visible only behind
+   * `includeFinished`, which is the same view that carries every settled
+   * monitor ever created.
+   */
   public listMonitors(controllerKey: string, includeFinished: boolean): MonitorRecord[] {
     assertControllerKey(controllerKey);
     const rows = this.db.prepare(
       `SELECT * FROM monitors
-        WHERE controller_key = ? AND system_key IS NULL AND (? = 1 OR state = 'armed')
+        WHERE controller_key = ? AND system_key IS NULL AND (? = 1 OR state IN ('armed', 'failed'))
         ORDER BY created_at DESC LIMIT ?`,
     ).all(controllerKey, includeFinished ? 1 : 0, MAX_ARMED_MONITORS * 4) as MonitorRow[];
     return rows.map(parseMonitor);
@@ -9860,9 +9867,12 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
   public cancelControllerMonitor(controllerKey: string, id: string, now: number): boolean {
     assertControllerKey(controllerKey);
     assertNonNegativeInteger(now, "now");
+    // Cancelling a failed monitor is how a dead schedule is cleared from the
+    // list once it has been dealt with. Without it the only way to stop seeing
+    // one was to stop being able to see it at all.
     return this.db.prepare(
       `UPDATE monitors SET state = 'cancelled', updated_at = ?
-        WHERE controller_key = ? AND id = ? AND system_key IS NULL AND state = 'armed'`,
+        WHERE controller_key = ? AND id = ? AND system_key IS NULL AND state IN ('armed', 'failed')`,
     ).run(now, controllerKey, id).changes === 1;
   }
 

--- a/tests/controller-capability-executor.test.ts
+++ b/tests/controller-capability-executor.test.ts
@@ -1225,3 +1225,34 @@ it("projects the remaining memory, monitor, health, scorecard, and style rows fr
   const sameStyle = await call("telegram_agent_set_working_style", { text: "Lead with the result." });
   expect(sameStyle._hanoonEvidence).toMatchObject({ outcome: "observed", proofKinds: ["memory_state"] });
 });
+
+it("keeps a long monitor list inside its result limit instead of failing the whole call", async () => {
+  const fixture = registeredControllerFixture();
+  // Monitor instructions are paragraphs the agent wrote to itself. Enough of
+  // them overran the result limit, and an overrun failed the call outright, so
+  // the view that would show a dead schedule was the one that never loaded.
+  const context = "Context the agent left for itself so the next turn knows what this was for. ".repeat(10);
+  for (let index = 0; index < 19; index += 1) {
+    fixture.store.createMonitor({
+      controllerKey: fixture.turn.controllerKey,
+      kind: "schedule",
+      cron: "0 9 * * 1-5",
+      instruction: `Sweep ${index}. ${context}`,
+      dueAt: 2_000 + index,
+      now: 2_000 + index,
+    });
+  }
+
+  const listed = JSON.parse(await fixture.harness.behavior.callAgentTool(
+    "telegram_agent_list_watches",
+    { includeFinished: true },
+    fixture.toolContext,
+  ) as string);
+
+  expect(listed.monitors.length).toBeGreaterThan(0);
+  // Nothing is dropped in silence: what did not fit is counted.
+  expect(listed.monitors.length + listed.omitted).toBe(19);
+  expect(listed.omitted).toBeGreaterThan(0);
+  expect(Buffer.byteLength(JSON.stringify(listed), "utf8"))
+    .toBeLessThanOrEqual(CONTROLLER_CAPABILITIES.telegram_agent_list_watches.result_limit);
+});

--- a/tests/monitor.test.ts
+++ b/tests/monitor.test.ts
@@ -421,3 +421,53 @@ it("treats an unreadable thread as no evidence of a stall", async () => {
   expect(store.listControllerTurns(CONTROLLER_KEY, 10)).toHaveLength(0);
   expect(store.listArmedMonitors(10)).toHaveLength(1);
 });
+
+it("delivers a schedule's last firing when its next run cannot be worked out", async () => {
+  const { store } = fixture();
+  // 30 February never arrives, so this schedule is due now and can never be
+  // advanced past now — the exact shape that used to die without a word.
+  const monitor = store.createMonitor({
+    controllerKey: CONTROLLER_KEY,
+    kind: "schedule",
+    cron: "0 0 30 2 *",
+    instruction: "Check the invite job and tell the owner where it got to.",
+    dueAt: NOW,
+    now: NOW,
+  });
+
+  await expect(service(store, async () => "idle").processDue()).resolves.toBe(true);
+
+  const turns = store.listControllerTurns(CONTROLLER_KEY, 10);
+  expect(turns).toHaveLength(1);
+  expect(turns[0]?.inputText).toContain("Check the invite job and tell the owner where it got to.");
+  expect(turns[0]?.inputText).toContain("last firing");
+  expect(turns[0]?.inputText).toContain("0 0 30 2 *");
+  expect(store.listMonitors(CONTROLLER_KEY, true)).toMatchObject([{
+    id: monitor.id,
+    state: "failed",
+    lastError: "Schedule could not be advanced",
+  }]);
+  // Failed is terminal: the next sweep must not deliver it a second time.
+  await expect(service(store, async () => "idle").processDue()).resolves.toBe(false);
+  expect(store.listControllerTurns(CONTROLLER_KEY, 10)).toHaveLength(1);
+});
+
+it("keeps a dead schedule in the default list until it is cleared", async () => {
+  const { store } = fixture();
+  const monitor = store.createMonitor({
+    controllerKey: CONTROLLER_KEY,
+    kind: "schedule",
+    cron: "0 0 30 2 *",
+    instruction: "Check the invite job.",
+    dueAt: NOW,
+    now: NOW,
+  });
+  await service(store, async () => "idle").processDue();
+
+  // Without this the only view holding a dead schedule was the one that also
+  // holds every settled monitor ever created.
+  expect(store.listMonitors(CONTROLLER_KEY, false)).toMatchObject([{ id: monitor.id, state: "failed" }]);
+
+  expect(store.cancelControllerMonitor(CONTROLLER_KEY, monitor.id, NOW + 1_000)).toBe(true);
+  expect(store.listMonitors(CONTROLLER_KEY, false)).toEqual([]);
+});


### PR DESCRIPTION
## What was wrong

Three faults in the same surface, which together made a dead schedule invisible.

**1. The last firing was thrown away.** In `monitor-service.ts`, a schedule whose next run could not be worked out was marked failed and its firing discarded. The schedule was over — but it was over *at the moment it was due*, and swallowing that wake-up meant the work never ran and nothing said so. From the outside the schedule simply stopped existing.

**2. A failed monitor was hidden.** `listMonitors` excluded anything not `armed`, so a dead schedule could only be found behind `includeFinished`.

**3. `includeFinished` could not load.** That view returns every settled monitor ever created. At 68 monitors with instructions averaging ~850 characters, the result ran to roughly 58KB against an 8,000-byte `result_limit`, so the call failed outright. The one view that would show a dead schedule was the one view that never loaded.

A real monitor sat failed for ten days on `Schedule could not be advanced` without anyone noticing. The cron engine that originally caused it has since been rewritten; this is about the reporting around it.

## What this changes

- A schedule that cannot be advanced is still marked failed, but now delivers its final firing first, carrying its instruction plus the news that it has stopped and can be re-armed.
- Failed monitors appear in the default list beside the armed ones, and `cancelControllerMonitor` accepts a failed monitor so it can be cleared once dealt with.
- `list_watches` packs rows into a byte budget: armed and failed first with room for their instructions, settled history with a recognisable opening, at least one row always returned, and whatever did not fit reported as an `omitted` count rather than dropped in silence.

Deliberately left alone: system monitors stay out of the owner's list, as `system-monitors.test.ts` asserts.

## Testing

Three new tests — the last firing being delivered and the monitor going terminal, a failed schedule staying listed until cancelled, and a long monitor list staying inside its `result_limit` with an honest `omitted` count. Each verified failing on the unpatched source and passing with the change.

`monitor`, `system-monitors`, `cron` and `controller-capability-executor` suites pass. `tsc` clean.