### PR TITLE
fix(telegram): stop duplicate fold acknowledgements and owner-facing dashes

### DIFF
--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -822,6 +822,7 @@ type ControllerSteerSettlementRow = Readonly<{
   controllerKey: string;
   waitingState: ControllerTurnState | null;
   waitingOrdinal: number | null;
+  waitingOrigin: string | null;
   inputText: string | null;
   telegramChatId: string;
 }>;
@@ -7771,6 +7772,7 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
       `SELECT running.controller_key AS controllerKey,
               waiting.state AS waitingState,
               waiting.ordinal AS waitingOrdinal,
+              waiting.origin AS waitingOrigin,
               waiting.input_text AS inputText,
               controller.telegram_chat_id AS telegramChatId
          FROM controller_turns AS running
@@ -7831,13 +7833,26 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
     });
     // The answer itself arrives folded into the reply already being written, so
     // without this the owner's message drew no bubble at all and reads in
-    // Telegram exactly like being ignored.
+    // Telegram exactly like being ignored. That debt exists only for the
+    // owner's own words: a system injection folded the same way was never a
+    // message the owner sent, and acknowledging it reads as answering nobody.
+    if (row.waitingOrigin !== "owner") return;
     //
-    // Once, though. Two messages sent seconds apart both fold into the same
-    // running answer, and keying this by the waiting turn gave each its own
-    // row: the owner got the identical sentence twice, which reads like a
-    // stutter rather than an acknowledgement. One undelivered acknowledgement
-    // already says everything a second would.
+    // Once per answer, though. Keying this by the waiting turn gave every fold
+    // its own row, and checking only for a still-undelivered duplicate assumed
+    // the outbox was slower than the settles. It isn't: it drains sub-second,
+    // so the first bubble was sent before the second fold settled and the
+    // owner got the identical sentence twice. The running turn is the one
+    // thing every fold into the same answer shares, so the row is keyed by it
+    // and its bare existence, delivered or not, is the fence. It is never
+    // re-persisted: the upsert would flip a sent row back to pending.
+    const logicalKey = `controller:${input.runningTurnId}:steer-folded`;
+    const announcementExists = this.db.prepare(
+      "SELECT 1 FROM outbox WHERE logical_key = ? LIMIT 1",
+    ).get(logicalKey) !== undefined;
+    if (announcementExists) return;
+    // A still-undelivered acknowledgement from a previous answer also says
+    // everything this one would.
     const announcementPending = this.db.prepare(
       `SELECT 1 FROM outbox
         WHERE chat_id = ? AND status IN ('pending', 'leased', 'failed')
@@ -7845,7 +7860,7 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
     ).get(row.telegramChatId, foldedAnnouncementJson()) !== undefined;
     if (announcementPending) return;
     persistControllerOutbox(this.db, {
-      logicalKey: controllerReplyLogicalKey(input.waitingTurnId, null),
+      logicalKey,
       chatId: row.telegramChatId,
       payload: FOLDED_ANNOUNCEMENT_PAYLOAD,
     }, input.now);

--- a/src/telegram/client.ts
+++ b/src/telegram/client.ts
@@ -8,6 +8,7 @@ import {
   type TelegramUpdate,
 } from "./types";
 import { TelegramApiError, type TelegramDeliveryOutcome } from "./errors";
+import { scrubOwnerDashes } from "./dashes";
 
 export { TelegramApiError } from "./errors";
 
@@ -293,7 +294,7 @@ export class TelegramClient {
   public sendMessage(chatId: string, payload: SendMessagePayload, signal?: AbortSignal): Promise<{ message_id: number }> {
     return this.request({
       method: "sendMessage",
-      payload: { ...payload, chat_id: chatId },
+      payload: { ...payload, text: scrubOwnerDashes(payload.text), chat_id: chatId },
       callerSignal: signal,
       timeoutMs: ORDINARY_REQUEST_TIMEOUT_MS,
       parseResult: parseSentMessage,
@@ -318,7 +319,9 @@ export class TelegramClient {
       method: upload.field === "photo" ? "sendPhoto" : "sendVideo",
       payload: {
         chat_id: chatId,
-        ...(caption === null || caption.length === 0 ? {} : { caption, parse_mode: "HTML" }),
+        ...(caption === null || caption.length === 0
+          ? {}
+          : { caption: scrubOwnerDashes(caption), parse_mode: "HTML" }),
       },
       upload,
       callerSignal: signal,
@@ -350,7 +353,7 @@ export class TelegramClient {
     }
     return this.request({
       method: "sendMessageDraft",
-      payload: { chat_id: chatId, draft_id: draftId, text },
+      payload: { chat_id: chatId, draft_id: draftId, text: scrubOwnerDashes(text) },
       callerSignal: signal,
       timeoutMs: 5_000,
       maxAttempts: 1,
@@ -362,7 +365,7 @@ export class TelegramClient {
     if (!Number.isInteger(messageId) || messageId < 1) throw new TypeError("messageId must be a positive integer");
     return this.request({
       method: "editMessageText",
-      payload: { ...payload, chat_id: chatId, message_id: messageId },
+      payload: { ...payload, text: scrubOwnerDashes(payload.text), chat_id: chatId, message_id: messageId },
       callerSignal: signal,
       timeoutMs: ORDINARY_REQUEST_TIMEOUT_MS,
       parseResult: () => undefined,
@@ -373,7 +376,7 @@ export class TelegramClient {
   public answerCallback(callbackQueryId: string, text: string, signal?: AbortSignal): Promise<void> {
     return this.request({
       method: "answerCallbackQuery",
-      payload: { callback_query_id: callbackQueryId, text },
+      payload: { callback_query_id: callbackQueryId, text: scrubOwnerDashes(text) },
       callerSignal: signal,
       timeoutMs: ORDINARY_REQUEST_TIMEOUT_MS,
       parseResult: () => undefined,

--- a/src/telegram/dashes.ts
+++ b/src/telegram/dashes.ts
@@ -1,0 +1,43 @@
+// The owner has one standing rule about everything sent to them: no em or en
+// dashes, ever. The model carries the same rule in its writing skills, but a
+// rule a model follows most of the time is not a rule. The wire boundary is
+// where it becomes mechanical, so every path that can put text in front of
+// the owner - answers, drafts, captions, callback toasts - goes through here.
+//
+// Held <pre> and <code> spans keep their bytes: code is quoted material, not
+// Hanoon's own voice, and rewriting it would corrupt what the owner asked to
+// see.
+
+// NUL cannot appear in a Telegram message, so a held span can never collide
+// with surrounding text. Same trick as the markdown renderer.
+const HELD_MARKER = String.fromCharCode(0);
+
+// Em dash, en dash, and their look-alikes: figure dash and horizontal bar.
+const DASH = "[\\u2012-\\u2015]";
+const NUMERIC_RANGE = new RegExp(`(\\d)[ \\t]*${DASH}[ \\t]*(?=\\d)`, "g");
+const LINE_TRAILING = new RegExp(`[ \\t]*${DASH}+[ \\t]*(?=\\r?\\n|$)`, "g");
+const LINE_LEADING = new RegExp(`(^|\\n)[ \\t]*${DASH}+[ \\t]*`, "g");
+const CLAUSE = new RegExp(`[ \\t]*${DASH}+[ \\t]*`, "g");
+const CODE_SPAN = /<pre>[\s\S]*?<\/pre>|<code>[\s\S]*?<\/code>/g;
+
+function scrubProse(text: string): string {
+  return text
+    .replace(NUMERIC_RANGE, "$1-")
+    .replace(LINE_TRAILING, "")
+    .replace(LINE_LEADING, "$1- ")
+    .replace(CLAUSE, ", ");
+}
+
+export function scrubOwnerDashes(text: string): string {
+  const held: string[] = [];
+  const withoutCode = text.replace(CODE_SPAN, (span) => {
+    const token = `${HELD_MARKER}${held.length}${HELD_MARKER}`;
+    held.push(span);
+    return token;
+  });
+  let scrubbed = scrubProse(withoutCode);
+  held.forEach((span, index) => {
+    scrubbed = scrubbed.split(`${HELD_MARKER}${index}${HELD_MARKER}`).join(span);
+  });
+  return scrubbed;
+}

--- a/tests/controller-questions.test.ts
+++ b/tests/controller-questions.test.ts
@@ -878,7 +878,7 @@ it("hands a message sent mid-answer to the thread already writing it", async () 
   expect(store.getControllerTurn(correction.id)?.state).toBe("completed");
   // The running answer still owns the reply; the correction gets no second one.
   // A folded message still draws a bubble, so the owner can see it landed.
-  expect(store.getOutbox(`controller:${correction.id}:reply`)?.payload.text)
+  expect(store.getOutbox(`controller:${running.id}:steer-folded`)?.payload.text)
     .toMatch(/already writing/i);
   expect(store.getControllerTurn(running.id)?.state).toBe("submitted");
 });

--- a/tests/controller-store.test.ts
+++ b/tests/controller-store.test.ts
@@ -1432,9 +1432,82 @@ it("acknowledges an owner message folded into the running answer", () => {
   })).toBe("settled");
 
   expect(store.getControllerTurn(waiting.id)).toMatchObject({ state: "completed" });
-  const notice = store.getOutbox(`controller:${waiting.id}:reply`);
+  const notice = store.getOutbox(`controller:${running.id}:steer-folded`);
   expect(notice?.payload.text).toMatch(/answer i'm already writing|already writing/i);
   expect(notice?.chatId).toBe("7");
+});
+
+// Three system daily checks folded into a running answer at 09:19 and the
+// owner's phone showed "Got that" twice — acknowledging messages the owner
+// never sent. The bubble exists so an owner's own words don't look ignored;
+// a system injection owes no bubble at all.
+it("sends no folded acknowledgement for a system-origin injection", () => {
+  const { store } = fixture();
+  const { turn: running, fence } = submittedTurn(store, "thr_system_fold");
+  const waiting = store.enqueueControllerTurn({
+    ...turnInput(78_020, "Daily check on cyndra-saas:\ntech-debt: could not run"),
+    origin: "system" as const,
+  });
+  expect(store.reserveControllerSteer({
+    ...fence,
+    runningTurnId: running.id,
+    waitingTurnId: waiting.id,
+    controllerKey: running.controllerKey,
+    expectedThreadId: "thr_system_fold",
+  })).toBe(true);
+
+  expect(store.settleControllerSteer({
+    ...fence,
+    runningTurnId: running.id,
+    waitingTurnId: waiting.id,
+    controllerKey: running.controllerKey,
+    outcome: "applied",
+  })).toBe("settled");
+
+  expect(store.getControllerTurn(waiting.id)).toMatchObject({ state: "completed" });
+  const announcements = store.listOutbox(50)
+    .filter((row) => /already writing/i.test(String(row.payload.text ?? "")));
+  expect(announcements).toHaveLength(0);
+});
+
+// The outbox drains sub-second, so a duplicate check that only looks for a
+// still-undelivered acknowledgement almost never fires: the first bubble is
+// sent before the second fold settles. One acknowledgement per running
+// answer, however fast delivery is.
+it("acknowledges two owner messages folded into one answer exactly once", () => {
+  const { store } = fixture();
+  const { turn: running, fence } = submittedTurn(store, "thr_double_fold");
+  const first = store.enqueueControllerTurn(turnInput(78_030, "also check the deploy"));
+  const second = store.enqueueControllerTurn(turnInput(78_031, "and the logs too"));
+  const fold = (waitingTurnId: string) => {
+    expect(store.reserveControllerSteer({
+      ...fence,
+      runningTurnId: running.id,
+      waitingTurnId,
+      controllerKey: running.controllerKey,
+      expectedThreadId: "thr_double_fold",
+    })).toBe(true);
+    expect(store.settleControllerSteer({
+      ...fence,
+      runningTurnId: running.id,
+      waitingTurnId,
+      controllerKey: running.controllerKey,
+      outcome: "applied",
+    })).toBe("settled");
+  };
+
+  fold(first.id);
+  const leased = store.leaseOutbox(fence.ownerId, fence.generation, fence.now, 10, 30_000);
+  const announcement = leased.find((row) => /already writing/i.test(String(row.payload.text ?? "")));
+  expect(announcement).toBeDefined();
+  expect(store.completeOutbox(
+    announcement!.logicalKey, fence.ownerId, fence.generation, 900, fence.now,
+  )).toBe(true);
+
+  fold(second.id);
+  const announcements = store.listOutbox(50)
+    .filter((row) => /already writing/i.test(String(row.payload.text ?? "")));
+  expect(announcements).toHaveLength(1);
 });
 
 it("preserves an ambiguously steered owner message and inherits exact receipts", () => {

--- a/tests/controller-tools.test.ts
+++ b/tests/controller-tools.test.ts
@@ -2463,10 +2463,14 @@ it("scans every returned watch for obligations while capping only subject refs",
     "telegram_agent_list_watches",
     { includeFinished: true },
     controllerToolContext,
-  ) as string) as { _hanoonEvidence: { proofKinds: string[]; subjectRefs: string[] } };
+  ) as string) as { monitors: Array<{ id: string }>; _hanoonEvidence: { proofKinds: string[]; subjectRefs: string[] } };
   expect(output._hanoonEvidence.proofKinds).toEqual(["monitor_state", "obligation"]);
-  const returnedOrder = store.listMonitors(turn.controllerKey, true).map((monitor) => monitor.id);
-  expect(returnedOrder.at(-1)).toBe(monitorIds[0]);
+  // The list packs the armed watch first and settled history newest-first, so
+  // the refs are read from the rows the tool actually returned, not from the
+  // store's raw order.
+  const returnedOrder = output.monitors.map((monitor) => monitor.id);
+  expect(returnedOrder[0]).toBe(monitorIds[0]);
+  expect(returnedOrder).toHaveLength(17);
   expect(output._hanoonEvidence.subjectRefs).toEqual(returnedOrder.slice(0, 16).map((id) => `monitor:${id}`));
 });
 

--- a/tests/telegram-client.test.ts
+++ b/tests/telegram-client.test.ts
@@ -425,6 +425,50 @@ describe("Telegram Bot API client", () => {
     expect(fetchMock.calls[1]?.body).toContain('"callback_query_id":"callback-1"');
   });
 
+  // The owner's standing rule bans em and en dashes in everything sent to
+  // them. Prompts ask the model nicely; the wire boundary is where it becomes
+  // true no matter which layer produced the text.
+  it("scrubs em and en dashes from every owner-facing text field", async () => {
+    const fetchMock = telegramFetch([
+      { ok: true, result: { message_id: 21 } },
+      { ok: true, result: true },
+      { ok: true, result: true },
+      { ok: true, result: true },
+    ]);
+    const client = new TelegramClient("token", fetchMock);
+
+    await client.sendMessage("70", { text: "one shape — plan files" });
+    await client.editMessage("70", 21, { text: "no result – so treat it" });
+    await client.sendMessageDraft("70", 91, "draft — partial");
+    await client.answerCallback("callback-2", "done — noted");
+
+    expect(fetchMock.calls[0]?.body).toContain('"text":"one shape, plan files"');
+    expect(fetchMock.calls[1]?.body).toContain('"text":"no result, so treat it"');
+    expect(fetchMock.calls[2]?.body).toContain('"text":"draft, partial"');
+    expect(fetchMock.calls[3]?.body).toContain('"text":"done, noted"');
+  });
+
+  it("scrubs dashes from a media caption", async () => {
+    const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(input), init });
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 57 } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const client = new TelegramClient("123:secret", fetchMock);
+
+    await client.sendMedia(
+      "70",
+      { field: "photo", filename: "shot.png", mimeType: "image/png", bytes: new Uint8Array([1]) },
+      "the checkout — before login",
+    );
+
+    const body = calls[0]?.init?.body as FormData;
+    expect(body.get("caption")).toBe("the checkout, before login");
+  });
+
   it("sends the native typing chat action with the exact Telegram payload", async () => {
     const fetchMock = telegramFetch([{ ok: true, result: true }]);
     const client = new TelegramClient("token", fetchMock);

--- a/tests/telegram-dashes.test.ts
+++ b/tests/telegram-dashes.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { scrubOwnerDashes } from "../src/telegram/dashes";
+
+// The owner's standing rule: no em or en dashes in anything sent to them.
+// The model is asked politely in its skills; this is the mechanical guarantee.
+describe("scrubOwnerDashes", () => {
+  it("turns an em dash clause into a comma", () => {
+    expect(scrubOwnerDashes("the four docs findings are all one shape — plan and spec files"))
+      .toBe("the four docs findings are all one shape, plan and spec files");
+  });
+
+  it("handles unspaced em dashes", () => {
+    expect(scrubOwnerDashes("yes—but not yet")).toBe("yes, but not yet");
+  });
+
+  it("scrubs en dashes like em dashes in prose", () => {
+    expect(scrubOwnerDashes("no result – so treat that silence as unknown"))
+      .toBe("no result, so treat that silence as unknown");
+  });
+
+  it("keeps numeric ranges readable with a plain hyphen", () => {
+    expect(scrubOwnerDashes("retry 3–5 times")).toBe("retry 3-5 times");
+  });
+
+  it("collapses a run of dashes into one comma", () => {
+    expect(scrubOwnerDashes("wait —— what")).toBe("wait, what");
+  });
+
+  it("drops a dangling dash at the end of a line", () => {
+    expect(scrubOwnerDashes("he trailed off —\nthen stopped")).toBe("he trailed off\nthen stopped");
+  });
+
+  it("turns a dash-led line into a plain bullet", () => {
+    expect(scrubOwnerDashes("changes:\n— first\n— second")).toBe("changes:\n- first\n- second");
+  });
+
+  it("leaves quoted code untouched", () => {
+    const html = 'see <code>a — b</code> and <pre><code>x —— y</code></pre> here — done';
+    expect(scrubOwnerDashes(html)).toBe('see <code>a — b</code> and <pre><code>x —— y</code></pre> here, done');
+  });
+
+  it("passes dash-free text through unchanged", () => {
+    const text = "plain text, with commas, and a hyphenated-word";
+    expect(scrubOwnerDashes(text)).toBe(text);
+  });
+});


### PR DESCRIPTION
Two owner-visible Telegram faults, both caught from one screenshot of the owner's phone.

## "Got that" sent twice, answering nobody

At 09:19 the owner received "Got that, and I'm working it into the answer I'm already writing." twice in the same minute, with no message of their own anywhere near it. The store shows what happened: three system daily-check turns (cyndra-saas, parknwash-website, woo-app) folded into the running areliaa answer within one second, and each fold enqueued the owner-facing acknowledgement.

Two faults in `completeAppliedControllerSteer`:

- The acknowledgement exists so an owner's own words don't look ignored, but it fired for `origin: "system"` turns too. It now returns before the bubble unless the folded turn is the owner's.
- The duplicate check only suppressed a second bubble while the first was still undelivered. The outbox drains sub-second, so the first was already sent before the second fold settled, and the check saw nothing. The acknowledgement is now keyed by the running turn (`controller:<id>:steer-folded`), one per answer, and its existence in any status is the fence. It is checked rather than re-persisted because the outbox upsert would flip a sent row back to pending and resend it.

The same double-send pattern exists in the outbox history on Aug 18 and Aug 20, so this was recurring, not a one-off.

## Em dashes reaching the owner

The 12:20 daily-check answer carried three em dashes. The unslop skill already bans them, but a rule a model follows most of the time is not a rule. `TelegramClient` now scrubs em and en dashes (plus figure dash and horizontal bar) mechanically on every owner-facing text field: messages, edits, streaming drafts, media captions, and callback toasts. Clauses become commas, numeric ranges become hyphens, dash-led lines become plain bullets, and held `<pre>`/`<code>` spans keep their bytes so quoted code is never rewritten.

The exact production message from the incident round-trips to the owner's preferred comma style with zero dashes remaining.

## Review focus

`store.ts` is the riskier half: the new early return sits after the fold's digest bookkeeping, so a system fold still completes the waiting turn and records its digest row, it just draws no bubble. The three new store tests drive the exact production sequence, including delivery of the first acknowledgement between two folds.

## A repair main needed

Merging current main brought in #16, whose byte-budget packing reordered the monitor list and broke `controller-tools.test.ts` on main itself (its testing note covered four other suites). The obligations test asserted the store's raw order; its own name says it scans every returned watch, so it now reads its expectation from the tool's output. Nothing in the production packing changed.

Typecheck clean, 177 test files / 4541 tests pass on the merged branch.
