### PR TITLE
fix(review): read the PR's own diff instead of the stale local trunk

### DIFF
--- a/src/bb/handoffs.ts
+++ b/src/bb/handoffs.ts
@@ -231,6 +231,12 @@ export function buildReviewPacket(
   reviewLens: "quality" | "risk" | "consensus" = "quality",
   capability?: CapabilityWorkOrderEnvelope,
   reviewStage?: "diff-guards" | "review" | "task-review" | "integrated-review",
+  /** The exact command that produced `diff`, so the reviewer verifies the
+   * digest against the same source instead of improvising a local diff. A
+   * local `<base>...HEAD` reads against whatever the worktree's base ref
+   * happens to be, and a stale one once put nine thousand of main's own
+   * lines in front of a reviewer as if this job had written them. */
+  diffSource?: string,
 ): HandoffArtifact {
   const prNumber = job.prNumber;
   if (typeof prNumber !== "number" || !Number.isInteger(prNumber) || prNumber < 1) {
@@ -299,6 +305,7 @@ export function buildReviewPacket(
     },
     capabilityProfile: capability ?? null,
     diffDigest,
+    diffSource: diffSource ?? null,
     guardContract,
     lensInstruction: reviewLens === "risk"
       ? "Focus independently on security, destructive actions, data integrity, concurrency, rollback, and operational failure modes."

--- a/src/bb/runner.ts
+++ b/src/bb/runner.ts
@@ -563,16 +563,18 @@ export class BbRunner {
     requirePullRequestSnapshot(job, pullRequest);
     if (job.prHeadSha === null) throw new Error("Active job has no authoritative review head SHA");
     const remoteHeadSha = job.prHeadSha;
+    const reviewDiff = await this.reviewDiff(environmentId, job, snapshot.diff);
     const artifact = buildReviewPacket(
       job,
       policy,
       remoteHeadSha,
-      await this.reviewDiff(environmentId, job, snapshot.diff),
+      reviewDiff.diff,
       attempt.reviewLens ?? "quality",
       attempt.capabilityProfile,
       job.taskRecipe === "architectural"
         ? role === "final-review" ? "integrated-review" : "task-review"
         : job.taskRecipe === "direct" ? "diff-guards" : "review",
+      reviewDiff.source,
     );
     const project = projectId(job, policy);
     const uploaded = await this.upload(project, artifact);
@@ -653,22 +655,42 @@ export class BbRunner {
     return this.sdk.environments.pullRequest({ environmentId });
   }
 
-  private async reviewDiff(environmentId: string, job: Job, snapshot: EnvironmentDiff): Promise<string> {
+  /**
+   * The diff a reviewer reads, with where it came from.
+   *
+   * GitHub's own pull-request diff is preferred whenever the job has one: it
+   * is computed against the true remote base, which is also exactly what a
+   * merge would land. The environment diff reads against the worktree's local
+   * base ref, and a stale one once served a reviewer nine thousand lines of
+   * main's own history as if this job had written them — every cycle of that
+   * review demanded out-of-scope fixes until the job hit its review limit.
+   * The local diff remains the answer for a job that has no pull request yet.
+   */
+  private async reviewDiff(
+    environmentId: string,
+    job: Job,
+    snapshot: EnvironmentDiff,
+  ): Promise<{ diff: string; source: string }> {
+    if (job.prNumber !== null) {
+      const command = `gh pr diff ${String(job.prNumber)}`;
+      try {
+        const result = await new TerminalCommandRunner(this.sdk).run({
+          scope: { kind: "environment", environmentId },
+          title: `Telegram review diff ${job.id}`,
+          command,
+          timeoutMs: 60_000,
+        });
+        if (result.outcome === "exited" && result.exitCode === 0 && result.output.trim().length > 0) {
+          return { diff: result.output, source: command };
+        }
+      } catch {
+        // GitHub being unreachable must not stop review; the environment diff
+        // below is the answer it always was, stale-base risk and all.
+      }
+    }
     const local = environmentDiffText(snapshot);
-    if (local !== null) return local;
-    if (job.prNumber === null) {
-      throw new Error("Complete environment diff is unavailable and the job has no pull request");
-    }
-    const result = await new TerminalCommandRunner(this.sdk).run({
-      scope: { kind: "environment", environmentId },
-      title: `Telegram review diff ${job.id}`,
-      command: `gh pr diff ${String(job.prNumber)}`,
-      timeoutMs: 60_000,
-    });
-    if (result.outcome === "exited" && result.exitCode === 0 && result.output.trim().length > 0) {
-      return result.output;
-    }
-    throw new Error("Complete review diff is unavailable from the environment and GitHub");
+    if (local !== null) return { diff: local, source: "environment diff against the local base branch" };
+    throw new Error("Complete review diff is unavailable from GitHub and the environment");
   }
 }
 

--- a/tests/bb-runner.test.ts
+++ b/tests/bb-runner.test.ts
@@ -335,6 +335,26 @@ it("spawns review as a hidden child in the exact implementation environment", as
   });
 });
 
+// A stale local base ref once served a reviewer nine thousand lines of main's
+// own history as this job's diff, and every review cycle demanded fixes to
+// code the job never touched until it hit its review limit. GitHub's own
+// pull-request diff reads against the true remote base, which is also exactly
+// what a merge would land.
+it("prefers the GitHub pull-request diff over the environment snapshot", async () => {
+  const { calls, runner } = runnerFixture();
+  const reviewAttempt = attempt("attempt_review_preferred");
+
+  await runner.spawnReview(selectedJob, reviewAttempt, policyFixture());
+
+  const uploaded = calls.attachments[0] as { clientFile: Uint8Array };
+  const packet = JSON.parse(new TextDecoder().decode(uploaded.clientFile)) as {
+    diff: string;
+    diffSource: string;
+  };
+  expect(packet.diff).toContain("fallback");
+  expect(packet.diffSource).toBe("gh pr diff 42");
+});
+
 it("falls back to the GitHub pull-request diff when the environment snapshot is truncated", async () => {
   const { calls, runner } = runnerFixture();
   const reviewAttempt = attempt("attempt_review_truncated");


### PR DESCRIPTION
The Areliaa job hit its review limit because the review packet diffed against the environment's local base ref, which sat 112 files and 9038 lines behind origin. The reviewer honestly reviewed main's own history as this job's change and demanded out-of-scope fixes every cycle, which the work order forbade, so the loop could never converge. The local trunk cannot simply be fast-forwarded: it is checked out in the source workspace, so git refuses the update.

GitHub's pull-request diff becomes the preferred review source whenever a PR exists; it reads against the true remote base, exactly what a merge would land. The packet records the command that produced its diff (`diffSource`) so the reviewer verifies the digest against the same source. An unreachable GitHub degrades to the environment diff, preserving prior behavior for PR-less jobs and harnesses without terminals.

Verified by explicit exit codes: typecheck clean, 4564 tests pass.