### PR TITLE
fix(agent): keep workers alive while they work and act on accepted offers

### DIFF
--- a/src/bb/runner.ts
+++ b/src/bb/runner.ts
@@ -476,6 +476,24 @@ export class BbRunner {
     return result.output ?? "";
   }
 
+  /**
+   * The newest event sequence past `afterSeq`, or `afterSeq` when nothing new
+   * arrived. One page suffices: the liveness watchdog only asks whether the
+   * provider moved at all since the last poll, not how far.
+   */
+  public async latestThreadEventSeq(threadId: string, afterSeq: number): Promise<number> {
+    if (!threadId) throw new TypeError("threadId must not be empty");
+    if (!Number.isInteger(afterSeq) || afterSeq < 0) throw new TypeError("afterSeq must be a non-negative integer");
+    const rows = await this.sdk.threads.events.list({
+      threadId,
+      afterSeq: String(afterSeq),
+      limit: String(USAGE_EVENT_PAGE_LIMIT),
+    });
+    let latest = afterSeq;
+    for (const row of rows) latest = Math.max(latest, row.seq);
+    return latest;
+  }
+
   public async spawnDocs(job: Job, attempt: PipelineThreadAttempt): Promise<ThreadResult> {
     const policy = selectedPolicy(job);
     const project = projectId(job, policy);

--- a/src/capabilities/controller-bundles.ts
+++ b/src/capabilities/controller-bundles.ts
@@ -109,6 +109,40 @@ export function selectControllerBundles(text: string): ControllerToolBundleId[] 
   return orderedBundles(selected);
 }
 
+const AFFIRMATIVE_REPLY =
+  /^\s*(?:yes|yeah|yep|ya|ok(?:ay)?|sure|go ahead|do it|do that|do both|proceed|please do|sounds good|go on|approved?|confirm(?:ed)?)\b/iu;
+// Offers sit at the end of an answer, so the tail is where their intent lives.
+const PREVIOUS_ANSWER_TAIL_CHARS = 2_000;
+
+/**
+ * "yes but sent the pr link first" carries no intent a regex can see. The
+ * intent lives in the offer it accepts, one turn back: the agent had just
+ * asked "Want me to sort the conflict out and put it back through review?",
+ * and the reply arrived with observation tools only, so the agent promised
+ * the work and could not start it.
+ *
+ * An affirmative answering an offer therefore opens the whole fenced toolbox.
+ * Selecting a bundle exposes already-fenced tool interfaces, it executes
+ * nothing, so breadth here costs safety nothing while a missing tool costs
+ * the owner a promise that goes nowhere. Any reply also inherits whatever
+ * intent the previous answer itself names, for references like "the second
+ * option".
+ */
+export function selectControllerBundlesForConversation(
+  text: string,
+  previousResponse: string | null,
+): ControllerToolBundleId[] {
+  const selected = new Set<ControllerToolBundleId>(selectControllerBundles(text));
+  const tail = previousResponse?.slice(-PREVIOUS_ANSWER_TAIL_CHARS).trim() ?? "";
+  if (tail.length > 0) {
+    for (const bundleId of selectControllerBundles(tail)) selected.add(bundleId);
+    if (AFFIRMATIVE_REPLY.test(text) && tail.includes("?")) {
+      for (const bundleId of CONTROLLER_BUNDLE_IDS) selected.add(bundleId);
+    }
+  }
+  return orderedBundles(selected);
+}
+
 export function controllerSkillsForTurn(text: string): CapabilitySkillId[] {
   return MANUAL_DISCOVERY_COMMAND.test(text)
     ? [...CONTROLLER_DEFAULT_SKILLS, ...CONTROLLER_MANUAL_DISCOVERY_SKILLS]

--- a/src/controller/instructions.ts
+++ b/src/controller/instructions.ts
@@ -23,16 +23,17 @@ Every turn:
 - Finish with \`telegram_agent_respond\`. It is your last action; other text is not delivered.
 - Apply the unslop skill to every owner-facing message. Required, not optional.
 - Use your tools before answering about threads, jobs, projects, or progress. Every claim about current state or completed work rests on evidence gathered in this same turn.
-- A promise of later action needs a live job or armed monitor; durable job or monitor obligation is required.
-- Never narrate your tools or limits. Give your best read and say what would settle it. Uncertainty is one short clause (\"looks stalled, ~15m idle\"), never a disclaimer.
+- A promise of later action needs a live job or armed monitor; without one say you have not started it.
+- Missing a tool: request it via \`telegram_agent_request_capability\`, or say what you could not start.
+- Never narrate your tools or limits. Give your best read and say what would settle it. Uncertainty is one short clause, never a disclaimer.
 
 What to do:
 - Asked how something is going: read its live activity and say what it is doing and waiting on. Never invent a percentage or ETA.
 - Open a thread, message it, stop or retry it. Do the next step rather than ask. Split independent questions and answer once.
 - Software changes go through a guarded job. List projects, then start, inspect, retry, cancel, or land it. \`choose_job\` means present those ids, never guess.
 - \`awaiting_confirmation\` with \`awaitingOwner: false\` is queued, not waiting on them. Never tell them to tap what no tool said they block.
-- A monitor wakes you when a thread finishes or fails or on a schedule: do it, then message the owner. Write it in full; your future self gets only that. Watch any visible thread; ones you start or message already are.
-- Restart a paused project yourself with \`telegram_agent_resume_project\`. Never ask them to type a command. One question per message at most, never one they answered.
+- A monitor wakes you when a thread settles or on a schedule: do it, then message the owner. Write it in full; your future self gets only that. Watch any visible thread; ones you start or message already are.
+- Restart a paused project yourself with \`telegram_agent_resume_project\`. One question per message at most, never one they answered.
 
 Memory:
 - A turn may open with what you know about the owner and what was said before; use both silently, never quoting them.
@@ -40,7 +41,7 @@ Memory:
 
 Your authority:
 - You run on the owner's machine with authority to act for them. They work only from Telegram and never open the BB app, so anything waiting for a click there is a dead end: do it.
-- Use the shell freely, including the \`bb\` CLI, for anything BB can do, and the skills and MCP servers installed. Spawn threads with \`--parent-self\`, or blocks hit the owner. Never tell the owner to do something in BB: do it, or say what blocks you.`;
+- Use the shell and \`bb\` CLI freely for anything BB can do, plus installed skills and MCP servers. Spawn threads with \`--parent-self\`, or blocks hit the owner. Never tell the owner to do something in BB: do it, or say what blocks you.`;
 
 const IDENTITY_HEADING = "Who you are — never a boundary:";
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1469,6 +1469,31 @@ export async function createPlugin(bb: BbPluginApi, pluginRoot: string): Promise
     getPullRequestSnapshot: (environmentId: string) => bbRunner.getPullRequestSnapshot(environmentId),
     sdk: { threads: bb.sdk.threads },
   };
+  // Last provider-event sequence seen per worker thread, with when it moved.
+  // The BB thread row does not change while a provider works a turn, so this
+  // is the only pulse that distinguishes a reviewer deep in a long diff from
+  // one that died. In-memory on purpose: a plugin restart forgets it and the
+  // watchdog window simply starts over, which forgives rather than kills.
+  const workerEventPulse = new Map<string, { seq: number; at: number }>();
+  const WORKER_EVENT_PULSE_LIMIT = 512;
+  const observeWorkerEventPulse = async (resourceId: string, now: number): Promise<number | undefined> => {
+    const previous = workerEventPulse.get(resourceId);
+    try {
+      const latestSeq = await bbRunner.latestThreadEventSeq(resourceId, previous?.seq ?? 0);
+      if (previous === undefined || latestSeq > previous.seq) {
+        if (workerEventPulse.size >= WORKER_EVENT_PULSE_LIMIT && !workerEventPulse.has(resourceId)) {
+          const oldest = workerEventPulse.keys().next().value;
+          if (oldest !== undefined) workerEventPulse.delete(oldest);
+        }
+        workerEventPulse.set(resourceId, { seq: latestSeq, at: now });
+        return now;
+      }
+      return previous.at;
+    } catch {
+      // A failed read is not evidence of death; keep whatever pulse we had.
+      return previous?.at;
+    }
+  };
   const reconcileJob = async (
     job: NonNullable<ReturnType<typeof store.getJob>>,
     signal: AbortSignal,
@@ -1702,13 +1727,16 @@ export async function createPlugin(bb: BbPluginApi, pluginRoot: string): Promise
     // route the question and for the next reconciliation after the answer.
     if (hasPendingInteraction) return;
     const observedAt = clock();
+    const eventPulseAt = await observeWorkerEventPulse(resourceId, observedAt);
+    if (!fenceCurrent()) return;
     const projected = projectWorkerLiveness(store, current, thread, observedAt, workerKind, generation, {
       ownerId: fence.ownerId,
       generation: fence.generation,
       now: observedAt,
-    });
-    const recovery = classifyThreadRecovery(current, thread, previousLiveness, observedAt, workerKind);
+    }, eventPulseAt);
+    const recovery = classifyThreadRecovery(current, thread, previousLiveness, observedAt, workerKind, eventPulseAt);
     if (recovery) {
+      workerEventPulse.delete(resourceId);
       const retryPayload = recoveryRetryPayload();
       recoverWorker(current, workerKind, resourceId, generation, recovery.classification, recovery.signature, currentPipelineAttempt, retryPayload);
       return;
@@ -1733,6 +1761,7 @@ export async function createPlugin(bb: BbPluginApi, pluginRoot: string): Promise
       return;
     }
     if (projected.state !== "idle") return;
+    workerEventPulse.delete(resourceId);
     await settleStageMeasurement("succeeded");
     if (!fenceCurrent()) return;
 

--- a/src/services/worker-liveness.ts
+++ b/src/services/worker-liveness.ts
@@ -141,6 +141,11 @@ function recoverySignal(
  * thread is not progress, and a host reconnect remains exempt until its grace
  * window expires. A missing lookup needs a previous missing observation so a
  * transient API failure cannot kill useful work.
+ *
+ * `commandActivityAt` carries the newest provider-event time the caller has
+ * seen. The thread row's own timestamp does not move while a provider works a
+ * turn, so without this a reviewer deep in a long diff reads as dead at the
+ * watchdog and is retired mid-review.
  */
 export function classifyThreadRecovery(
   job: Job,
@@ -148,6 +153,7 @@ export function classifyThreadRecovery(
   previous: WorkerLiveness | null,
   now: number,
   workerKind: WorkerLiveness["workerKind"] = previous?.workerKind ?? "implementation",
+  commandActivityAt?: number,
 ): ThreadRecoverySignal | null {
   if (!Number.isInteger(now) || now < 0) throw new TypeError("now must be a non-negative integer");
   if (thread === null) {
@@ -170,7 +176,7 @@ export function classifyThreadRecovery(
 
   const state = stateForThread(thread);
   if (state === "failed") return recoverySignal(workerKind, "crash", `${thread.status}:${displayStatus}`);
-  const activityAt = threadActivityAt(thread);
+  const activityAt = threadActivityAt(thread, commandActivityAt);
   if (state === "starting" && now - activityAt > startGraceMs(job)) {
     return recoverySignal(workerKind, "never_started", `${thread.status}:${displayStatus}`);
   }

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -29,6 +29,7 @@ import {
   CONTROLLER_BUNDLE_IDS,
   DEFAULT_CONTROLLER_CAPABILITY_MODEL,
   expandControllerCapabilityProfile,
+  selectControllerBundlesForConversation,
   selectControllerCapabilityProfile,
   type ControllerToolBundleId,
 } from "../capabilities/controller-bundles";
@@ -4641,6 +4642,8 @@ const CONTROLLER_FAILURE_TEXT: Readonly<Record<ControllerFailureCode, string>> =
 
 /** Shown when a message arrives mid-turn and is folded into the running reply. */
 const CONTROLLER_STEER_FOLDED_TEXT = "Got that, and I'm working it into the answer I'm already writing.";
+/** Recorded on a folded waiting turn in place of an answer of its own. */
+const CONTROLLER_STEER_FOLDED_RESPONSE = "(sent to the answer already in progress)";
 /** Frozen so the stored payload and the duplicate check compare byte for byte. */
 const FOLDED_ANNOUNCEMENT_PAYLOAD = Object.freeze({
   text: CONTROLLER_STEER_FOLDED_TEXT,
@@ -5526,9 +5529,21 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
       !["adaptive", "legacy"].includes(dispatchSettings.jobGraph) ||
       !["bundled", "all-tools"].includes(dispatchSettings.controllerTools)
     ) throw new TypeError("Capability dispatch settings are invalid");
+    // The offer a short reply accepts lives in the previous answer, so bundle
+    // selection reads the conversation rather than the message alone. Folded
+    // placeholders are skipped: they stand in for an answer, they are not one.
+    const previousResponse = (this.db.prepare(
+      `SELECT response_text FROM controller_turns
+        WHERE controller_key = ? AND state = 'completed' AND response_text IS NOT NULL
+          AND response_text <> ?
+        ORDER BY ordinal DESC LIMIT 1`,
+    ).get(input.controllerKey, CONTROLLER_STEER_FOLDED_RESPONSE) as { response_text: string } | undefined)
+      ?.response_text ?? null;
     const capabilitySelection = selectControllerCapabilityProfile(
       input.inputText,
-      dispatchSettings.controllerTools === "all-tools" ? CONTROLLER_BUNDLE_IDS : undefined,
+      dispatchSettings.controllerTools === "all-tools"
+        ? CONTROLLER_BUNDLE_IDS
+        : selectControllerBundlesForConversation(input.inputText, previousResponse),
       this.controllerModelRoute(),
     );
 
@@ -7815,7 +7830,7 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
     input: ControllerSteerSettlementInput,
     row: ControllerSteerSettlementRow,
   ): void {
-    const folded = "(sent to the answer already in progress)";
+    const folded = CONTROLLER_STEER_FOLDED_RESPONSE;
     const updated = this.db.prepare(
       `UPDATE controller_turns
           SET state = 'completed', response_text = ?, stream_phase = 'complete',

--- a/tests/controller-capabilities.test.ts
+++ b/tests/controller-capabilities.test.ts
@@ -1,5 +1,5 @@
 import { createFakePluginHost } from "@bb/plugin-sdk/testing";
-import { expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   CAPABILITY_BY_ID,
   CONTROLLER_DOMAIN_TOOL_IDS,
@@ -15,6 +15,7 @@ import {
   controllerToolsForBundles,
   selectControllerCapabilityProfile,
   selectControllerBundles,
+  selectControllerBundlesForConversation,
 } from "../src/capabilities/controller-bundles";
 import { hashSecret } from "../src/crypto";
 import { openStore } from "../src/storage/store";
@@ -69,6 +70,50 @@ it.each([
   ["delegate these independent tasks", ["core-observation", "operations"]],
 ] as const)("selects the least controller bundles for %s", (text, expected) => {
   expect(selectControllerBundles(text)).toEqual(expected);
+});
+
+// "yes but sent the pr link first" carries no intent a regex can see; the
+// intent lives in the offer it accepts, one turn back. The owner said yes to
+// "Want me to sort the conflict out and put it back through review?" and the
+// turn arrived with observation tools only, so the agent promised the work
+// and could not start it.
+describe("conversation-aware bundle selection", () => {
+  it("gives an affirmative reply to an offer the full fenced toolbox", () => {
+    expect(selectControllerBundlesForConversation(
+      "yes but sent the pr link first",
+      "Want me to sort the conflict out and put it back through review?",
+    )).toEqual([...CONTROLLER_BUNDLE_IDS]);
+  });
+
+  it("keeps a plain statement after a statement at its own bundles", () => {
+    expect(selectControllerBundlesForConversation(
+      "show job status",
+      "The pipeline finished the build stage.",
+    )).toEqual(["core-observation"]);
+  });
+
+  it("does not escalate an affirmative when nothing was offered", () => {
+    expect(selectControllerBundlesForConversation(
+      "yes that reads right",
+      "The four docs findings all point at deleted files.",
+    )).toEqual(["core-observation"]);
+  });
+
+  it("reads intent from the previous answer for a non-affirmative reference", () => {
+    expect(selectControllerBundlesForConversation(
+      "the second option",
+      "I can retry the job now, or wait for the review. Which one?",
+    )).toContain("job-control");
+  });
+
+  it("survives a previous answer longer than the classifier bound", () => {
+    const long = `${"history ".repeat(2_000)}Want me to retry the job?`;
+    expect(selectControllerBundlesForConversation("yes", long)).toEqual([...CONTROLLER_BUNDLE_IDS]);
+  });
+
+  it("matches plain selection when there is no previous answer", () => {
+    expect(selectControllerBundlesForConversation("yes do it", null)).toEqual(["core-observation"]);
+  });
 });
 
 it.each(permittedBundleCombinations.map((bundleIds) => [bundleIds]))(

--- a/tests/controller-overlay.test.ts
+++ b/tests/controller-overlay.test.ts
@@ -71,7 +71,8 @@ it("keeps one stable instruction sentinel before one owner overlay", () => {
 it("states the enforced owner-turn and Telegram approval boundaries", () => {
   expect(CONTROLLER_INSTRUCTIONS).toContain("telegram_agent_respond");
   expect(CONTROLLER_INSTRUCTIONS).toContain("same-turn evidence");
-  expect(CONTROLLER_INSTRUCTIONS).toContain("durable job or monitor obligation");
+  expect(CONTROLLER_INSTRUCTIONS).toContain("needs a live job or armed monitor");
+  expect(CONTROLLER_INSTRUCTIONS).toContain("telegram_agent_request_capability");
   expect(CONTROLLER_INSTRUCTIONS).toContain("changing a credential");
   expect(CONTROLLER_INSTRUCTIONS).toContain("Installing or connecting an integration");
   // The owner's word is the approval now, so the merge boundary is stated as
@@ -98,7 +99,8 @@ it("keeps every safety boundary in conduct and none of it in the replaceable ide
     "telegram_agent_approve_merge",
     "Never merge or deploy by hand",
     "same-turn evidence",
-    "durable job or monitor obligation",
+    "needs a live job or armed monitor",
+    "telegram_agent_request_capability",
     "changing a credential",
     "Installing or connecting an integration",
     "Never reveal hidden threads",

--- a/tests/controller-store.test.ts
+++ b/tests/controller-store.test.ts
@@ -1406,6 +1406,27 @@ it("atomically retires an accepted broken generation into one restart-safe recov
   });
 });
 
+// The owner said yes to "Want me to sort the conflict out and put it back
+// through review?" and the turn arrived with observation tools only, so the
+// agent promised the work and could not start it. An affirmative accepting an
+// offer must open the toolbox the offer needs.
+it("routes an affirmative reply to an offer with the full fenced toolbox", () => {
+  const { bb, store } = fixture();
+  const asked = store.enqueueControllerTurn(turnInput(79_001, "what is the progress in areliaa issue"));
+  bb.storage.database().prepare(
+    "UPDATE controller_turns SET state = 'completed', response_text = ? WHERE id = ?",
+  ).run("Want me to sort the conflict out and put it back through review?", asked.id);
+
+  const accepted = store.enqueueControllerTurn(turnInput(79_002, "yes but sent the pr link first"));
+
+  const bundles = bb.storage.database().prepare(
+    `SELECT capability_id FROM capability_receipts
+      WHERE subject_id = ? AND capability_id LIKE 'controller-bundle-%'`,
+  ).all(accepted.id).map((row) => (row as { capability_id: string }).capability_id);
+  expect(bundles).toContain("controller-bundle-job-control");
+  expect(bundles).toContain("controller-bundle-thread-control");
+});
+
 // The owner asked a real question at 1:42am, it was folded into the running
 // answer, and no bubble appeared at all. From Telegram that is identical to
 // being ignored, so a folded message has to leave something visible behind.

--- a/tests/worker-liveness.test.ts
+++ b/tests/worker-liveness.test.ts
@@ -81,6 +81,20 @@ describe("worker liveness projection", () => {
     expect(value.staleNotifiedAt).toBeNull();
   });
 
+  // A codex review ran 23 minutes without the BB thread row moving once, and
+  // the watchdog retired it at five, four times over, then failed the job
+  // while a complete verdict was still on its way. Provider events are the
+  // real pulse: a thread whose event stream advanced inside the window is
+  // working, however quiet its row.
+  it("keeps a quiet-rowed worker alive while its provider events still advance", () => {
+    const job = jobFixture({ policy: policyFixture({ workerLivenessWatchdogMs: 60_000 }) });
+    const quietRow = thread({ status: "active", updatedAt: 1_000 });
+
+    expect(classifyThreadRecovery(job, quietRow, null, 61_001, "review", 45_000)).toBeNull();
+    expect(classifyThreadRecovery(job, quietRow, null, 106_001, "review", 45_000))
+      .toMatchObject({ classification: "no_progress" });
+  });
+
   it("classifies never-started and no-progress workers but honors host reconnect grace", () => {
     const job = jobFixture({
       policy: policyFixture({


### PR DESCRIPTION
The owner watched the Areliaa job burn four review workers in 23 minutes, fail "needing a manual retry", then said yes to the agent's own offer to fix it and got a promise with nothing behind it. Three faults, one theme: the agent looked alive and did nothing.

## A working reviewer read as dead

The liveness watchdog measured progress by the BB thread row's `updatedAt`, which does not move while a provider works a turn. A codex review that needs 23 minutes was declared `no_progress` at exactly 5, retired mid-work, and respawned, four times, before the job failed with "review worker stopped unexpectedly and needs a manual retry". The fourth reviewer finished a complete, valid verdict 18 minutes after the job had already given up.

The reconcile loop now reads the thread's provider event stream (`sdk.threads.events.list`, one page past the last seen seq) and feeds that pulse into `classifyThreadRecovery`. A thread whose events advance is alive however quiet its row; a thread whose events stop gets the same 5-minute watchdog as before. The pulse cache is in-memory on purpose: a plugin restart forgets it and the window starts over, which forgives rather than kills.

## "yes" arrived with no hands

Capability bundles were selected by regex over the new message text alone. "yes but sent the pr link first" matches nothing, so the turn that accepted the offer to fix the conflict got observation-only tools, promised the work, and could not start it. `selectControllerBundlesForConversation` now reads the conversation: any reply inherits the intent named in the previous answer, and an affirmative accepting an offer (previous answer carries a question) opens the whole fenced toolbox. Selecting a bundle exposes already-fenced tool interfaces and executes nothing, so breadth costs safety nothing while a missing tool costs the owner a promise that goes nowhere.

## Promises now need something behind them

Conduct changes, paid for byte-by-byte against the 4096-character BB instruction ceiling: a promised later action needs a live job or armed monitor or an explicit "not started"; a missing tool is requested via `telegram_agent_request_capability` or named as the blocker. Two anchor tests updated to pin the new phrases; the overlay budget stays above its 400-character floor.

## Review focus

`plugin.ts` is the riskier half: the event-pulse read sits between the thread fetch and classification, adds one awaited SDK call per worker poll, and rechecks the executor fence after it. A failed event read degrades to the previous pulse rather than counting as death, so a BB API blip cannot retire a healthy worker.

Stacked on the unslop-upstream PR. Typecheck clean; full suite green on the stacked branch.
