### PR TITLE
fix(pipeline): resume a review-limit block into patching

### DIFF
--- a/src/domain/state-machine.ts
+++ b/src/domain/state-machine.ts
@@ -918,8 +918,18 @@ function transitionBlocked(job: Job, event: JobEvent, effects: JobEffect[]): voi
   job.blockedReason = null;
   job.lastError = null;
   job.reviewBlockAt = job.reviewCycle + 3;
-  job.state = "reviewing";
-  emitEffect(job, effects, "spawn_review", job.prHeadSha ? { headSha: job.prHeadSha } : {});
+  // The limit is only ever reached while asking for another patch, so the work
+  // this job still owes is a fix, not another opinion. Resuming into review
+  // asked the same question of the same commit, and a review that already
+  // requested changes at this head refuses to answer twice: the job spent
+  // every restored cycle being told a new head is required and never produced
+  // one. Resuming into remediation is what makes that head exist.
+  job.state = "remediating";
+  emitEffect(job, effects, "send_remediation", {
+    summary: "Address the outstanding review findings that stopped this job at its review limit.",
+    findings: [],
+    reasons: [],
+  });
 }
 
 function planBlockSummary(summary: string): string {

--- a/src/services/effect-runner.ts
+++ b/src/services/effect-runner.ts
@@ -1781,9 +1781,16 @@ export class EffectRunner {
   }
 
   private async sendRemediation(effect: StoredEffect, job: Job): Promise<void> {
-    const findings = Array.isArray(recordPayload(effect).findings)
+    const payloadFindings = Array.isArray(recordPayload(effect).findings)
       ? recordPayload(effect).findings as ReviewFinding[]
       : [];
+    // Hitting the review limit blocks before any remediation is sent, so the
+    // findings that stopped the job are carried only by the review attempt
+    // that produced them. Resuming with an empty list would ask the worker to
+    // fix nothing at all, so the last review's own findings are recovered here.
+    const findings = payloadFindings.length > 0
+      ? payloadFindings
+      : this.lastReviewFindings(job);
     const reasons = Array.isArray(recordPayload(effect).reasons)
       ? (recordPayload(effect).reasons as unknown[]).filter((reason): reason is string => typeof reason === "string").slice(0, 20)
       : [];
@@ -1794,6 +1801,19 @@ export class EffectRunner {
     this.renewOperationFence(effect);
     const current = this.dependencies.store.getJob(job.id);
     if (current?.state === "remediating") this.applyEvent(job.id, current.version, { type: "REMEDIATION_SENT" });
+  }
+
+  /** The findings of the review this job last heard from, or none. */
+  private lastReviewFindings(job: Job): ReviewFinding[] {
+    if (!job.reviewThreadId) return [];
+    const attempt = this.dependencies.store.getAttemptByThreadId(job.reviewThreadId);
+    if (!attempt || attempt.jobId !== job.id || !attempt.resultJson) return [];
+    try {
+      const parsed = JSON.parse(attempt.resultJson) as { findings?: unknown };
+      return Array.isArray(parsed.findings) ? parsed.findings.slice(0, 20) as ReviewFinding[] : [];
+    } catch {
+      return [];
+    }
   }
 
   private async runValidation(effect: StoredEffect, job: Job, final = false): Promise<void> {

--- a/tests/state-machine.test.ts
+++ b/tests/state-machine.test.ts
@@ -590,7 +590,12 @@ describe("job state machine", () => {
     if (state === "blocked") expect(result.job.blockedReason).toBe("review_limit");
   });
 
-  it("continues review only from a review-limit block and advances the next block threshold", () => {
+  // The limit is only reached while asking for another patch, so what the job
+  // still owes is a fix. Resuming into review asked the same question of the
+  // same commit, and a review that already requested changes at this head
+  // refuses to answer twice: the job burned every restored cycle being told a
+  // new head is required and never produced one.
+  it("continues patching only from a review-limit block and advances the next block threshold", () => {
     const result = transition(
       stateJob("blocked", {
         reviewCycle: 3,
@@ -602,10 +607,10 @@ describe("job state machine", () => {
       3_500,
     );
 
-    expect(result.job.state).toBe("reviewing");
+    expect(result.job.state).toBe("remediating");
     expect(result.job.blockedReason).toBeNull();
     expect(result.job.reviewBlockAt).toBe(6);
-    expect(result.effects.map((item) => item.kind)).toEqual(["spawn_review"]);
+    expect(result.effects.map((item) => item.kind)).toEqual(["send_remediation"]);
     expect(() => transition(stateJob("blocked", { blockedReason: "configuration" }), { type: "CONTINUE_REVIEW" }, 3_500)).toThrow(IllegalTransitionError);
   });
 


### PR DESCRIPTION
A job that hits its review limit is a job that was being asked for another patch, so the work it still owes is a fix. The resume sent it back into review instead, which asks the same question of the same commit, and a review that already requested changes at that head refuses to answer twice: every restored cycle was spent being told "a new head is required after changes were requested", and none of them produced one. That is the loop the Areliaa job has been stuck in.

Blocking on the limit also happens inside `enterPatch` before any `send_remediation` is emitted, so the findings that caused the block are carried only by the review attempt that produced them. The resume now recovers them from that attempt; asking a worker to fix an empty list is not a resume.

Verified by explicit exit codes: typecheck clean, 4565 tests pass.