### PR TITLE
fix(pipeline): configuration-block resume re-resolves the PR head

### DIFF
--- a/src/domain/state-machine.ts
+++ b/src/domain/state-machine.ts
@@ -1,6 +1,7 @@
 import {
   isResumablePermanentFailure,
   isResumablePlanBlock,
+  isResumableConfigurationBlock,
   isReviewedPrCompletionBlock,
   isSmallFixJob,
   mergesWithoutProduction,
@@ -890,6 +891,17 @@ function transitionBlocked(job: Job, event: JobEvent, effects: JobEffect[]): voi
     return;
   }
   if (job.prNumber !== null) {
+    // A configuration block means the review group settled against this very
+    // head (a dirty worktree, drifted evidence). Resuming pinned to it replays
+    // that settled verdict within a reconcile pass and re-blocks. Re-resolving
+    // the head gives the job fresh validation and a fresh review group.
+    if (isResumableConfigurationBlock(job)) {
+      job.blockedReason = null;
+      job.lastError = null;
+      job.resumeState = null;
+      invalidateDriftedHead(job, effects);
+      return;
+    }
     resumeFromExistingPr(job, effects);
     return;
   }

--- a/tests/state-machine.test.ts
+++ b/tests/state-machine.test.ts
@@ -227,6 +227,32 @@ describe("job state machine", () => {
     expect(failed.effects.map((effect) => effect.kind)).toEqual(["spawn_review"]);
   });
 
+  // The Areliaa job resumed pinned to the head its review group had settled
+  // "blocked" against, so the stale verdict replayed and re-blocked it within
+  // a second. A configuration block resumes by re-resolving the pull request
+  // head, which gives it a fresh validation and a fresh review group.
+  it("re-resolves the head when a configuration-blocked review continues", () => {
+    const resumed = transition(
+      stateJob("blocked", {
+        blockedReason: "configuration",
+        prNumber: 42,
+        prUrl: "https://github.test/pr/42",
+        prHeadSha: sha(),
+        implementationThreadId: "thr_impl",
+      }),
+      { type: "CONTINUE_REVIEW" },
+      2_244,
+    );
+    expect(resumed.job).toMatchObject({
+      state: "resolving_pr_head",
+      blockedReason: null,
+      lastError: null,
+      prHeadSha: null,
+      prNumber: 42,
+    });
+    expect(resumed.effects.map((effect) => effect.kind)).toEqual(["revoke_approvals", "resolve_pr_head"]);
+  });
+
   it("retries a permanent effect failure when the next step is already known", () => {
     const retried = transition(
       stateJob("blocked", {


### PR DESCRIPTION
Resuming a configuration-blocked job pinned to its recorded head replayed the very review verdict that blocked it, within one reconcile pass; observed live on the Areliaa job after PR #21's resume path landed. CONTINUE_REVIEW on that shape now clears the head and receipts and re-resolves the pull request, giving the job a fresh validation and a fresh review group. Verified by explicit exit codes: typecheck clean, full suite green (4558 tests).