### PR TITLE
fix(pipeline): make the review-limit patch resume reachable

### DIFF
--- a/src/domain/state-machine.ts
+++ b/src/domain/state-machine.ts
@@ -891,6 +891,13 @@ function transitionBlocked(job: Job, event: JobEvent, effects: JobEffect[]): voi
     completeReviewedWork(job, effects);
     return;
   }
+  // Checked before the pull-request branch below, which would otherwise send
+  // every job that has one back into review. A plan-limit block recorded under
+  // the old reason is excluded: it has no implementation to patch.
+  if (job.blockedReason === "review_limit" && !isResumablePlanBlock(job)) {
+    resumeIntoPatching(job, effects);
+    return;
+  }
   if (job.prNumber !== null) {
     // A configuration block means the review group settled against this very
     // head (a dirty worktree, drifted evidence). Resuming pinned to it replays
@@ -914,16 +921,21 @@ function transitionBlocked(job: Job, event: JobEvent, effects: JobEffect[]): voi
     emitEffect(job, effects, "spawn_plan");
     return;
   }
-  if (job.blockedReason !== "review_limit") illegal(job, event);
+  illegal(job, event);
+}
+
+/**
+ * The review limit is only ever reached while asking for another patch, so the
+ * work this job still owes is a fix, not another opinion. Resuming into review
+ * asked the same question of the same commit, and a review that already
+ * requested changes at that head refuses to answer twice: the job spent every
+ * restored cycle being told a new head is required and never produced one.
+ * Resuming into remediation is what makes that head exist.
+ */
+function resumeIntoPatching(job: Job, effects: JobEffect[]): void {
   job.blockedReason = null;
   job.lastError = null;
   job.reviewBlockAt = job.reviewCycle + 3;
-  // The limit is only ever reached while asking for another patch, so the work
-  // this job still owes is a fix, not another opinion. Resuming into review
-  // asked the same question of the same commit, and a review that already
-  // requested changes at this head refuses to answer twice: the job spent
-  // every restored cycle being told a new head is required and never produced
-  // one. Resuming into remediation is what makes that head exist.
   job.state = "remediating";
   emitEffect(job, effects, "send_remediation", {
     summary: "Address the outstanding review findings that stopped this job at its review limit.",

--- a/tests/state-machine.test.ts
+++ b/tests/state-machine.test.ts
@@ -611,6 +611,26 @@ describe("job state machine", () => {
     expect(result.job.blockedReason).toBeNull();
     expect(result.job.reviewBlockAt).toBe(6);
     expect(result.effects.map((item) => item.kind)).toEqual(["send_remediation"]);
+
+    // Every real job at this limit already has a pull request, and the branch
+    // that resumes one used to intercept first, so the patch resume never ran
+    // where it was needed.
+    const withPullRequest = transition(
+      stateJob("blocked", {
+        reviewCycle: 6,
+        reviewBlockAt: 6,
+        blockedReason: "review_limit",
+        prNumber: 42,
+        prUrl: "https://github.test/pr/42",
+        prHeadSha: sha(),
+        implementationThreadId: "thr_impl",
+      }),
+      { type: "CONTINUE_REVIEW" },
+      3_600,
+    );
+    expect(withPullRequest.job.state).toBe("remediating");
+    expect(withPullRequest.job.reviewBlockAt).toBe(9);
+    expect(withPullRequest.effects.map((item) => item.kind)).toEqual(["send_remediation"]);
     expect(() => transition(stateJob("blocked", { blockedReason: "configuration" }), { type: "CONTINUE_REVIEW" }, 3_500)).toThrow(IllegalTransitionError);
   });
 


### PR DESCRIPTION
PR #27 routed a review-limit block into patching, but placed the check below the branch that resumes any job holding a pull request. Every job that reaches this limit holds one, so the new path never ran and the Areliaa job went straight back into review, exactly as before.

The check now runs ahead of that branch. A plan-limit block recorded under the legacy `review_limit` reason is still excluded, since it has no implementation to patch. The regression test pins the case the first attempt missed: a review-limit block that has a pull request.

Verified by explicit exit codes: typecheck clean, 4565 tests pass.