### PR TITLE
fix(agent): resume blocked reviews with open PRs and delegate all tasks to fresh-worktree threads

### DIFF
--- a/skills/hanoon/driving-bb/SKILL.md
+++ b/skills/hanoon/driving-bb/SKILL.md
@@ -13,6 +13,24 @@ the BB app is yours to run.
 `bb guide` is the full reference and `bb guide <chapter>` the detail. Reach for
 it when something here is not enough, rather than guessing a flag.
 
+## A task means a spawned thread
+
+Work the owner asks for runs in its own BB thread, on a fresh worktree cut
+from the trunk. Your turn starts it, steers it, and reports it; it does not
+edit files or run the change itself. A shared checkout is where two tasks
+corrupt each other, so the worktree is not optional:
+
+```bash
+bb thread spawn --project <id> --parent-self \
+  --new-environment worktree --base-branch main \
+  --prompt "objective, constraints, deliverable, verification, what to report"
+```
+
+`--parent-self` keeps the child reporting to you, so its blockers reach you
+instead of dying quietly. Your own thread tools (`telegram_agent_create_thread`)
+already provision a fresh worktree from the project's base branch; this shape is
+for anything you spawn through the CLI.
+
 ## Never poll
 
 This is the rule that matters most. A loop of `sleep` and `bb thread show` burns

--- a/skills/skills.lock.json
+++ b/skills/skills.lock.json
@@ -351,7 +351,7 @@
     },
     {
       "path": "skills/hanoon/driving-bb/SKILL.md",
-      "sha256": "40d036f020e76f28bbb42d49eb63ed291cb2c56fcb0ee2d08141193842175cb9"
+      "sha256": "e66fc93e4940ac8372ea88d7c5a3d2d0668db5872e919046e0f82d2ab7ffd216"
     },
     {
       "path": "skills/hanoon/durable-boundary-audit/SKILL.md",

--- a/src/capabilities/catalog.ts
+++ b/src/capabilities/catalog.ts
@@ -82,7 +82,7 @@ const SKILL_DIGESTS = {
   "clean-code-guard": "4694ad1d36cdcff2e1bfe3b1f903bc21820b682a35385e0f8b382e2cce897be2",
   "dispatching-parallel-agents": "1968923066f3b707eb01d1992cdf4c42284c3855f70253b9cd5000ff45fca13c",
   "docs-guard": "8648f87ad021a87225d46a5c83c977e8e56594068a9f3fe4e4ad47da93f418ef",
-  "driving-bb": "40d036f020e76f28bbb42d49eb63ed291cb2c56fcb0ee2d08141193842175cb9",
+  "driving-bb": "e66fc93e4940ac8372ea88d7c5a3d2d0668db5872e919046e0f82d2ab7ffd216",
   "domain-modeling": "152e2c97239affb12a60c5f4a7e74ab546a49ae169688c81f4e2ccc42dafa579",
   "durable-boundary-audit": "5e0ce676aae53ced4e50e225eb1cb630d7d7f7c33769a63e7fb3886cedc9b44f",
   "executing-plans": "c4c3d8b628c51114cd165fb8246fe02744cd8be180032328391252e653028d9b",

--- a/src/controller/instructions.ts
+++ b/src/controller/instructions.ts
@@ -29,7 +29,7 @@ Every turn:
 
 What to do:
 - Asked how something is going: read its live activity and say what it is doing and waiting on. Never invent a percentage or ETA.
-- Open a thread, message it, stop or retry it. Do the next step rather than ask. Split independent questions and answer once.
+- A task runs in a spawned thread on a fresh trunk worktree, never inline. Do the next step rather than ask. Split independent questions and answer once.
 - Software changes go through a guarded job. List projects, then start, inspect, retry, cancel, or land it. \`choose_job\` means present those ids, never guess.
 - \`awaiting_confirmation\` with \`awaitingOwner: false\` is queued, not waiting on them. Never tell them to tap what no tool said they block.
 - A monitor wakes you when a thread settles or on a schedule: do it, then message the owner. Write it in full; your future self gets only that. Watch any visible thread; ones you start or message already are.
@@ -40,7 +40,7 @@ Memory:
 - Remember standing preferences, decisions, and corrections: the rule, not the conversation, replacing what proves wrong. Project knowledge lives under its project id.
 
 Your authority:
-- You run on the owner's machine with authority to act for them. They work only from Telegram and never open the BB app, so anything waiting for a click there is a dead end: do it.
+- You run on the owner's machine with authority to act for them. They only use Telegram, so anything waiting for a BB click is a dead end: do it.
 - Use the shell and \`bb\` CLI freely for anything BB can do, plus installed skills and MCP servers. Spawn threads with \`--parent-self\`, or blocks hit the owner. Never tell the owner to do something in BB: do it, or say what blocks you.`;
 
 const IDENTITY_HEADING = "Who you are — never a boundary:";

--- a/src/controller/tools.ts
+++ b/src/controller/tools.ts
@@ -6,6 +6,7 @@ import {
   isResumablePermanentFailure,
   isResumablePlanBlock,
   isResumableReviewBlock,
+  isResumableConfigurationBlock,
   isReviewedPrCompletionBlock,
   isRetryableJob,
   type Job,
@@ -1881,7 +1882,8 @@ export function registerControllerTools(bb: BbPluginApi, dependencies: ToolDepen
       if (jobResolution.outcome !== "job") return resolutionProjection(jobResolution);
       const job = jobResolution.job;
       if (job.cancelRequestedAt !== null) throw new Error("The requested job is not retryable");
-      if (isResumablePlanBlock(job) || isResumableReviewBlock(job) || isReviewedPrCompletionBlock(job)) {
+      if (isResumablePlanBlock(job) || isResumableReviewBlock(job) || isReviewedPrCompletionBlock(job) ||
+        isResumableConfigurationBlock(job)) {
         const queued = runControllerMutation(dependencies, authorized, context, (now) =>
           dependencies.store.requeueReviewAdmission(job.id, job.version, now));
         if (queued.outcome === "unavailable") throw new Error("The requested job is not retryable");

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -453,6 +453,23 @@ export function isReviewedPrCompletionBlock(
     && job.policy?.production === undefined;
 }
 
+/**
+ * A review group that settles as blocked (a dirty review worktree, evidence
+ * bound to the wrong head) parks its job at blocked/configuration. When the
+ * job still holds an open pull request, the blocked transition already knows
+ * how to resume from it; this is the admission-side voice of the same fact.
+ * Without it a transient environment condition became a permanent dead end.
+ */
+export function isResumableConfigurationBlock(
+  job: Pick<Job, "state" | "blockedReason" | "lastError" | "prNumber" | "cancelRequestedAt">,
+): boolean {
+  return job.state === "blocked"
+    && job.blockedReason === "configuration"
+    && job.lastError !== PRODUCTION_NOT_CONFIGURED
+    && job.prNumber !== null
+    && job.cancelRequestedAt === null;
+}
+
 export function shouldResumeExistingPr(
   job: Pick<Job, "prNumber" | "deliveryMode" | "resumeState">,
 ): boolean {
@@ -480,7 +497,8 @@ export function isRetryableJob(
   return isResumablePlanBlock(job)
     || isResumableReviewBlock(job)
     || isResumablePermanentFailure(job)
-    || isReviewedPrCompletionBlock(job);
+    || isReviewedPrCompletionBlock(job)
+    || isResumableConfigurationBlock(job);
 }
 
 export interface Job {

--- a/src/storage/autonomy-repository.ts
+++ b/src/storage/autonomy-repository.ts
@@ -17,6 +17,7 @@ import {
   isResumablePermanentFailure,
   isResumablePlanBlock,
   isResumableReviewBlock,
+  isResumableConfigurationBlock,
   isReviewedPrCompletionBlock,
   type Job,
   type JobEvent,
@@ -321,8 +322,9 @@ function assertJobIdentity(job: Job, input: AdmissionWriteInput): void {
 
 function assertContinuationState(job: Job, resumeEvent: AdmissionResumeEvent): void {
   if (resumeEvent === "CONTINUE_REVIEW" && !isResumablePlanBlock(job) &&
-    !isResumableReviewBlock(job) && !isReviewedPrCompletionBlock(job)) {
-    throw new AutonomyAdmissionConflictError(job.id, "review continuation requires a review-limit, plan-limit, or reviewed-PR completion block");
+    !isResumableReviewBlock(job) && !isReviewedPrCompletionBlock(job) &&
+    !isResumableConfigurationBlock(job)) {
+    throw new AutonomyAdmissionConflictError(job.id, "review continuation requires a review-limit, plan-limit, configuration, or reviewed-PR completion block");
   }
   if (resumeEvent === "RETRY" && !isResumablePermanentFailure(job) && (
     job.state !== "failed" || job.resumeState === null || job.cancelRequestedAt !== null
@@ -445,7 +447,8 @@ function currentExecutorLease(
 function resumeEventForAdmission(job: Job, resumeEvent: AdmissionResumeEvent): JobEvent | null {
   if (resumeEvent === "CONFIRMED" && job.state === "awaiting_confirmation") return { type: "CONFIRMED" };
   if (resumeEvent === "CONTINUE_REVIEW" && job.state === "blocked" &&
-    (isResumablePlanBlock(job) || isResumableReviewBlock(job) || isReviewedPrCompletionBlock(job))) {
+    (isResumablePlanBlock(job) || isResumableReviewBlock(job) || isReviewedPrCompletionBlock(job) ||
+      isResumableConfigurationBlock(job))) {
     return { type: "CONTINUE_REVIEW" };
   }
   if (resumeEvent === "RETRY" && (

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -3,6 +3,7 @@ import type Database from "better-sqlite3";
 import { createHash, randomUUID } from "node:crypto";
 import {
   isResumablePermanentFailure,
+  isResumableConfigurationBlock,
   isReviewedPrCompletionBlock,
   PRODUCTION_NOT_CONFIGURED,
   projectPolicySchema,
@@ -11838,7 +11839,7 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
     const admission = this.autonomyRepository.getAdmission(jobId);
     if (!job || job.version !== expectedVersion || job.state !== "blocked" ||
       (job.blockedReason !== "review_limit" && job.blockedReason !== "plan_limit" &&
-        !isReviewedPrCompletionBlock(job)) || !admission) {
+        !isReviewedPrCompletionBlock(job) && !isResumableConfigurationBlock(job)) || !admission) {
       return { outcome: "unavailable" };
     }
     if (job.projectId !== admission.projectId || job.policy?.projectId !== admission.projectId) {

--- a/tests/job-store.test.ts
+++ b/tests/job-store.test.ts
@@ -368,6 +368,40 @@ it("requeues a released plan-limit block the same way as a review-limit block", 
   });
 });
 
+// A review group settled as blocked (a dirty review worktree at the wrong
+// moment) parked a real job at blocked/configuration with an open pull
+// request, and nothing could ever take it back: the transition supported
+// resuming from the PR, but no admission predicate offered it. That job sat
+// dead until a person edited the database or gave up on it.
+it("requeues a configuration-blocked job that still has an open pull request", () => {
+  const { db, store } = storeFixture();
+  const blocked = store.createJob({ id: "job_config_blocked", sourceUpdateId: 106, requestText: "config blocked", now: 1_000 });
+  const selected = store.applyJobEvent(blocked.id, blocked.version, {
+    type: "PROJECT_SELECTED",
+    projectId: "proj_1",
+    policyVersion: 1,
+    policy: policyFixture(),
+  }, 1_050);
+  store.queueAdmission({
+    jobId: blocked.id,
+    expectedVersion: selected.version,
+    projectId: "proj_1",
+    resumeEvent: "CONFIRMED",
+    now: 1_050,
+  });
+  db.prepare(
+    `UPDATE jobs SET state = 'blocked', blocked_reason = 'configuration', pr_number = 42,
+       pr_url = 'https://github.com/example/repo/pull/42',
+       implementation_thread_id = 'thr_impl', review_cycle = 0 WHERE id = ?`,
+  ).run(blocked.id);
+  db.prepare("UPDATE job_admissions SET state = 'released', released_at = 1_100, release_reason = 'review_blocked' WHERE job_id = ?").run(blocked.id);
+
+  expect(store.requeueReviewAdmission(blocked.id, selected.version, 1_200)).toMatchObject({
+    outcome: "queued",
+    admission: { state: "queued", resumeEvent: "CONTINUE_REVIEW" },
+  });
+});
+
 it("requeues a released failed job and resumes it only after capacity is reacquired", () => {
   const { db, store } = storeFixture();
   const draft = store.createJob({ id: "job_released_retry", sourceUpdateId: 103, requestText: "retry", now: 1_000 });


### PR DESCRIPTION
Two changes from today's production rescue and the owner's new standing rule.

## A blocked review with an open PR is no longer a dead end

The Areliaa job's review group settled as blocked ("review environment worktree is dirty", a transient condition from work stranded by the old watchdog bug), which parked the job at blocked/configuration. The blocked transition already knows how to resume such a job from its open pull request, but no admission predicate ever offered CONTINUE_REVIEW for that shape, so the job could not be retried by any tool, CLI command, or admission path. It sat dead until a person intervened.

`isResumableConfigurationBlock` names the shape (blocked, configuration, an open PR, not the production-not-configured completion case, no cancel requested) and joins the existing predicate trio in the admission gate, the continuation assertion, the retry tool, and `requeueReviewAdmission`. The regression test drives the exact production state through the store and asserts it queues a CONTINUE_REVIEW admission.

## Owner tasks always run in spawned threads on fresh trunk worktrees

Standing rule from the owner: a task means a BB thread on a new worktree cut from main, never inline work in the controller's own turn. The conduct now says so (paid for within the 4096-character instruction ceiling by tightening two unpinned lines), and the driving-bb skill opens with the rule and the exact spawn shape, including `--parent-self` so child blockers reach the controller. `telegram_agent_create_thread` already provisions managed worktrees from the project base branch, so the tool path needed no change; the skill covers CLI spawns.

Skill digest bookkeeping (bundle lock and capability catalog) follows the same convention the unslop upstreaming used: both carry the new file hash.

Typecheck clean; full suite green.
