### PR TITLE
feat: add navigator planning frontier

### DIFF
--- a/src/navigator/executor.ts
+++ b/src/navigator/executor.ts
@@ -9,7 +9,10 @@ import type {
   NavigatorSnapshot,
 } from "./models";
 import { NAVIGATOR_RESEARCH_STEP_CONTRACT } from "./models";
-import type { NavigatorPlanningPublication } from "./planning-publisher";
+import {
+  NavigatorPublicationDriftError,
+  type NavigatorPlanningPublication,
+} from "./planning-publisher";
 import { navigatorStepContract } from "./planning-contracts";
 
 export interface WorkflowNavigator {
@@ -207,6 +210,7 @@ export class NavigatorWorkflowExecutor {
         observedExternalStateDigest: skillRun.observedExternalStateDigest,
         result: durableResult?.result ?? skillRun.result,
         ...(publication === null ? {} : { publishedArtifactBindings: publication.artifactBindings }),
+        ...(publication === null ? {} : { reconciledArtifactIds: publication.reconciledArtifactIds }),
         ...(policyFailureReason === undefined ? {} : { policyFailureReason }),
         ownerId: fence.ownerId,
         generation: fence.generation,
@@ -215,6 +219,21 @@ export class NavigatorWorkflowExecutor {
       if (!settled) throw new Error("navigator skill settlement fence was lost");
       return true;
     } catch (error) {
+      const durableResult = this.dependencies.store.getNavigatorPlanningResult(attempt.id);
+      if (error instanceof NavigatorPublicationDriftError && durableResult) {
+        const settled = this.dependencies.store.settleNavigatorSkillAttempt({
+          attemptId: attempt.id,
+          effectIdempotencyKey: effect.idempotencyKey,
+          observedExternalStateDigest: durableResult.observedExternalStateDigest,
+          result: durableResult.result,
+          policyFailureReason: error.reasonCode,
+          ownerId: fence.ownerId,
+          generation: fence.generation,
+          now: this.dependencies.clock.now(),
+        });
+        if (!settled) throw new Error("navigator publication drift settlement fence was lost");
+        return true;
+      }
       this.dependencies.store.failEffect(
         effect.idempotencyKey,
         fence.ownerId,

--- a/src/navigator/executor.ts
+++ b/src/navigator/executor.ts
@@ -9,6 +9,8 @@ import type {
   NavigatorSnapshot,
 } from "./models";
 import { NAVIGATOR_RESEARCH_STEP_CONTRACT } from "./models";
+import type { NavigatorPlanningPublication } from "./planning-publisher";
+import { navigatorStepContract } from "./planning-contracts";
 
 export interface WorkflowNavigator {
   propose(snapshot: NavigatorSnapshot): Promise<unknown>;
@@ -38,6 +40,13 @@ export type NavigatorWorkflowExecutorDependencies = Readonly<{
   navigator: WorkflowNavigator;
   observeInference(snapshot: NavigatorSnapshot): Promise<NavigatorInferenceObservation>;
   skillRunner: NavigatorSkillRunner;
+  planningPublisher?: Readonly<{
+    publish(
+      attempt: NavigatorSkillAttempt,
+      result: unknown,
+      fence: Readonly<{ ownerId: string; generation: number; now: number }>,
+    ): Promise<NavigatorPlanningPublication>;
+  }>;
   modelRoute(): ModelRoute;
   clock: { now(): number };
   leaseMs?: number;
@@ -114,9 +123,10 @@ export class NavigatorWorkflowExecutor {
         reject(runSignal.reason ?? new Error("navigator skill run was aborted"));
       }, { once: true });
     });
+    const contract = navigatorStepContract(attempt.skillId) ?? NAVIGATOR_RESEARCH_STEP_CONTRACT;
     const timeout = setTimeout(() => {
       timeoutAbort.abort(new Error("navigator skill step timed out"));
-    }, NAVIGATOR_RESEARCH_STEP_CONTRACT.timeoutMs);
+    }, contract.timeoutMs);
     const renewal = setInterval(() => {
       try {
         const renewed = this.dependencies.store.renewJobOperationFences({
@@ -148,10 +158,17 @@ export class NavigatorWorkflowExecutor {
           if (!bound) throw new Error("navigator skill resource fence was lost");
         },
       };
-      const skillRun = await Promise.race([
-        this.dependencies.skillRunner.run(attempt, hooks, runSignal),
-        interruption,
-      ]);
+      const persistedResult = this.dependencies.store.getNavigatorPlanningResult(attempt.id);
+      const skillRun = persistedResult === null
+        ? await Promise.race([
+          this.dependencies.skillRunner.run(attempt, hooks, runSignal),
+          interruption,
+        ])
+        : {
+          resource: attempt.resource!,
+          observedExternalStateDigest: persistedResult.observedExternalStateDigest,
+          result: persistedResult.result,
+        };
       const returnedDifferentResource = attempt.resource !== null && (
         attempt.resource.kind !== skillRun.resource.kind || attempt.resource.id !== skillRun.resource.id
       );
@@ -161,11 +178,35 @@ export class NavigatorWorkflowExecutor {
         rebound.resource.id === skillRun.resource.id
         ? undefined
         : "bb_resource_mismatch";
+      const durableResult = policyFailureReason === undefined
+        ? persistedResult ?? this.dependencies.store.recordNavigatorPlanningResult({
+          attemptId: attempt.id,
+          effectIdempotencyKey: effect.idempotencyKey,
+          observedExternalStateDigest: skillRun.observedExternalStateDigest,
+          result: skillRun.result,
+          ownerId: fence.ownerId,
+          generation: fence.generation,
+          now: this.dependencies.clock.now(),
+        })
+        : null;
+      let publication: NavigatorPlanningPublication | null = null;
+      if (durableResult && this.dependencies.planningPublisher) {
+        publication = await this.dependencies.planningPublisher.publish(
+          attempt,
+          durableResult.result,
+          {
+            ownerId: fence.ownerId,
+            generation: fence.generation,
+            now: this.dependencies.clock.now(),
+          },
+        );
+      }
       const settled = this.dependencies.store.settleNavigatorSkillAttempt({
         attemptId: attempt.id,
         effectIdempotencyKey: effect.idempotencyKey,
         observedExternalStateDigest: skillRun.observedExternalStateDigest,
-        result: skillRun.result,
+        result: durableResult?.result ?? skillRun.result,
+        ...(publication === null ? {} : { publishedArtifactBindings: publication.artifactBindings }),
         ...(policyFailureReason === undefined ? {} : { policyFailureReason }),
         ownerId: fence.ownerId,
         generation: fence.generation,

--- a/src/navigator/models.ts
+++ b/src/navigator/models.ts
@@ -49,7 +49,7 @@ export const navigatorProposalSchema = z.discriminatedUnion("kind", [
     ...proposalBase,
     kind: z.literal("invoke_skill"),
     skillId: identifierSchema,
-    subjectArtifactIds: z.array(identifierSchema).min(1).max(32),
+    subjectArtifactIds: z.array(identifierSchema).max(32),
     objective: boundedTextSchema,
   }).strict(),
   z.object({
@@ -165,14 +165,15 @@ export type NavigatorSkillStepContract = Readonly<{
   id: string;
   revision: number;
   skillId: string;
-  invocationClass: "model";
+  invocationClass: "model" | "user";
   allowedArtifactKinds: readonly string[];
-  operationClass: "read_only";
+  minimumSubjects: number;
+  operationClass: "read_only" | "artifact_write";
   resourceClass: "bb_thread_read_only";
-  inputSchema: "navigator-research-input-v1";
-  resultSchema: "navigator-research-result-v1";
+  inputSchema: "navigator-research-input-v1" | "navigator-planning-input-v1";
+  resultSchema: string;
   mandatoryEvidence: readonly string[];
-  modelPools: readonly ["strong"];
+  modelPools: readonly ("fast" | "standard" | "strong")[];
   timeoutMs: number;
   maximumResultBytes: number;
   retryClass: "resume_bound_resource";
@@ -189,6 +190,7 @@ const unsignedResearchContract = {
   skillId: "research",
   invocationClass: "model",
   allowedArtifactKinds: ["map", "specification", "decision_ticket", "implementation_ticket"],
+  minimumSubjects: 1,
   operationClass: "read_only",
   resourceClass: "bb_thread_read_only",
   inputSchema: "navigator-research-input-v1",
@@ -246,7 +248,7 @@ export function assertModelRouteForContract(
   contract: NavigatorSkillStepContract,
 ): ModelRoute {
   const parsed = modelRouteSchema.parse(route);
-  if (!contract.modelPools.includes(parsed.pool as "strong")) {
+  if (!contract.modelPools.includes(parsed.pool)) {
     throw new TypeError(`model pool ${parsed.pool} is outside the step contract`);
   }
   return parsed;
@@ -298,7 +300,14 @@ export type NavigatorSkillAttempt = Readonly<{
   stepContractRevision: number;
   stepContractDigest: string;
   catalogDigest: string;
-  stepInput: NavigatorResearchInput;
+  stepInput: NavigatorResearchInput | Readonly<{
+    kind: "navigator_planning_input";
+    skillId: string;
+    objective: string;
+    artifactBindings: readonly NavigatorArtifactBinding[];
+    evidenceRefs: readonly string[];
+    routingDecisionDigest: string | null;
+  }>;
   stepInputDigest: string;
   modelRoute: ModelRoute;
   artifactBindings: readonly NavigatorArtifactBinding[];
@@ -319,4 +328,34 @@ export type NavigatorWorkflowStepOutcome = Readonly<{
   artifactEvidence: readonly z.infer<typeof researchArtifactEvidenceSchema>[];
   resultDigest: string;
   recordedAt: number;
+}>;
+
+export type NavigatorPlanningResultRecord = Readonly<{
+  attemptId: string;
+  workflowStepId: string;
+  skillId: string;
+  result: unknown;
+  resultDigest: string;
+  observedExternalStateDigest: string;
+  recordedAt: number;
+}>;
+
+export type NavigatorRoutingDecision = Readonly<{
+  decisionDigest: string;
+  jobId: string;
+  question: string;
+  candidateSkillIds: readonly string[];
+  rationale: string;
+  evidenceRefs: readonly string[];
+  consultationStepId: string;
+  recordedAt: number;
+  advice: Readonly<{
+    attemptId: string;
+    advice: string;
+    suggestedSkillIds: readonly string[];
+    evidenceRefs: readonly string[];
+    resultDigest: string;
+    recordedAt: number;
+  }> | null;
+  blocked: boolean;
 }>;

--- a/src/navigator/models.ts
+++ b/src/navigator/models.ts
@@ -342,6 +342,7 @@ export type NavigatorPlanningResultRecord = Readonly<{
 
 export type NavigatorRoutingDecision = Readonly<{
   decisionDigest: string;
+  scopeDigest: string;
   jobId: string;
   question: string;
   candidateSkillIds: readonly string[];

--- a/src/navigator/planning-contracts.ts
+++ b/src/navigator/planning-contracts.ts
@@ -1,0 +1,307 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import {
+  NAVIGATOR_RESEARCH_STEP_CONTRACT,
+  artifactBindingSchema,
+  type NavigatorArtifactBinding,
+  type NavigatorSkillStepContract,
+} from "./models";
+
+const identifierSchema = z.string().trim().min(1).max(256);
+const boundedTextSchema = z.string().trim().min(1).max(8_000);
+const evidenceRefsSchema = z.array(z.string().trim().min(1).max(1_024)).max(128);
+const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/u);
+
+const artifactDraftSchema = z.object({
+  title: z.string().trim().min(1).max(512),
+  body: z.string().trim().min(1).max(65_536),
+  acceptanceCriteria: z.array(z.string().trim().min(1).max(2_048)).max(128),
+}).strict();
+
+const artifactEvidenceSchema = z.object({
+  artifactId: identifierSchema,
+  snapshotId: identifierSchema,
+  snapshotDigest: sha256Schema,
+  finding: boundedTextSchema,
+  evidenceRefs: evidenceRefsSchema,
+}).strict();
+
+const setupResultSchema = z.object({
+  kind: z.literal("setup_result"),
+  summary: boundedTextSchema,
+  trackerKind: z.enum(["github", "local_markdown"]),
+  trackerNamespace: z.string().trim().min(1).max(1_024),
+  evidenceRefs: evidenceRefsSchema,
+}).strict();
+
+const wayfinderResultSchema = z.object({
+  kind: z.literal("wayfinder_result"),
+  summary: boundedTextSchema,
+  map: artifactDraftSchema,
+  decisionTickets: z.array(artifactDraftSchema.extend({
+    blockedBy: z.array(z.number().int().min(0).max(29)).max(30),
+  }).strict()).min(1).max(30),
+  evidenceRefs: evidenceRefsSchema,
+}).strict();
+
+const toSpecResultSchema = z.object({
+  kind: z.literal("to_spec_result"),
+  summary: boundedTextSchema,
+  specification: artifactDraftSchema,
+  evidenceRefs: evidenceRefsSchema,
+}).strict();
+
+const toTicketsResultSchema = z.object({
+  kind: z.literal("to_tickets_result"),
+  summary: boundedTextSchema,
+  tickets: z.array(artifactDraftSchema.extend({
+    blockedBy: z.array(z.number().int().min(0).max(31)).max(32),
+  }).strict()).min(1).max(32),
+  evidenceRefs: evidenceRefsSchema,
+}).strict();
+
+const prototypeResultSchema = z.object({
+  kind: z.literal("prototype_result"),
+  summary: boundedTextSchema,
+  verdict: boundedTextSchema,
+  assetRef: z.string().trim().min(1).max(2_048),
+  artifactEvidence: z.array(artifactEvidenceSchema).min(1).max(32),
+}).strict();
+
+const handoffResultSchema = z.object({
+  kind: z.literal("handoff_result"),
+  summary: boundedTextSchema,
+  handoffRef: z.string().trim().min(1).max(2_048),
+  evidenceRefs: evidenceRefsSchema,
+}).strict();
+
+const askMattResultSchema = z.object({
+  kind: z.literal("ask_matt_result"),
+  decisionDigest: sha256Schema,
+  advice: boundedTextSchema,
+  suggestedSkillIds: z.array(identifierSchema).max(32),
+  evidenceRefs: evidenceRefsSchema,
+}).strict();
+
+export const navigatorPlanningResultSchema = z.discriminatedUnion("kind", [
+  setupResultSchema,
+  wayfinderResultSchema,
+  toSpecResultSchema,
+  toTicketsResultSchema,
+  prototypeResultSchema,
+  handoffResultSchema,
+  askMattResultSchema,
+]);
+
+export type NavigatorPlanningResult = Readonly<z.infer<typeof navigatorPlanningResultSchema>>;
+
+export const navigatorPlanningInputSchema = z.object({
+  kind: z.literal("navigator_planning_input"),
+  skillId: identifierSchema,
+  objective: boundedTextSchema,
+  artifactBindings: z.array(artifactBindingSchema).max(128),
+  evidenceRefs: evidenceRefsSchema,
+  routingDecisionDigest: sha256Schema.nullable(),
+}).strict();
+
+export type NavigatorPlanningInput = Readonly<z.infer<typeof navigatorPlanningInputSchema>>;
+
+type PlanningSkillId =
+  | "setup-matt-pocock-skills"
+  | "wayfinder"
+  | "to-spec"
+  | "to-tickets"
+  | "research"
+  | "prototype"
+  | "handoff"
+  | "ask-matt";
+
+const RESULT_KIND_BY_SKILL: Readonly<Record<
+  Exclude<PlanningSkillId, "research">,
+  NavigatorPlanningResult["kind"]
+>> = {
+  "setup-matt-pocock-skills": "setup_result",
+  wayfinder: "wayfinder_result",
+  "to-spec": "to_spec_result",
+  "to-tickets": "to_tickets_result",
+  prototype: "prototype_result",
+  handoff: "handoff_result",
+  "ask-matt": "ask_matt_result",
+};
+
+function digestJson(subject: unknown): string {
+  return createHash("sha256").update(JSON.stringify(subject), "utf8").digest("hex");
+}
+
+function planningContract(input: Omit<NavigatorSkillStepContract, "digest">): NavigatorSkillStepContract {
+  return Object.freeze({ ...input, digest: digestJson(input) });
+}
+
+const sharedContract = {
+  revision: 1,
+  inputSchema: "navigator-planning-input-v1" as const,
+  mandatoryEvidence: ["structured_result", "bb_resource"],
+  modelPools: ["strong"] as const,
+  timeoutMs: 600_000,
+  maximumResultBytes: 64_000,
+  retryClass: "resume_bound_resource" as const,
+};
+
+export const NAVIGATOR_PLANNING_STEP_CONTRACTS: Readonly<Record<PlanningSkillId, NavigatorSkillStepContract>> =
+  Object.freeze({
+    "setup-matt-pocock-skills": planningContract({
+      ...sharedContract,
+      id: "navigator-setup",
+      skillId: "setup-matt-pocock-skills",
+      invocationClass: "user",
+      allowedArtifactKinds: [],
+      minimumSubjects: 0,
+      operationClass: "read_only",
+      resourceClass: "bb_thread_read_only",
+      resultSchema: "navigator-setup-result-v1",
+    }),
+    wayfinder: planningContract({
+      ...sharedContract,
+      id: "navigator-wayfinder",
+      skillId: "wayfinder",
+      invocationClass: "user",
+      allowedArtifactKinds: ["map", "decision_ticket", "specification", "implementation_ticket"],
+      minimumSubjects: 1,
+      operationClass: "artifact_write",
+      resourceClass: "bb_thread_read_only",
+      resultSchema: "navigator-wayfinder-result-v1",
+    }),
+    "to-spec": planningContract({
+      ...sharedContract,
+      id: "navigator-to-spec",
+      skillId: "to-spec",
+      invocationClass: "user",
+      allowedArtifactKinds: ["map", "decision_ticket", "specification"],
+      minimumSubjects: 1,
+      operationClass: "artifact_write",
+      resourceClass: "bb_thread_read_only",
+      resultSchema: "navigator-to-spec-result-v1",
+    }),
+    "to-tickets": planningContract({
+      ...sharedContract,
+      id: "navigator-to-tickets",
+      skillId: "to-tickets",
+      invocationClass: "user",
+      allowedArtifactKinds: ["specification"],
+      minimumSubjects: 1,
+      operationClass: "artifact_write",
+      resourceClass: "bb_thread_read_only",
+      resultSchema: "navigator-to-tickets-result-v1",
+    }),
+    research: NAVIGATOR_RESEARCH_STEP_CONTRACT,
+    prototype: planningContract({
+      ...sharedContract,
+      id: "navigator-prototype",
+      skillId: "prototype",
+      invocationClass: "model",
+      allowedArtifactKinds: ["map", "decision_ticket", "specification"],
+      minimumSubjects: 1,
+      operationClass: "read_only",
+      resourceClass: "bb_thread_read_only",
+      resultSchema: "navigator-prototype-result-v1",
+    }),
+    handoff: planningContract({
+      ...sharedContract,
+      id: "navigator-handoff",
+      skillId: "handoff",
+      invocationClass: "user",
+      allowedArtifactKinds: ["map", "decision_ticket", "specification", "implementation_ticket"],
+      minimumSubjects: 1,
+      operationClass: "read_only",
+      resourceClass: "bb_thread_read_only",
+      resultSchema: "navigator-handoff-result-v1",
+    }),
+    "ask-matt": planningContract({
+      ...sharedContract,
+      id: "navigator-ask-matt",
+      skillId: "ask-matt",
+      invocationClass: "user",
+      allowedArtifactKinds: ["map", "decision_ticket", "specification", "implementation_ticket"],
+      minimumSubjects: 0,
+      operationClass: "read_only",
+      resourceClass: "bb_thread_read_only",
+      resultSchema: "navigator-ask-matt-result-v1",
+    }),
+  });
+
+export function navigatorStepContract(skillId: string): NavigatorSkillStepContract | null {
+  return Object.prototype.hasOwnProperty.call(NAVIGATOR_PLANNING_STEP_CONTRACTS, skillId)
+    ? NAVIGATOR_PLANNING_STEP_CONTRACTS[skillId as PlanningSkillId]
+    : null;
+}
+
+function blockersAreOrdered(planningOutcome: NavigatorPlanningResult): boolean {
+  if (planningOutcome.kind !== "wayfinder_result" && planningOutcome.kind !== "to_tickets_result") return true;
+  const drafts = planningOutcome.kind === "wayfinder_result"
+    ? planningOutcome.decisionTickets
+    : planningOutcome.tickets;
+  return drafts.every((draft, index) =>
+    new Set(draft.blockedBy).size === draft.blockedBy.length &&
+    draft.blockedBy.every((blocker) => blocker < index));
+}
+
+export function safeParseNavigatorStepResult(skillId: string, rawOutcome: unknown): unknown | null {
+  if (skillId === "research") return rawOutcome;
+  const parsed = navigatorPlanningResultSchema.safeParse(rawOutcome);
+  if (!parsed.success) return null;
+  const expectedKind = RESULT_KIND_BY_SKILL[skillId as Exclude<PlanningSkillId, "research">];
+  return parsed.data.kind === expectedKind && blockersAreOrdered(parsed.data) ? parsed.data : null;
+}
+
+export function parseNavigatorStepResult(skillId: string, rawOutcome: unknown): unknown {
+  const parsedOutcome = safeParseNavigatorStepResult(skillId, rawOutcome);
+  if (parsedOutcome === null) throw new TypeError(`navigator result does not match ${skillId}`);
+  return parsedOutcome;
+}
+
+export type NavigatorRoutingSignals = Readonly<{
+  trackerConfigured: boolean;
+  specificationReady: boolean;
+  hugeMultiSessionEffort: boolean;
+  routeToDestinationVisible: boolean;
+  needsPrimarySourceFacts: boolean;
+  runnableDesignQuestion: boolean;
+  workingDirectoryAvailable: boolean;
+  requirementsUnclear: boolean;
+}>;
+
+export type NavigatorPlanningRoute =
+  | "setup-matt-pocock-skills"
+  | "wayfinder"
+  | "research"
+  | "prototype"
+  | "grill-with-docs"
+  | "to-spec"
+  | "to-tickets";
+
+export function selectNavigatorPlanningRoute(signals: NavigatorRoutingSignals): NavigatorPlanningRoute {
+  if (!signals.trackerConfigured) return "setup-matt-pocock-skills";
+  if (signals.specificationReady) return "to-tickets";
+  if (signals.needsPrimarySourceFacts) return "research";
+  if (signals.runnableDesignQuestion) return "prototype";
+  if (signals.hugeMultiSessionEffort && !signals.routeToDestinationVisible) return "wayfinder";
+  if (signals.workingDirectoryAvailable && signals.requirementsUnclear) return "grill-with-docs";
+  return "to-spec";
+}
+
+export function navigatorPlanningInput(input: Readonly<{
+  skillId: string;
+  objective: string;
+  artifactBindings: readonly NavigatorArtifactBinding[];
+  evidenceRefs: readonly string[];
+  routingDecisionDigest?: string | null;
+}>): NavigatorPlanningInput {
+  return navigatorPlanningInputSchema.parse({
+    kind: "navigator_planning_input",
+    skillId: input.skillId,
+    objective: input.objective,
+    artifactBindings: input.artifactBindings,
+    evidenceRefs: input.evidenceRefs,
+    routingDecisionDigest: input.routingDecisionDigest ?? null,
+  });
+}

--- a/src/navigator/planning-contracts.ts
+++ b/src/navigator/planning-contracts.ts
@@ -116,6 +116,11 @@ type PlanningSkillId =
   | "handoff"
   | "ask-matt";
 
+type SchedulablePlanningSkillId = Exclude<
+  PlanningSkillId,
+  "setup-matt-pocock-skills" | "prototype" | "handoff"
+>;
+
 const RESULT_KIND_BY_SKILL: Readonly<Record<
   Exclude<PlanningSkillId, "research">,
   NavigatorPlanningResult["kind"]
@@ -147,19 +152,10 @@ const sharedContract = {
   retryClass: "resume_bound_resource" as const,
 };
 
-export const NAVIGATOR_PLANNING_STEP_CONTRACTS: Readonly<Record<PlanningSkillId, NavigatorSkillStepContract>> =
+export const NAVIGATOR_PLANNING_STEP_CONTRACTS: Readonly<
+  Record<SchedulablePlanningSkillId, NavigatorSkillStepContract>
+> =
   Object.freeze({
-    "setup-matt-pocock-skills": planningContract({
-      ...sharedContract,
-      id: "navigator-setup",
-      skillId: "setup-matt-pocock-skills",
-      invocationClass: "user",
-      allowedArtifactKinds: [],
-      minimumSubjects: 0,
-      operationClass: "read_only",
-      resourceClass: "bb_thread_read_only",
-      resultSchema: "navigator-setup-result-v1",
-    }),
     wayfinder: planningContract({
       ...sharedContract,
       id: "navigator-wayfinder",
@@ -194,28 +190,6 @@ export const NAVIGATOR_PLANNING_STEP_CONTRACTS: Readonly<Record<PlanningSkillId,
       resultSchema: "navigator-to-tickets-result-v1",
     }),
     research: NAVIGATOR_RESEARCH_STEP_CONTRACT,
-    prototype: planningContract({
-      ...sharedContract,
-      id: "navigator-prototype",
-      skillId: "prototype",
-      invocationClass: "model",
-      allowedArtifactKinds: ["map", "decision_ticket", "specification"],
-      minimumSubjects: 1,
-      operationClass: "read_only",
-      resourceClass: "bb_thread_read_only",
-      resultSchema: "navigator-prototype-result-v1",
-    }),
-    handoff: planningContract({
-      ...sharedContract,
-      id: "navigator-handoff",
-      skillId: "handoff",
-      invocationClass: "user",
-      allowedArtifactKinds: ["map", "decision_ticket", "specification", "implementation_ticket"],
-      minimumSubjects: 1,
-      operationClass: "read_only",
-      resourceClass: "bb_thread_read_only",
-      resultSchema: "navigator-handoff-result-v1",
-    }),
     "ask-matt": planningContract({
       ...sharedContract,
       id: "navigator-ask-matt",
@@ -231,7 +205,7 @@ export const NAVIGATOR_PLANNING_STEP_CONTRACTS: Readonly<Record<PlanningSkillId,
 
 export function navigatorStepContract(skillId: string): NavigatorSkillStepContract | null {
   return Object.prototype.hasOwnProperty.call(NAVIGATOR_PLANNING_STEP_CONTRACTS, skillId)
-    ? NAVIGATOR_PLANNING_STEP_CONTRACTS[skillId as PlanningSkillId]
+    ? NAVIGATOR_PLANNING_STEP_CONTRACTS[skillId as SchedulablePlanningSkillId]
     : null;
 }
 

--- a/src/navigator/planning-publisher.ts
+++ b/src/navigator/planning-publisher.ts
@@ -16,11 +16,22 @@ type PlanningPublisherStore = Pick<TelegramAgentStore,
   | "getJob"
   | "getWorkArtifact"
   | "getCurrentWorkArtifactSnapshot"
+  | "isWorkArtifactSnapshotValid"
 >;
 
 export type NavigatorPlanningPublication = Readonly<{
   artifactBindings: readonly NavigatorArtifactBinding[];
+  reconciledArtifactIds: readonly string[];
 }>;
+
+export class NavigatorPublicationDriftError extends Error {
+  public readonly reasonCode = "stale_artifact_snapshot";
+
+  public constructor() {
+    super("Navigator subject artifact changed during planning publication");
+    this.name = "NavigatorPublicationDriftError";
+  }
+}
 
 type PublicationFence = Readonly<{
   ownerId: string;
@@ -71,6 +82,55 @@ function blockerRelationship(ticketId: string, blockerId: string): WorkArtifactR
   };
 }
 
+function bodySectionContent(content: string): string {
+  const startMarker = "<!-- hanoon:owned:body:start -->";
+  const endMarker = "<!-- hanoon:owned:body:end -->";
+  const start = content.indexOf(startMarker);
+  const end = content.indexOf(endMarker);
+  if (start < 0 || end <= start) throw new Error("Navigator map body section is unavailable");
+  return content.slice(start + startMarker.length, end).trim();
+}
+
+function decisionIndexBody(body: string, entry: string, link: string): string {
+  if (body.includes(`](${link}):`)) return body;
+  const heading = /^## Decisions so far\s*$/mu.exec(body);
+  if (!heading || heading.index === undefined) {
+    throw new Error("Navigator map has no Decisions so far section");
+  }
+  const sectionStart = heading.index + heading[0].length;
+  const nextHeading = /^##\s+/mu.exec(body.slice(sectionStart));
+  const sectionEnd = nextHeading?.index === undefined
+    ? body.length
+    : sectionStart + nextHeading.index;
+  const before = body.slice(0, sectionEnd).trimEnd();
+  const after = body.slice(sectionEnd).trimStart();
+  return after.length === 0 ? `${before}\n\n${entry}` : `${before}\n\n${entry}\n\n${after}`;
+}
+
+function oneLineGist(answer: string): string {
+  const normalized = answer.replace(/\s+/gu, " ").trim();
+  return normalized.length <= 512 ? normalized : `${normalized.slice(0, 509).trimEnd()}...`;
+}
+
+function decisionAnswer(
+  skillId: string,
+  skillOutcome: Record<string, unknown>,
+  artifactId: string,
+): string {
+  if (skillId === "prototype" && typeof skillOutcome.verdict === "string") {
+    return skillOutcome.verdict;
+  }
+  const evidence = Array.isArray(skillOutcome.artifactEvidence)
+    ? skillOutcome.artifactEvidence.find((entry) =>
+      typeof entry === "object" && entry !== null &&
+      (entry as { artifactId?: unknown }).artifactId === artifactId)
+    : undefined;
+  if (typeof (evidence as { finding?: unknown } | undefined)?.finding !== "string") {
+    throw new TypeError(`Decision ${artifactId} has no matched durable answer`);
+  }
+  return (evidence as { finding: string }).finding;
+}
+
 export class NavigatorPlanningPublisher {
   public constructor(
     private readonly store: PlanningPublisherStore,
@@ -82,14 +142,15 @@ export class NavigatorPlanningPublisher {
     rawResult: unknown,
     fence: PublicationFence,
   ): Promise<NavigatorPlanningPublication> {
+    this.assertAttemptBindingsCurrent(attempt, new Set());
     if (attempt.skillId === "research") {
-      await this.resolveDecisionSubjects(attempt, rawResult as Record<string, unknown>, fence);
-      return this.currentBindings(attempt.jobId, attempt.artifactBindings);
+      const reconciled = await this.resolveDecisionSubjects(attempt, rawResult as Record<string, unknown>, fence);
+      return this.currentBindings(attempt.jobId, reconciled, reconciled.map((binding) => binding.artifactId));
     }
     const planningOutcome = navigatorPlanningResultSchema.parse(rawResult);
     if (planningOutcome.kind === "prototype_result") {
-      await this.resolveDecisionSubjects(attempt, planningOutcome, fence);
-      return this.currentBindings(attempt.jobId, attempt.artifactBindings);
+      const reconciled = await this.resolveDecisionSubjects(attempt, planningOutcome, fence);
+      return this.currentBindings(attempt.jobId, reconciled, reconciled.map((binding) => binding.artifactId));
     }
     if (planningOutcome.kind === "wayfinder_result") {
       return this.publishWayfinder(attempt, planningOutcome, fence);
@@ -100,7 +161,7 @@ export class NavigatorPlanningPublisher {
     if (planningOutcome.kind === "to_tickets_result") {
       return this.publishTickets(attempt, planningOutcome, fence);
     }
-    return this.currentBindings(attempt.jobId, attempt.artifactBindings);
+    return this.currentBindings(attempt.jobId, [], []);
   }
 
   private async publishWayfinder(
@@ -120,6 +181,7 @@ export class NavigatorPlanningPublisher {
       relationships: [],
       trackerOrder: 0,
     }, fence);
+    this.assertAttemptBindingsCurrent(attempt, new Set());
     const ticketIds = wayfinderOutcome.decisionTickets.map((_ticket, index) =>
       stableWorkArtifactId(job.projectId!, `${attempt.workflowStepId}:decision:${index}`));
     for (const [index, ticket] of wayfinderOutcome.decisionTickets.entries()) {
@@ -138,12 +200,12 @@ export class NavigatorPlanningPublisher {
         relationships,
         trackerOrder: index + 1,
       }, fence);
+      this.assertAttemptBindingsCurrent(attempt, new Set());
     }
     return this.currentBindings(attempt.jobId, [
-      ...attempt.artifactBindings,
       artifactBinding(this.store, mapId),
       ...ticketIds.map((ticketId) => artifactBinding(this.store, ticketId)),
-    ]);
+    ], []);
   }
 
   private async publishSpecification(
@@ -152,8 +214,23 @@ export class NavigatorPlanningPublisher {
     fence: PublicationFence,
   ): Promise<NavigatorPlanningPublication> {
     const job = this.requireJob(attempt.jobId);
-    this.assertNoBoundKind(attempt, "specification");
-    const map = this.boundArtifacts(attempt).find((artifact) => artifact.kind === "map");
+    const boundArtifacts = this.boundArtifacts(attempt);
+    const existingSpecification = boundArtifacts.find((artifact) => artifact.kind === "specification");
+    if (existingSpecification) {
+      await this.coordinator.updateOwnedSection({
+        artifactId: existingSpecification.id,
+        sectionId: "body",
+        content: specificationOutcome.specification.body,
+        operationId: `${attempt.workflowStepId}:revise-specification:${existingSpecification.id}`,
+        ...fence,
+      });
+      const reconciled = new Set([existingSpecification.id]);
+      this.assertAttemptBindingsCurrent(attempt, reconciled);
+      return this.currentBindings(attempt.jobId, [
+        artifactBinding(this.store, existingSpecification.id),
+      ], [...reconciled]);
+    }
+    const map = boundArtifacts.find((artifact) => artifact.kind === "map");
     const operationId = `${attempt.workflowStepId}:specification`;
     const specificationId = stableWorkArtifactId(job.projectId!, operationId);
     await this.createArtifact(job, {
@@ -164,10 +241,10 @@ export class NavigatorPlanningPublisher {
       relationships: map ? [derivedRelationship(specificationId, map.id)] : [],
       trackerOrder: 0,
     }, fence);
+    this.assertAttemptBindingsCurrent(attempt, new Set());
     return this.currentBindings(attempt.jobId, [
-      ...attempt.artifactBindings,
       artifactBinding(this.store, specificationId),
-    ]);
+    ], []);
   }
 
   private async publishTickets(
@@ -197,31 +274,61 @@ export class NavigatorPlanningPublisher {
         relationships,
         trackerOrder: index + 1,
       }, fence);
+      this.assertAttemptBindingsCurrent(attempt, new Set());
     }
     return this.currentBindings(attempt.jobId, [
-      ...attempt.artifactBindings,
       ...ticketIds.map((ticketId) => artifactBinding(this.store, ticketId)),
-    ]);
+    ], []);
   }
 
   private async resolveDecisionSubjects(
     attempt: NavigatorSkillAttempt,
     skillOutcome: Record<string, unknown>,
     fence: PublicationFence,
-  ): Promise<void> {
-    const summary = typeof skillOutcome.summary === "string"
-      ? skillOutcome.summary
-      : "Decision evidence recorded.";
+  ): Promise<readonly NavigatorArtifactBinding[]> {
+    const reconciled = new Set<string>();
     for (const artifact of this.boundArtifacts(attempt)) {
-      if (artifact.kind !== "decision_ticket" || artifact.status === "resolved") continue;
-      await this.coordinator.resolve({
-        artifactId: artifact.id,
-        evidenceRefs: [`navigator-result:${attempt.id}`],
-        resolution: summary,
-        operationId: `${attempt.workflowStepId}:resolve:${artifact.id}`,
-        ...fence,
-      });
+      if (artifact.kind !== "decision_ticket") continue;
+      const answer = decisionAnswer(attempt.skillId, skillOutcome, artifact.id);
+      if (artifact.status !== "resolved") {
+        await this.coordinator.resolve({
+          artifactId: artifact.id,
+          evidenceRefs: [`navigator-result:${attempt.id}`],
+          resolution: answer,
+          operationId: `${attempt.workflowStepId}:resolve:${artifact.id}`,
+          ...fence,
+        });
+        reconciled.add(artifact.id);
+        this.assertAttemptBindingsCurrent(attempt, reconciled);
+      }
+      await this.indexDecision(attempt, artifact, answer, fence);
+      this.assertAttemptBindingsCurrent(attempt, reconciled);
     }
+    const affectedIds = new Set(reconciled);
+    const map = this.boundMap(attempt.jobId);
+    if (map) affectedIds.add(map.id);
+    return [...affectedIds].map((artifactId) => artifactBinding(this.store, artifactId));
+  }
+
+  private async indexDecision(
+    attempt: NavigatorSkillAttempt,
+    decision: WorkArtifact,
+    answer: string,
+    fence: PublicationFence,
+  ): Promise<void> {
+    const map = this.boundMap(attempt.jobId);
+    if (!map) return;
+    const snapshot = this.store.getCurrentWorkArtifactSnapshot(map.id);
+    if (!snapshot) throw new Error(`Navigator map ${map.id} has no current snapshot`);
+    const link = decision.externalUrl ?? decision.externalId;
+    const entry = `- [${decision.title}](${link}): ${oneLineGist(answer)}`;
+    await this.coordinator.updateOwnedSection({
+      artifactId: map.id,
+      sectionId: "body",
+      content: decisionIndexBody(bodySectionContent(snapshot.content), entry, link),
+      operationId: `${attempt.workflowStepId}:map-index:${decision.id}`,
+      ...fence,
+    });
   }
 
   private async createArtifact(
@@ -240,14 +347,37 @@ export class NavigatorPlanningPublisher {
 
   private currentBindings(
     jobId: string,
-    additionalBindings: readonly NavigatorArtifactBinding[],
+    replacementBindings: readonly NavigatorArtifactBinding[],
+    reconciledArtifactIds: readonly string[],
   ): NavigatorPlanningPublication {
     const unique = new Map<string, NavigatorArtifactBinding>();
     const job = this.requireJob(jobId);
-    for (const bindingValue of [...job.artifactBindings, ...additionalBindings]) {
-      unique.set(bindingValue.artifactId, artifactBinding(this.store, bindingValue.artifactId));
+    for (const binding of job.artifactBindings) unique.set(binding.artifactId, binding);
+    for (const binding of replacementBindings) unique.set(binding.artifactId, binding);
+    return { artifactBindings: [...unique.values()], reconciledArtifactIds };
+  }
+
+  private assertAttemptBindingsCurrent(
+    attempt: NavigatorSkillAttempt,
+    reconciledArtifactIds: ReadonlySet<string>,
+  ): void {
+    for (const binding of attempt.artifactBindings) {
+      const current = this.store.getCurrentWorkArtifactSnapshot(binding.artifactId);
+      const exact = current?.id === binding.snapshotId && current.snapshotDigest === binding.snapshotDigest;
+      const revisableSpecification = attempt.skillId === "to-spec" &&
+        this.store.getWorkArtifact(binding.artifactId)?.kind === "specification";
+      if (exact && (this.store.isWorkArtifactSnapshotValid(binding.snapshotId) || revisableSpecification)) continue;
+      if (reconciledArtifactIds.has(binding.artifactId) && current && this.store.isWorkArtifactSnapshotValid(current.id)) {
+        continue;
+      }
+      throw new NavigatorPublicationDriftError();
     }
-    return { artifactBindings: [...unique.values()] };
+  }
+
+  private boundMap(jobId: string): WorkArtifact | null {
+    return this.requireJob(jobId).artifactBindings
+      .map((binding) => this.store.getWorkArtifact(binding.artifactId))
+      .find((artifact): artifact is WorkArtifact => artifact?.kind === "map") ?? null;
   }
 
   private boundArtifacts(attempt: NavigatorSkillAttempt): readonly WorkArtifact[] {

--- a/src/navigator/planning-publisher.ts
+++ b/src/navigator/planning-publisher.ts
@@ -142,26 +142,32 @@ export class NavigatorPlanningPublisher {
     rawResult: unknown,
     fence: PublicationFence,
   ): Promise<NavigatorPlanningPublication> {
-    this.assertAttemptBindingsCurrent(attempt, new Set());
-    if (attempt.skillId === "research") {
-      const reconciled = await this.resolveDecisionSubjects(attempt, rawResult as Record<string, unknown>, fence);
-      return this.currentBindings(attempt.jobId, reconciled, reconciled.map((binding) => binding.artifactId));
+    try {
+      this.assertAttemptBindingsCurrent(attempt, new Set());
+      if (attempt.skillId === "research") {
+        const reconciled = await this.resolveDecisionSubjects(attempt, rawResult as Record<string, unknown>, fence);
+        return this.currentBindings(attempt.jobId, reconciled, reconciled.map((binding) => binding.artifactId));
+      }
+      const planningOutcome = navigatorPlanningResultSchema.parse(rawResult);
+      if (planningOutcome.kind === "prototype_result") {
+        const reconciled = await this.resolveDecisionSubjects(attempt, planningOutcome, fence);
+        return this.currentBindings(attempt.jobId, reconciled, reconciled.map((binding) => binding.artifactId));
+      }
+      if (planningOutcome.kind === "wayfinder_result") {
+        return await this.publishWayfinder(attempt, planningOutcome, fence);
+      }
+      if (planningOutcome.kind === "to_spec_result") {
+        return await this.publishSpecification(attempt, planningOutcome, fence);
+      }
+      if (planningOutcome.kind === "to_tickets_result") {
+        return await this.publishTickets(attempt, planningOutcome, fence);
+      }
+      return this.currentBindings(attempt.jobId, [], []);
+    } catch (error) {
+      if (!(error instanceof NavigatorPublicationDriftError)) throw error;
+      await this.reconcileSupersededArtifacts(attempt, rawResult, fence);
+      throw error;
     }
-    const planningOutcome = navigatorPlanningResultSchema.parse(rawResult);
-    if (planningOutcome.kind === "prototype_result") {
-      const reconciled = await this.resolveDecisionSubjects(attempt, planningOutcome, fence);
-      return this.currentBindings(attempt.jobId, reconciled, reconciled.map((binding) => binding.artifactId));
-    }
-    if (planningOutcome.kind === "wayfinder_result") {
-      return this.publishWayfinder(attempt, planningOutcome, fence);
-    }
-    if (planningOutcome.kind === "to_spec_result") {
-      return this.publishSpecification(attempt, planningOutcome, fence);
-    }
-    if (planningOutcome.kind === "to_tickets_result") {
-      return this.publishTickets(attempt, planningOutcome, fence);
-    }
-    return this.currentBindings(attempt.jobId, [], []);
   }
 
   private async publishWayfinder(
@@ -343,6 +349,54 @@ export class NavigatorPlanningPublisher {
       effortId: job.id,
       ...fence,
     });
+  }
+
+  private plannedArtifactIds(
+    attempt: NavigatorSkillAttempt,
+    rawResult: unknown,
+  ): readonly string[] {
+    if (attempt.skillId === "research") return [];
+    const parsed = navigatorPlanningResultSchema.safeParse(rawResult);
+    if (!parsed.success) return [];
+    const projectId = this.requireJob(attempt.jobId).projectId!;
+    if (parsed.data.kind === "wayfinder_result") {
+      return [
+        stableWorkArtifactId(projectId, `${attempt.workflowStepId}:map`),
+        ...parsed.data.decisionTickets.map((_ticket, index) =>
+          stableWorkArtifactId(projectId, `${attempt.workflowStepId}:decision:${index}`)),
+      ];
+    }
+    if (parsed.data.kind === "to_tickets_result") {
+      return parsed.data.tickets.map((_ticket, index) =>
+        stableWorkArtifactId(projectId, `${attempt.workflowStepId}:ticket:${index}`));
+    }
+    const hasSpecification = parsed.data.kind === "to_spec_result" &&
+      this.boundArtifacts(attempt).some((artifact) => artifact.kind === "specification");
+    return parsed.data.kind === "to_spec_result" && !hasSpecification
+      ? [stableWorkArtifactId(projectId, `${attempt.workflowStepId}:specification`)]
+      : [];
+  }
+
+  private async reconcileSupersededArtifacts(
+    attempt: NavigatorSkillAttempt,
+    rawResult: unknown,
+    fence: PublicationFence,
+  ): Promise<void> {
+    const boundArtifactIds = new Set(
+      this.requireJob(attempt.jobId).artifactBindings.map((binding) => binding.artifactId),
+    );
+    for (const artifactId of [...this.plannedArtifactIds(attempt, rawResult)].reverse()) {
+      if (boundArtifactIds.has(artifactId)) continue;
+      const artifact = this.store.getWorkArtifact(artifactId);
+      if (!artifact || artifact.status === "cancelled") continue;
+      await this.coordinator.cancel({
+        artifactId,
+        evidenceRefs: [`navigator-result:${attempt.id}`],
+        reason: "Planning publication superseded after its subject artifact changed.",
+        operationId: `${attempt.workflowStepId}:supersede:${artifactId}`,
+        ...fence,
+      });
+    }
   }
 
   private currentBindings(

--- a/src/navigator/planning-publisher.ts
+++ b/src/navigator/planning-publisher.ts
@@ -1,0 +1,272 @@
+import type { Job } from "../domain/models";
+import type { TelegramAgentStore } from "../storage/store";
+import {
+  WorkArtifactCoordinator,
+  type CreateCoordinatedArtifactInput,
+} from "../work-artifacts/coordinator";
+import type { WorkArtifact, WorkArtifactRelationship } from "../work-artifacts/models";
+import { stableWorkArtifactId } from "../work-artifacts/repository";
+import type { NavigatorArtifactBinding, NavigatorSkillAttempt } from "./models";
+import {
+  navigatorPlanningResultSchema,
+  type NavigatorPlanningResult,
+} from "./planning-contracts";
+
+type PlanningPublisherStore = Pick<TelegramAgentStore,
+  | "getJob"
+  | "getWorkArtifact"
+  | "getCurrentWorkArtifactSnapshot"
+>;
+
+export type NavigatorPlanningPublication = Readonly<{
+  artifactBindings: readonly NavigatorArtifactBinding[];
+}>;
+
+type PublicationFence = Readonly<{
+  ownerId: string;
+  generation: number;
+  now: number;
+}>;
+
+function artifactBinding(
+  store: PlanningPublisherStore,
+  artifactId: string,
+): NavigatorArtifactBinding {
+  const snapshot = store.getCurrentWorkArtifactSnapshot(artifactId);
+  if (!snapshot) throw new Error(`Navigator artifact ${artifactId} has no current snapshot`);
+  return {
+    artifactId,
+    snapshotId: snapshot.id,
+    snapshotDigest: snapshot.snapshotDigest,
+  };
+}
+
+function parentRelationship(childId: string, parentId: string): WorkArtifactRelationship {
+  return {
+    kind: "parent",
+    sourceArtifactId: childId,
+    sourceRef: `artifact:${childId}`,
+    targetArtifactId: parentId,
+    targetRef: `artifact:${parentId}`,
+  };
+}
+
+function derivedRelationship(childId: string, sourceId: string): WorkArtifactRelationship {
+  return {
+    kind: "derived_from",
+    sourceArtifactId: childId,
+    sourceRef: `artifact:${childId}`,
+    targetArtifactId: sourceId,
+    targetRef: `artifact:${sourceId}`,
+  };
+}
+
+function blockerRelationship(ticketId: string, blockerId: string): WorkArtifactRelationship {
+  return {
+    kind: "blocks",
+    sourceArtifactId: blockerId,
+    sourceRef: `artifact:${blockerId}`,
+    targetArtifactId: ticketId,
+    targetRef: `artifact:${ticketId}`,
+  };
+}
+
+export class NavigatorPlanningPublisher {
+  public constructor(
+    private readonly store: PlanningPublisherStore,
+    private readonly coordinator: WorkArtifactCoordinator,
+  ) {}
+
+  public async publish(
+    attempt: NavigatorSkillAttempt,
+    rawResult: unknown,
+    fence: PublicationFence,
+  ): Promise<NavigatorPlanningPublication> {
+    if (attempt.skillId === "research") {
+      await this.resolveDecisionSubjects(attempt, rawResult as Record<string, unknown>, fence);
+      return this.currentBindings(attempt.jobId, attempt.artifactBindings);
+    }
+    const planningOutcome = navigatorPlanningResultSchema.parse(rawResult);
+    if (planningOutcome.kind === "prototype_result") {
+      await this.resolveDecisionSubjects(attempt, planningOutcome, fence);
+      return this.currentBindings(attempt.jobId, attempt.artifactBindings);
+    }
+    if (planningOutcome.kind === "wayfinder_result") {
+      return this.publishWayfinder(attempt, planningOutcome, fence);
+    }
+    if (planningOutcome.kind === "to_spec_result") {
+      return this.publishSpecification(attempt, planningOutcome, fence);
+    }
+    if (planningOutcome.kind === "to_tickets_result") {
+      return this.publishTickets(attempt, planningOutcome, fence);
+    }
+    return this.currentBindings(attempt.jobId, attempt.artifactBindings);
+  }
+
+  private async publishWayfinder(
+    attempt: NavigatorSkillAttempt,
+    wayfinderOutcome: Extract<NavigatorPlanningResult, { kind: "wayfinder_result" }>,
+    fence: PublicationFence,
+  ): Promise<NavigatorPlanningPublication> {
+    const job = this.requireJob(attempt.jobId);
+    this.assertNoBoundKind(attempt, "map");
+    const mapOperationId = `${attempt.workflowStepId}:map`;
+    const mapId = stableWorkArtifactId(job.projectId!, mapOperationId);
+    await this.createArtifact(job, {
+      operationId: mapOperationId,
+      kind: "map",
+      status: "open",
+      ...wayfinderOutcome.map,
+      relationships: [],
+      trackerOrder: 0,
+    }, fence);
+    const ticketIds = wayfinderOutcome.decisionTickets.map((_ticket, index) =>
+      stableWorkArtifactId(job.projectId!, `${attempt.workflowStepId}:decision:${index}`));
+    for (const [index, ticket] of wayfinderOutcome.decisionTickets.entries()) {
+      const ticketId = ticketIds[index]!;
+      const relationships = [
+        parentRelationship(ticketId, mapId),
+        ...ticket.blockedBy.map((blockerIndex) => blockerRelationship(ticketId, ticketIds[blockerIndex]!)),
+      ];
+      await this.createArtifact(job, {
+        operationId: `${attempt.workflowStepId}:decision:${index}`,
+        kind: "decision_ticket",
+        status: "ready",
+        title: ticket.title,
+        body: ticket.body,
+        acceptanceCriteria: ticket.acceptanceCriteria,
+        relationships,
+        trackerOrder: index + 1,
+      }, fence);
+    }
+    return this.currentBindings(attempt.jobId, [
+      ...attempt.artifactBindings,
+      artifactBinding(this.store, mapId),
+      ...ticketIds.map((ticketId) => artifactBinding(this.store, ticketId)),
+    ]);
+  }
+
+  private async publishSpecification(
+    attempt: NavigatorSkillAttempt,
+    specificationOutcome: Extract<NavigatorPlanningResult, { kind: "to_spec_result" }>,
+    fence: PublicationFence,
+  ): Promise<NavigatorPlanningPublication> {
+    const job = this.requireJob(attempt.jobId);
+    this.assertNoBoundKind(attempt, "specification");
+    const map = this.boundArtifacts(attempt).find((artifact) => artifact.kind === "map");
+    const operationId = `${attempt.workflowStepId}:specification`;
+    const specificationId = stableWorkArtifactId(job.projectId!, operationId);
+    await this.createArtifact(job, {
+      operationId,
+      kind: "specification",
+      status: "ready",
+      ...specificationOutcome.specification,
+      relationships: map ? [derivedRelationship(specificationId, map.id)] : [],
+      trackerOrder: 0,
+    }, fence);
+    return this.currentBindings(attempt.jobId, [
+      ...attempt.artifactBindings,
+      artifactBinding(this.store, specificationId),
+    ]);
+  }
+
+  private async publishTickets(
+    attempt: NavigatorSkillAttempt,
+    ticketsOutcome: Extract<NavigatorPlanningResult, { kind: "to_tickets_result" }>,
+    fence: PublicationFence,
+  ): Promise<NavigatorPlanningPublication> {
+    const job = this.requireJob(attempt.jobId);
+    const specification = this.boundArtifacts(attempt).find((artifact) => artifact.kind === "specification");
+    if (!specification) throw new TypeError("to-tickets requires one bound specification");
+    const ticketIds = ticketsOutcome.tickets.map((_ticket, index) =>
+      stableWorkArtifactId(job.projectId!, `${attempt.workflowStepId}:ticket:${index}`));
+    for (const [index, ticket] of ticketsOutcome.tickets.entries()) {
+      const ticketId = ticketIds[index]!;
+      const relationships = [
+        parentRelationship(ticketId, specification.id),
+        derivedRelationship(ticketId, specification.id),
+        ...ticket.blockedBy.map((blockerIndex) => blockerRelationship(ticketId, ticketIds[blockerIndex]!)),
+      ];
+      await this.createArtifact(job, {
+        operationId: `${attempt.workflowStepId}:ticket:${index}`,
+        kind: "implementation_ticket",
+        status: "ready",
+        title: ticket.title,
+        body: ticket.body,
+        acceptanceCriteria: ticket.acceptanceCriteria,
+        relationships,
+        trackerOrder: index + 1,
+      }, fence);
+    }
+    return this.currentBindings(attempt.jobId, [
+      ...attempt.artifactBindings,
+      ...ticketIds.map((ticketId) => artifactBinding(this.store, ticketId)),
+    ]);
+  }
+
+  private async resolveDecisionSubjects(
+    attempt: NavigatorSkillAttempt,
+    skillOutcome: Record<string, unknown>,
+    fence: PublicationFence,
+  ): Promise<void> {
+    const summary = typeof skillOutcome.summary === "string"
+      ? skillOutcome.summary
+      : "Decision evidence recorded.";
+    for (const artifact of this.boundArtifacts(attempt)) {
+      if (artifact.kind !== "decision_ticket" || artifact.status === "resolved") continue;
+      await this.coordinator.resolve({
+        artifactId: artifact.id,
+        evidenceRefs: [`navigator-result:${attempt.id}`],
+        resolution: summary,
+        operationId: `${attempt.workflowStepId}:resolve:${artifact.id}`,
+        ...fence,
+      });
+    }
+  }
+
+  private async createArtifact(
+    job: Job,
+    input: Omit<CreateCoordinatedArtifactInput,
+      "projectId" | "effortId" | "ownerId" | "generation" | "now">,
+    fence: PublicationFence,
+  ): Promise<void> {
+    await this.coordinator.create({
+      ...input,
+      projectId: job.projectId!,
+      effortId: job.id,
+      ...fence,
+    });
+  }
+
+  private currentBindings(
+    jobId: string,
+    additionalBindings: readonly NavigatorArtifactBinding[],
+  ): NavigatorPlanningPublication {
+    const unique = new Map<string, NavigatorArtifactBinding>();
+    const job = this.requireJob(jobId);
+    for (const bindingValue of [...job.artifactBindings, ...additionalBindings]) {
+      unique.set(bindingValue.artifactId, artifactBinding(this.store, bindingValue.artifactId));
+    }
+    return { artifactBindings: [...unique.values()] };
+  }
+
+  private boundArtifacts(attempt: NavigatorSkillAttempt): readonly WorkArtifact[] {
+    return attempt.artifactBindings.map((bindingValue) => {
+      const artifact = this.store.getWorkArtifact(bindingValue.artifactId);
+      if (!artifact) throw new Error(`Navigator artifact ${bindingValue.artifactId} disappeared`);
+      return artifact;
+    });
+  }
+
+  private assertNoBoundKind(attempt: NavigatorSkillAttempt, kind: WorkArtifact["kind"]): void {
+    if (this.boundArtifacts(attempt).some((artifact) => artifact.kind === kind)) {
+      throw new TypeError(`navigator effort already has a canonical ${kind}`);
+    }
+  }
+
+  private requireJob(jobId: string): Job {
+    const job = this.store.getJob(jobId);
+    if (!job?.projectId) throw new Error(`Navigator job ${jobId} has no selected project`);
+    return job;
+  }
+}

--- a/src/navigator/repository.ts
+++ b/src/navigator/repository.ts
@@ -236,13 +236,29 @@ function parseAttempt(row: AttemptRow): NavigatorSkillAttempt {
   };
 }
 
-function routingDecisionDigest(proposal: Extract<NavigatorProposal, { kind: "unresolved_next_step" }>): string {
-  return createHash("sha256").update(JSON.stringify({
+function routingDecisionIdentity(
+  job: Job,
+  snapshot: NavigatorSnapshot,
+  proposal: Extract<NavigatorProposal, { kind: "unresolved_next_step" }>,
+): Readonly<{ decisionDigest: string; scopeDigest: string }> {
+  const boundScope = {
+    jobId: job.id,
+    workflowRevision: job.workflowRevision,
+    artifactBindings: snapshot.artifactBindings,
     question: proposal.question,
     candidateSkillIds: proposal.candidateSkillIds,
     rationale: proposal.rationale,
     evidenceRefs: proposal.evidenceRefs,
+  };
+  const scopeDigest = createHash("sha256")
+    .update(JSON.stringify(boundScope), "utf8")
+    .digest("hex");
+  const decisionDigest = createHash("sha256").update(JSON.stringify({
+    ...boundScope,
+    navigatorSnapshotId: snapshot.snapshotId,
+    navigatorSnapshotDigest: snapshot.identity.digest,
   }), "utf8").digest("hex");
+  return { decisionDigest, scopeDigest };
 }
 
 function artifactEvidenceMatchesBindings(
@@ -292,12 +308,18 @@ function proposalReason(
     proposal.basedOn.jobId !== job.id ||
     proposal.basedOn.digest !== snapshot.identity.digest
   ) return "snapshot_digest_mismatch";
+  const revisableSpecificationIds = proposal.kind === "invoke_skill" && proposal.skillId === "to-spec"
+    ? new Set(proposal.subjectArtifactIds.filter((artifactId) =>
+      artifacts.getArtifact(artifactId)?.kind === "specification"))
+    : new Set<string>();
   for (const binding of job.artifactBindings) {
     const current = artifacts.getCurrentSnapshot(binding.artifactId);
     if (
       current?.id !== binding.snapshotId ||
-      current.snapshotDigest !== binding.snapshotDigest ||
-      !artifacts.isSnapshotValid(binding.snapshotId)
+      current.snapshotDigest !== binding.snapshotDigest || (
+        !artifacts.isSnapshotValid(binding.snapshotId) &&
+        !revisableSpecificationIds.has(binding.artifactId)
+      )
     ) return "stale_artifact_snapshot";
   }
   if (observation.nativeToolCalls.length > 0) return "policy_native_tool_use";
@@ -337,7 +359,9 @@ function proposalReason(
   ) return "unnecessary_wayfinding";
   if (
     proposal.skillId === "to-spec" &&
-    job.artifactBindings.some((binding) => artifacts.getArtifact(binding.artifactId)?.kind === "specification")
+    job.artifactBindings.some((binding) =>
+      artifacts.getArtifact(binding.artifactId)?.kind === "specification" &&
+      !revisableSpecificationIds.has(binding.artifactId))
   ) return "canonical_specification_exists";
   for (const artifactId of proposal.subjectArtifactIds) {
     const artifact = artifacts.getArtifact(artifactId);
@@ -425,7 +449,8 @@ export class NavigatorRepository {
       const refreshedBindings: NavigatorArtifactBinding[] = [];
       for (const binding of job.artifactBindings) {
         const snapshot = this.artifacts.getCurrentSnapshot(binding.artifactId);
-        if (snapshot && this.artifacts.isSnapshotValid(snapshot.id)) {
+        const artifact = this.artifacts.getArtifact(binding.artifactId);
+        if (snapshot && (this.artifacts.isSnapshotValid(snapshot.id) || artifact?.kind === "specification")) {
           refreshedBindings.push({
             artifactId: binding.artifactId,
             snapshotId: snapshot.id,
@@ -554,17 +579,18 @@ export class NavigatorRepository {
       if (proposal?.kind !== "invoke_skill" && proposal?.kind !== "unresolved_next_step") {
         throw new Error("deterministic proposal validation was inconsistent");
       }
-      const unresolvedDigest = proposal.kind === "unresolved_next_step"
-        ? routingDecisionDigest(proposal)
+      const routingIdentity = proposal.kind === "unresolved_next_step"
+        ? routingDecisionIdentity(job, snapshot, proposal)
         : null;
-      if (unresolvedDigest !== null) {
-        const existingRouting = this.getRoutingDecision(unresolvedDigest);
+      const unresolvedDigest = routingIdentity?.decisionDigest ?? null;
+      if (routingIdentity !== null) {
+        const existingRouting = this.getRoutingDecisionByScope(routingIdentity.scopeDigest);
         if (existingRouting) {
           this.db.prepare(
             `INSERT OR IGNORE INTO navigator_routing_blocks (
                decision_digest, proposal_id, reason, recorded_at
              ) VALUES (?, ?, 'unchanged_routing_unresolved_after_consultation', ?)`,
-          ).run(unresolvedDigest, proposalId, input.now);
+          ).run(existingRouting.decisionDigest, proposalId, input.now);
           this.db.prepare(
             `UPDATE jobs SET state = 'blocked', last_error = ?, version = version + 1, updated_at = ?
               WHERE id = ? AND version = ? AND current_workflow_step_id IS NULL`,
@@ -661,11 +687,12 @@ export class NavigatorRepository {
       if (proposal.kind === "unresolved_next_step") {
         this.db.prepare(
           `INSERT INTO navigator_routing_decisions (
-             decision_digest, job_id, question, candidate_skill_ids_json,
+             decision_digest, scope_digest, job_id, question, candidate_skill_ids_json,
              rationale, evidence_refs_json, consultation_step_id, recorded_at
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         ).run(
           unresolvedDigest,
+          routingIdentity!.scopeDigest,
           job.id,
           proposal.question,
           JSON.stringify(proposal.candidateSkillIds),
@@ -834,8 +861,10 @@ export class NavigatorRepository {
         input.observedExternalStateDigest !== snapshot.externalStateDigest ||
         attempt.artifactBindings.some((binding) => {
           const current = this.artifacts.getCurrentSnapshot(binding.artifactId);
+          const revisableSpecification = attempt.skillId === "to-spec" &&
+            this.artifacts.getArtifact(binding.artifactId)?.kind === "specification";
           return current?.id !== binding.snapshotId || current.snapshotDigest !== binding.snapshotDigest ||
-            !this.artifacts.isSnapshotValid(binding.snapshotId);
+            (!revisableSpecification && !this.artifacts.isSnapshotValid(binding.snapshotId));
         })
       ) return null;
       const existing = this.getPlanningResult(input.attemptId);
@@ -917,6 +946,7 @@ export class NavigatorRepository {
         WHERE decision.decision_digest = ?`,
     ).get(decisionDigest) as Readonly<{
       decision_digest: string;
+      scope_digest: string;
       job_id: string;
       question: string;
       candidate_skill_ids_json: string;
@@ -938,6 +968,7 @@ export class NavigatorRepository {
     }>;
     return {
       decisionDigest: row.decision_digest,
+      scopeDigest: row.scope_digest,
       jobId: row.job_id,
       question: row.question,
       candidateSkillIds: JSON.parse(row.candidate_skill_ids_json) as readonly string[],
@@ -953,6 +984,14 @@ export class NavigatorRepository {
       },
       blocked: row.blocked_digest !== null,
     };
+  }
+
+  private getRoutingDecisionByScope(scopeDigest: string): NavigatorRoutingDecision | null {
+    if (!/^[0-9a-f]{64}$/u.test(scopeDigest)) throw new TypeError("scopeDigest must be a SHA-256 digest");
+    const row = this.db.prepare(
+      "SELECT decision_digest FROM navigator_routing_decisions WHERE scope_digest = ?",
+    ).get(scopeDigest) as { decision_digest: string } | undefined;
+    return row ? this.getRoutingDecision(row.decision_digest) : null;
   }
 
   public leaseSkillEffect(input: Readonly<{
@@ -1050,6 +1089,7 @@ export class NavigatorRepository {
     observedExternalStateDigest: string;
     result: unknown;
     publishedArtifactBindings?: readonly NavigatorArtifactBinding[];
+    reconciledArtifactIds?: readonly string[];
     policyFailureReason?: string;
     ownerId: string;
     generation: number;
@@ -1130,6 +1170,17 @@ export class NavigatorRepository {
       const publishedBindings = input.publishedArtifactBindings === undefined
         ? null
         : artifactBindingSchema.array().max(128).parse(input.publishedArtifactBindings);
+      const reconciledArtifactIds = new Set(input.reconciledArtifactIds ?? []);
+      if (reconciledArtifactIds.size !== (input.reconciledArtifactIds?.length ?? 0)) {
+        throw new TypeError("reconciled navigator artifacts contain duplicates");
+      }
+      if (
+        outcome === "succeeded" &&
+        !this.attemptBindingsAreCurrent(attempt, publishedBindings, reconciledArtifactIds)
+      ) {
+        outcome = "policy_failure";
+        reasonCode = "stale_artifact_snapshot";
+      }
       if (outcome === "succeeded" && contract?.operationClass === "artifact_write") {
         if (publishedBindings === null || publishedBindings.length === 0) {
           outcome = "policy_failure";
@@ -1212,10 +1263,11 @@ export class NavigatorRepository {
         : job.artifactBindings;
       const jobUpdate = this.db.prepare(
         `UPDATE jobs SET current_workflow_step_id = NULL,
-             artifact_bindings_json = ?, workflow_revision = workflow_revision + 1,
+             artifact_bindings_json = ?,
+             workflow_revision = workflow_revision + CASE WHEN ? = 'ask_matt_result' THEN 0 ELSE 1 END,
              version = version + 1, updated_at = ?
           WHERE id = ? AND current_workflow_step_id = ?`,
-      ).run(JSON.stringify(nextBindings), input.now, attempt.jobId, attempt.workflowStepId);
+      ).run(JSON.stringify(nextBindings), resultKind, input.now, attempt.jobId, attempt.workflowStepId);
       if (jobUpdate.changes !== 1) throw new Error("navigator workflow step changed before settlement");
       const effectUpdate = this.db.prepare(
         `UPDATE effects SET status = 'done', lease_owner = NULL, lease_generation = NULL,
@@ -1226,6 +1278,25 @@ export class NavigatorRepository {
       if (effectUpdate.changes !== 1) throw new Error("navigator effect lease changed before settlement");
       return this.getOutcome(attempt.workflowStepId);
     }).immediate();
+  }
+
+  private attemptBindingsAreCurrent(
+    attempt: NavigatorSkillAttempt,
+    publishedBindings: readonly NavigatorArtifactBinding[] | null,
+    reconciledArtifactIds: ReadonlySet<string>,
+  ): boolean {
+    return attempt.artifactBindings.every((binding) => {
+      const current = this.artifacts.getCurrentSnapshot(binding.artifactId);
+      const exact = current?.id === binding.snapshotId &&
+        current.snapshotDigest === binding.snapshotDigest &&
+        this.artifacts.isSnapshotValid(binding.snapshotId);
+      if (exact) return true;
+      return current !== null && this.artifacts.isSnapshotValid(current.id) &&
+        reconciledArtifactIds.has(binding.artifactId) &&
+        publishedBindings?.some((published) =>
+          published.artifactId === binding.artifactId && published.snapshotId === current.id &&
+          published.snapshotDigest === current.snapshotDigest) === true;
+    });
   }
 
   private acceptedSettlementJob(

--- a/src/navigator/repository.ts
+++ b/src/navigator/repository.ts
@@ -11,10 +11,16 @@ import {
 } from "../storage/job-persistence";
 import { WorkArtifactRepository } from "../work-artifacts/repository";
 import {
+  navigatorPlanningInput,
+  navigatorPlanningInputSchema,
+  navigatorStepContract,
+  parseNavigatorStepResult,
+  safeParseNavigatorStepResult,
+} from "./planning-contracts";
+import {
   MATT_POCOCK_SKILL_REVISION,
   MAX_NAVIGATOR_JSON_BYTES,
   NAVIGATOR_ENGINE_REVISION,
-  NAVIGATOR_RESEARCH_STEP_CONTRACT,
   NAVIGATOR_SKILL_CATALOG,
   NAVIGATOR_SKILL_CATALOG_DIGEST,
   artifactBindingSchema,
@@ -32,6 +38,8 @@ import {
   type NavigatorProposal,
   type NavigatorProposalDecision,
   type NavigatorProposalRecord,
+  type NavigatorPlanningResultRecord,
+  type NavigatorRoutingDecision,
   type NavigatorSkillAttempt,
   type NavigatorSnapshot,
   type NavigatorWorkflowStep,
@@ -192,7 +200,10 @@ function parseAttempt(row: AttemptRow): NavigatorSkillAttempt {
   const resource = row.resource_kind === null || row.resource_id === null
     ? null
     : { kind: "bb_thread" as const, id: row.resource_id };
-  const stepInput = navigatorResearchInputSchema.parse(JSON.parse(row.step_input_json));
+  const rawStepInput = JSON.parse(row.step_input_json);
+  const stepInput = row.skill_id === "research"
+    ? navigatorResearchInputSchema.parse(rawStepInput)
+    : navigatorPlanningInputSchema.parse(rawStepInput);
   const stepInputDigest = createHash("sha256").update(JSON.stringify(stepInput), "utf8").digest("hex");
   if (stepInputDigest !== row.step_input_digest) throw new Error("navigator step input digest binding is invalid");
   const artifactBindings = artifactBindingSchema.array().parse(JSON.parse(row.artifact_bindings_json));
@@ -223,6 +234,41 @@ function parseAttempt(row: AttemptRow): NavigatorSkillAttempt {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+}
+
+function routingDecisionDigest(proposal: Extract<NavigatorProposal, { kind: "unresolved_next_step" }>): string {
+  return createHash("sha256").update(JSON.stringify({
+    question: proposal.question,
+    candidateSkillIds: proposal.candidateSkillIds,
+    rationale: proposal.rationale,
+    evidenceRefs: proposal.evidenceRefs,
+  }), "utf8").digest("hex");
+}
+
+function artifactEvidenceMatchesBindings(
+  parsedOutcome: Record<string, unknown>,
+  bindings: readonly NavigatorArtifactBinding[],
+): boolean {
+  if (!Array.isArray(parsedOutcome.artifactEvidence)) return false;
+  const evidence = parsedOutcome.artifactEvidence as readonly Readonly<{
+    artifactId: string;
+    snapshotId: string;
+    snapshotDigest: string;
+  }>[];
+  const evidenceByArtifact = new Map(evidence.map((entry) => [entry.artifactId, entry]));
+  return evidenceByArtifact.size === evidence.length && evidenceByArtifact.size === bindings.length &&
+    bindings.every((binding) => {
+      const entry = evidenceByArtifact.get(binding.artifactId);
+      return entry?.snapshotId === binding.snapshotId && entry.snapshotDigest === binding.snapshotDigest;
+    });
+}
+
+function validatedNavigatorOutcome(skillId: string, rawOutcome: unknown): Record<string, unknown> | null {
+  const parsed = skillId === "research"
+    ? navigatorResearchResultSchema.safeParse(rawOutcome)
+    : { success: true as const, data: safeParseNavigatorStepResult(skillId, rawOutcome) };
+  if (!parsed.success || parsed.data === null) return null;
+  return parsed.data as Record<string, unknown>;
 }
 
 function proposalReason(
@@ -259,21 +305,43 @@ function proposalReason(
   if (observation.dynamicEffectToolIds.length > 0) return "policy_dynamic_effect_tool";
   if (observation.externalStateDigest !== snapshot.externalStateDigest) return "external_drift";
   if (job.workflowMode === "shadow") return null;
+  if (proposal.kind === "unresolved_next_step") {
+    const candidates = new Set(proposal.candidateSkillIds);
+    if (candidates.size !== proposal.candidateSkillIds.length) return "malformed_proposal";
+    if (proposal.candidateSkillIds.some((skillId) =>
+      !NAVIGATOR_SKILL_CATALOG.some((entry) => entry.id === skillId && entry.admitted))) return "capability_denied";
+    return null;
+  }
   if (proposal.kind !== "invoke_skill") return "unsupported_deterministic_action";
   const catalog = NAVIGATOR_SKILL_CATALOG.find((entry) => entry.id === proposal.skillId);
+  const contract = navigatorStepContract(proposal.skillId);
   if (
-    proposal.skillId !== NAVIGATOR_RESEARCH_STEP_CONTRACT.skillId ||
+    proposal.skillId === "ask-matt" || contract === null ||
     catalog?.admitted !== true ||
-    catalog.invocationClass !== "model" ||
+    catalog.invocationClass !== contract.invocationClass ||
     catalog.denialReason !== null
   ) return "capability_denied";
   const subjects = new Set(proposal.subjectArtifactIds);
-  if (subjects.size !== proposal.subjectArtifactIds.length) return "malformed_proposal";
+  if (
+    subjects.size !== proposal.subjectArtifactIds.length ||
+    subjects.size < contract.minimumSubjects
+  ) return "malformed_proposal";
   const boundIds = new Set(job.artifactBindings.map((binding) => binding.artifactId));
   if (proposal.subjectArtifactIds.some((artifactId) => !boundIds.has(artifactId))) return "unauthorized_subject";
+  if (
+    proposal.skillId === "wayfinder" &&
+    job.artifactBindings.some((binding) => {
+      const kind = artifacts.getArtifact(binding.artifactId)?.kind;
+      return kind === "map" || kind === "specification";
+    })
+  ) return "unnecessary_wayfinding";
+  if (
+    proposal.skillId === "to-spec" &&
+    job.artifactBindings.some((binding) => artifacts.getArtifact(binding.artifactId)?.kind === "specification")
+  ) return "canonical_specification_exists";
   for (const artifactId of proposal.subjectArtifactIds) {
     const artifact = artifacts.getArtifact(artifactId);
-    if (!artifact || !NAVIGATOR_RESEARCH_STEP_CONTRACT.allowedArtifactKinds.includes(artifact.kind)) {
+    if (!artifact || !contract.allowedArtifactKinds.includes(artifact.kind)) {
       return "capability_denied";
     }
   }
@@ -348,18 +416,35 @@ export class NavigatorRepository {
       throw new TypeError("externalStateDigest must be a SHA-256 digest");
     }
     return this.db.transaction((): NavigatorSnapshot => {
-      const job = readJobById(this.db, input.jobId);
+      let job = readJobById(this.db, input.jobId);
       if (!job) throw new Error(`Job ${input.jobId} was not found`);
       if (job.workflowEngine !== "navigator-v1" || (job.workflowMode !== "shadow" && job.workflowMode !== "deterministic")) {
         throw new TypeError("job is not an executable navigator-v1 job");
       }
       if (job.currentWorkflowStepId !== null) throw new TypeError("job already has an active workflow step");
+      const refreshedBindings: NavigatorArtifactBinding[] = [];
       for (const binding of job.artifactBindings) {
         const snapshot = this.artifacts.getCurrentSnapshot(binding.artifactId);
-        if (
-          snapshot?.id !== binding.snapshotId || snapshot.snapshotDigest !== binding.snapshotDigest ||
-          !this.artifacts.isSnapshotValid(binding.snapshotId)
-        ) throw new TypeError("navigator artifact snapshot is stale");
+        if (snapshot && this.artifacts.isSnapshotValid(snapshot.id)) {
+          refreshedBindings.push({
+            artifactId: binding.artifactId,
+            snapshotId: snapshot.id,
+            snapshotDigest: snapshot.snapshotDigest,
+          });
+        }
+      }
+      if (JSON.stringify(refreshedBindings) !== JSON.stringify(job.artifactBindings)) {
+        const refreshed = this.db.prepare(
+          `UPDATE jobs SET artifact_bindings_json = ?, workflow_revision = workflow_revision + 1,
+               version = version + 1, updated_at = ?
+            WHERE id = ? AND version = ? AND current_workflow_step_id IS NULL`,
+        ).run(JSON.stringify(refreshedBindings), input.now, job.id, job.version);
+        if (refreshed.changes !== 1) throw new VersionConflictError(job.id, job.version);
+        job = readJobById(this.db, input.jobId);
+        if (!job) throw new Error("navigator job disappeared during artifact reconsideration");
+      }
+      if (job.workflowMode !== "shadow" && job.workflowMode !== "deterministic") {
+        throw new TypeError("navigator workflow mode changed during artifact reconsideration");
       }
       const payload = {
         engine: "navigator-v1" as const,
@@ -466,34 +551,81 @@ export class NavigatorRepository {
         this.insertDecision(proposalId, job.id, input.snapshotId, "shadowed", "shadow_only", input.now);
         return this.requireDecision(proposalId);
       }
-      if (proposal?.kind !== "invoke_skill") throw new Error("deterministic proposal validation was inconsistent");
-      const invokeProposal = proposal;
-      const catalogEntry = NAVIGATOR_SKILL_CATALOG.find((entry) => entry.id === invokeProposal.skillId);
+      if (proposal?.kind !== "invoke_skill" && proposal?.kind !== "unresolved_next_step") {
+        throw new Error("deterministic proposal validation was inconsistent");
+      }
+      const unresolvedDigest = proposal.kind === "unresolved_next_step"
+        ? routingDecisionDigest(proposal)
+        : null;
+      if (unresolvedDigest !== null) {
+        const existingRouting = this.getRoutingDecision(unresolvedDigest);
+        if (existingRouting) {
+          this.db.prepare(
+            `INSERT OR IGNORE INTO navigator_routing_blocks (
+               decision_digest, proposal_id, reason, recorded_at
+             ) VALUES (?, ?, 'unchanged_routing_unresolved_after_consultation', ?)`,
+          ).run(unresolvedDigest, proposalId, input.now);
+          this.db.prepare(
+            `UPDATE jobs SET state = 'blocked', last_error = ?, version = version + 1, updated_at = ?
+              WHERE id = ? AND version = ? AND current_workflow_step_id IS NULL`,
+          ).run(
+            "Navigator routing remained unresolved after one ask-matt consultation",
+            input.now,
+            job.id,
+            job.version,
+          );
+          this.insertDecision(
+            proposalId,
+            job.id,
+            input.snapshotId,
+            "accepted",
+            "routing_blocked_after_consultation",
+            input.now,
+          );
+          return this.requireDecision(proposalId);
+        }
+      }
+      const skillId = proposal.kind === "invoke_skill" ? proposal.skillId : "ask-matt";
+      const objective = proposal.kind === "invoke_skill" ? proposal.objective : proposal.question;
+      const evidenceRefs = proposal.evidenceRefs;
+      const subjectArtifactIds = proposal.kind === "invoke_skill"
+        ? new Set(proposal.subjectArtifactIds)
+        : new Set(job.artifactBindings.map((binding) => binding.artifactId));
+      const catalogEntry = NAVIGATOR_SKILL_CATALOG.find((entry) => entry.id === skillId);
       if (!catalogEntry) throw new Error("accepted skill disappeared from the navigator catalog");
-      const route = assertModelRouteForContract(input.selectModelRoute(), NAVIGATOR_RESEARCH_STEP_CONTRACT);
-      const subjectArtifactIds = new Set(invokeProposal.subjectArtifactIds);
+      const contract = navigatorStepContract(skillId);
+      if (!contract) throw new Error("accepted skill contract disappeared");
+      const route = assertModelRouteForContract(input.selectModelRoute(), contract);
       const subjectArtifactBindings = job.artifactBindings.filter((binding) => subjectArtifactIds.has(binding.artifactId));
-      const stepInput = navigatorResearchInputSchema.parse({
-        kind: "navigator_research_input",
-        objective: invokeProposal.objective,
-        artifactBindings: subjectArtifactBindings,
-        evidenceRefs: invokeProposal.evidenceRefs,
-      });
-      const stepInputJson = serializeNavigatorJson(stepInput, "navigator research step input");
+      const stepInput = skillId === "research"
+        ? navigatorResearchInputSchema.parse({
+          kind: "navigator_research_input",
+          objective,
+          artifactBindings: subjectArtifactBindings,
+          evidenceRefs,
+        })
+        : navigatorPlanningInput({
+          skillId,
+          objective,
+          artifactBindings: subjectArtifactBindings,
+          evidenceRefs,
+          routingDecisionDigest: unresolvedDigest,
+        });
+      const stepInputJson = serializeNavigatorJson(stepInput, "navigator skill step input");
       const stepInputDigest = createHash("sha256").update(stepInputJson, "utf8").digest("hex");
       const stepId = digestId("wfstep", proposalId, digest);
-      const attemptId = digestId("navattempt", stepId, invokeProposal.skillId);
+      const attemptId = digestId("navattempt", stepId, skillId);
       const effectKey = `${job.id}:navigator:${stepId}:run_skill`;
-      const contractJson = serializeNavigatorJson(NAVIGATOR_RESEARCH_STEP_CONTRACT, "navigator step contract");
+      const contractJson = serializeNavigatorJson(contract, "navigator step contract");
       this.db.prepare(
         `INSERT OR IGNORE INTO workflow_step_contracts (
            id, revision, skill_id, digest, contract_json, recorded_at
          ) VALUES (?, ?, ?, ?, ?, ?)`,
       ).run(
-        NAVIGATOR_RESEARCH_STEP_CONTRACT.id,
-        NAVIGATOR_RESEARCH_STEP_CONTRACT.revision,
-        NAVIGATOR_RESEARCH_STEP_CONTRACT.skillId,
-        NAVIGATOR_RESEARCH_STEP_CONTRACT.digest,
+        contract.id,
+        contract.revision,
+        contract.skillId,
+        contract.digest,
         contractJson,
         input.now,
       );
@@ -502,12 +634,12 @@ export class NavigatorRepository {
            FROM workflow_step_contracts
           WHERE id = ? AND revision = ?`,
       ).get(
-        NAVIGATOR_RESEARCH_STEP_CONTRACT.id,
-        NAVIGATOR_RESEARCH_STEP_CONTRACT.revision,
+        contract.id,
+        contract.revision,
       ) as { skill_id: string; digest: string; contract_json: string } | undefined;
       if (
-        storedContract?.skill_id !== NAVIGATOR_RESEARCH_STEP_CONTRACT.skillId ||
-        storedContract.digest !== NAVIGATOR_RESEARCH_STEP_CONTRACT.digest ||
+        storedContract?.skill_id !== contract.skillId ||
+        storedContract.digest !== contract.digest ||
         storedContract.contract_json !== contractJson
       ) {
         throw new Error("navigator step contract revision drifted");
@@ -521,11 +653,28 @@ export class NavigatorRepository {
         job.id,
         proposalId,
         input.snapshotId,
-        invokeProposal.skillId,
+        skillId,
         job.version,
         job.workflowRevision,
         input.now,
       );
+      if (proposal.kind === "unresolved_next_step") {
+        this.db.prepare(
+          `INSERT INTO navigator_routing_decisions (
+             decision_digest, job_id, question, candidate_skill_ids_json,
+             rationale, evidence_refs_json, consultation_step_id, recorded_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          unresolvedDigest,
+          job.id,
+          proposal.question,
+          JSON.stringify(proposal.candidateSkillIds),
+          proposal.rationale,
+          JSON.stringify(proposal.evidenceRefs),
+          stepId,
+          input.now,
+        );
+      }
       const effectPayload = {
         workflowStepId: stepId,
         attemptId,
@@ -557,13 +706,13 @@ export class NavigatorRepository {
         job.id,
         stepId,
         effectKey,
-        invokeProposal.skillId,
+        skillId,
         MATT_POCOCK_SKILL_REVISION,
         catalogEntry.sourceDigest,
         catalogEntry.descriptorDigest,
-        NAVIGATOR_RESEARCH_STEP_CONTRACT.id,
-        NAVIGATOR_RESEARCH_STEP_CONTRACT.revision,
-        NAVIGATOR_RESEARCH_STEP_CONTRACT.digest,
+        contract.id,
+        contract.revision,
+        contract.digest,
         NAVIGATOR_SKILL_CATALOG_DIGEST,
         stepInputJson,
         stepInputDigest,
@@ -580,7 +729,14 @@ export class NavigatorRepository {
           WHERE id = ? AND version = ? AND current_workflow_step_id IS NULL`,
       ).run(stepId, input.now, job.id, job.version);
       if (updated.changes !== 1) throw new VersionConflictError(job.id, job.version);
-      this.insertDecision(proposalId, job.id, input.snapshotId, "accepted", "accepted", input.now);
+      this.insertDecision(
+        proposalId,
+        job.id,
+        input.snapshotId,
+        "accepted",
+        proposal.kind === "unresolved_next_step" ? "ask_matt_scheduled" : "accepted",
+        input.now,
+      );
       return this.requireDecision(proposalId);
     }).immediate();
   }
@@ -640,6 +796,163 @@ export class NavigatorRepository {
       resultDigest: row.result_digest,
       recordedAt: row.recorded_at,
     } : null;
+  }
+
+  public recordPlanningResult(input: Readonly<{
+    attemptId: string;
+    effectIdempotencyKey: string;
+    observedExternalStateDigest: string;
+    result: unknown;
+    ownerId: string;
+    generation: number;
+    now: number;
+  }>): NavigatorPlanningResultRecord | null {
+    assertIdentifier(input.attemptId, "attemptId");
+    assertIdentifier(input.effectIdempotencyKey, "effectIdempotencyKey");
+    assertIdentifier(input.ownerId, "ownerId");
+    assertPositiveInteger(input.generation, "generation");
+    assertNonNegativeInteger(input.now, "now");
+    return this.db.transaction(() => {
+      if (!this.effectLeaseCurrent(input.effectIdempotencyKey, input.ownerId, input.generation, input.now)) {
+        return null;
+      }
+      const attempt = this.getAttempt(input.attemptId);
+      if (!attempt || attempt.effectIdempotencyKey !== input.effectIdempotencyKey || attempt.resource === null) {
+        return null;
+      }
+      const snapshotRow = this.db.prepare(
+        `SELECT snapshot.* FROM navigator_snapshots AS snapshot
+          JOIN workflow_steps AS step ON step.snapshot_id = snapshot.id
+         WHERE step.id = ?`,
+      ).get(attempt.workflowStepId) as SnapshotRow | undefined;
+      if (!snapshotRow) return null;
+      const snapshot = parseSnapshot(snapshotRow);
+      const job = this.acceptedSettlementJob(attempt, input.effectIdempotencyKey, snapshot);
+      if (
+        !job || job.cancelRequestedAt !== null ||
+        !/^[0-9a-f]{64}$/u.test(input.observedExternalStateDigest) ||
+        input.observedExternalStateDigest !== snapshot.externalStateDigest ||
+        attempt.artifactBindings.some((binding) => {
+          const current = this.artifacts.getCurrentSnapshot(binding.artifactId);
+          return current?.id !== binding.snapshotId || current.snapshotDigest !== binding.snapshotDigest ||
+            !this.artifacts.isSnapshotValid(binding.snapshotId);
+        })
+      ) return null;
+      const existing = this.getPlanningResult(input.attemptId);
+      if (existing) return existing;
+      const contract = navigatorStepContract(attempt.skillId);
+      if (!contract) return null;
+      const parsedResult = validatedNavigatorOutcome(attempt.skillId, input.result);
+      if (parsedResult === null) return null;
+      const resultKind = typeof parsedResult.kind === "string" ? parsedResult.kind : null;
+      if (
+        (resultKind === "research_result" || resultKind === "prototype_result") &&
+        !artifactEvidenceMatchesBindings(parsedResult, attempt.artifactBindings)
+      ) return null;
+      const resultJson = JSON.stringify(parsedResult);
+      if (Buffer.byteLength(resultJson, "utf8") > contract.maximumResultBytes) return null;
+      const resultDigest = createHash("sha256").update(resultJson, "utf8").digest("hex");
+      this.db.prepare(
+        `INSERT INTO navigator_planning_results (
+           attempt_id, workflow_step_id, skill_id, result_json, result_digest,
+           observed_external_state_digest, recorded_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        attempt.id,
+        attempt.workflowStepId,
+        attempt.skillId,
+        resultJson,
+        resultDigest,
+        input.observedExternalStateDigest,
+        input.now,
+      );
+      return this.getPlanningResult(input.attemptId);
+    }).immediate();
+  }
+
+  public getPlanningResult(attemptId: string): NavigatorPlanningResultRecord | null {
+    assertIdentifier(attemptId, "attemptId");
+    const row = this.db.prepare(
+      `SELECT attempt_id, workflow_step_id, skill_id, result_json, result_digest,
+              observed_external_state_digest, recorded_at
+         FROM navigator_planning_results WHERE attempt_id = ?`,
+    ).get(attemptId) as Readonly<{
+      attempt_id: string;
+      workflow_step_id: string;
+      skill_id: string;
+      result_json: string;
+      result_digest: string;
+      observed_external_state_digest: string;
+      recorded_at: number;
+    }> | undefined;
+    if (!row) return null;
+    const persistedOutcome = row.skill_id === "research"
+      ? navigatorResearchResultSchema.parse(JSON.parse(row.result_json))
+      : parseNavigatorStepResult(row.skill_id, JSON.parse(row.result_json));
+    if (createHash("sha256").update(JSON.stringify(persistedOutcome), "utf8").digest("hex") !== row.result_digest) {
+      throw new Error("navigator planning result digest binding is invalid");
+    }
+    return {
+      attemptId: row.attempt_id,
+      workflowStepId: row.workflow_step_id,
+      skillId: row.skill_id,
+      result: persistedOutcome,
+      resultDigest: row.result_digest,
+      observedExternalStateDigest: row.observed_external_state_digest,
+      recordedAt: row.recorded_at,
+    };
+  }
+
+  public getRoutingDecision(decisionDigest: string): NavigatorRoutingDecision | null {
+    if (!/^[0-9a-f]{64}$/u.test(decisionDigest)) throw new TypeError("decisionDigest must be a SHA-256 digest");
+    const row = this.db.prepare(
+      `SELECT decision.*, advice.attempt_id AS advice_attempt_id,
+              advice.advice_json, advice.result_digest, advice.recorded_at AS advice_recorded_at,
+              block.decision_digest AS blocked_digest
+         FROM navigator_routing_decisions AS decision
+         LEFT JOIN navigator_routing_advice AS advice
+           ON advice.decision_digest = decision.decision_digest
+         LEFT JOIN navigator_routing_blocks AS block
+           ON block.decision_digest = decision.decision_digest
+        WHERE decision.decision_digest = ?`,
+    ).get(decisionDigest) as Readonly<{
+      decision_digest: string;
+      job_id: string;
+      question: string;
+      candidate_skill_ids_json: string;
+      rationale: string;
+      evidence_refs_json: string;
+      consultation_step_id: string;
+      recorded_at: number;
+      advice_attempt_id: string | null;
+      advice_json: string | null;
+      result_digest: string | null;
+      advice_recorded_at: number | null;
+      blocked_digest: string | null;
+    }> | undefined;
+    if (!row) return null;
+    const adviceValue = row.advice_json === null ? null : JSON.parse(row.advice_json) as Readonly<{
+      advice: string;
+      suggestedSkillIds: readonly string[];
+      evidenceRefs: readonly string[];
+    }>;
+    return {
+      decisionDigest: row.decision_digest,
+      jobId: row.job_id,
+      question: row.question,
+      candidateSkillIds: JSON.parse(row.candidate_skill_ids_json) as readonly string[],
+      rationale: row.rationale,
+      evidenceRefs: JSON.parse(row.evidence_refs_json) as readonly string[],
+      consultationStepId: row.consultation_step_id,
+      recordedAt: row.recorded_at,
+      advice: adviceValue === null ? null : {
+        attemptId: row.advice_attempt_id!,
+        ...adviceValue,
+        resultDigest: row.result_digest!,
+        recordedAt: row.advice_recorded_at!,
+      },
+      blocked: row.blocked_digest !== null,
+    };
   }
 
   public leaseSkillEffect(input: Readonly<{
@@ -736,6 +1049,7 @@ export class NavigatorRepository {
     effectIdempotencyKey: string;
     observedExternalStateDigest: string;
     result: unknown;
+    publishedArtifactBindings?: readonly NavigatorArtifactBinding[];
     policyFailureReason?: string;
     ownerId: string;
     generation: number;
@@ -769,7 +1083,8 @@ export class NavigatorRepository {
       if (["merged", "cancelled", "blocked", "complete", "production_failed"].includes(job.state)) return null;
       let reasonCode = input.policyFailureReason ?? "succeeded";
       let outcome: NavigatorWorkflowStepOutcome["outcome"] = input.policyFailureReason ? "policy_failure" : "succeeded";
-      const parsedResult = navigatorResearchResultSchema.safeParse(input.result);
+      const contract = navigatorStepContract(attempt.skillId);
+      const parsedResult = validatedNavigatorOutcome(attempt.skillId, input.result);
       if (outcome === "succeeded" && !/^[0-9a-f]{64}$/u.test(input.observedExternalStateDigest)) {
         outcome = "policy_failure";
         reasonCode = "malformed_external_state_digest";
@@ -778,35 +1093,32 @@ export class NavigatorRepository {
         outcome = "policy_failure";
         reasonCode = "external_drift";
       }
-      if (outcome === "succeeded" && !parsedResult.success) {
+      if (outcome === "succeeded" && parsedResult === null) {
         outcome = "policy_failure";
         reasonCode = "malformed_result";
       }
       if (
-        outcome === "succeeded" && parsedResult.success &&
-        Buffer.byteLength(JSON.stringify(parsedResult.data), "utf8") > NAVIGATOR_RESEARCH_STEP_CONTRACT.maximumResultBytes
+        outcome === "succeeded" && parsedResult !== null && contract !== null &&
+        Buffer.byteLength(JSON.stringify(parsedResult), "utf8") > contract.maximumResultBytes
       ) {
         outcome = "policy_failure";
         reasonCode = "result_too_large";
       }
-      if (outcome === "succeeded" && parsedResult.success) {
-        const evidenceByArtifact = new Map(parsedResult.data.artifactEvidence.map((entry) => [entry.artifactId, entry]));
-        const boundArtifactIds = new Set(attempt.artifactBindings.map((binding) => binding.artifactId));
-        if (
-          evidenceByArtifact.size !== parsedResult.data.artifactEvidence.length ||
-          evidenceByArtifact.size !== boundArtifactIds.size ||
-          [...evidenceByArtifact.keys()].some((artifactId) => !boundArtifactIds.has(artifactId))
-        ) {
+      const resultKind = typeof parsedResult?.kind === "string" ? parsedResult.kind : null;
+      const validatesBoundEvidence = resultKind === "research_result" || resultKind === "prototype_result";
+      if (
+        outcome === "succeeded" && parsedResult !== null && validatesBoundEvidence &&
+        input.publishedArtifactBindings === undefined
+      ) {
+        if (!artifactEvidenceMatchesBindings(parsedResult, attempt.artifactBindings)) {
           outcome = "policy_failure";
           reasonCode = "unauthorized_artifact_evidence";
         } else {
           for (const binding of attempt.artifactBindings) {
             const current = this.artifacts.getCurrentSnapshot(binding.artifactId);
-            const evidence = evidenceByArtifact.get(binding.artifactId);
             if (
               current?.id !== binding.snapshotId || current.snapshotDigest !== binding.snapshotDigest ||
-              !this.artifacts.isSnapshotValid(binding.snapshotId) ||
-              evidence?.snapshotId !== binding.snapshotId || evidence.snapshotDigest !== binding.snapshotDigest
+              !this.artifacts.isSnapshotValid(binding.snapshotId)
             ) {
               outcome = "policy_failure";
               reasonCode = "stale_artifact_snapshot";
@@ -815,14 +1127,48 @@ export class NavigatorRepository {
           }
         }
       }
-      const artifactEvidence = outcome === "succeeded" && parsedResult.success
-        ? parsedResult.data.artifactEvidence
+      const publishedBindings = input.publishedArtifactBindings === undefined
+        ? null
+        : artifactBindingSchema.array().max(128).parse(input.publishedArtifactBindings);
+      if (outcome === "succeeded" && contract?.operationClass === "artifact_write") {
+        if (publishedBindings === null || publishedBindings.length === 0) {
+          outcome = "policy_failure";
+          reasonCode = "artifact_publication_missing";
+        } else if (publishedBindings.some((binding) => {
+          const current = this.artifacts.getCurrentSnapshot(binding.artifactId);
+          return current?.id !== binding.snapshotId || current.snapshotDigest !== binding.snapshotDigest ||
+            !this.artifacts.isSnapshotValid(binding.snapshotId);
+        })) {
+          outcome = "policy_failure";
+          reasonCode = "stale_published_artifact";
+        }
+      }
+      if (outcome === "succeeded" && resultKind === "ask_matt_result") {
+        const routingDigest = attempt.stepInput.kind === "navigator_planning_input"
+          ? attempt.stepInput.routingDecisionDigest
+          : null;
+        if (routingDigest === null || parsedResult?.decisionDigest !== routingDigest) {
+          outcome = "policy_failure";
+          reasonCode = "routing_decision_digest_mismatch";
+        }
+      }
+      const evidenceSource = input.publishedArtifactBindings === undefined
+        ? parsedResult?.artifactEvidence as NavigatorWorkflowStepOutcome["artifactEvidence"] | undefined
+        : undefined;
+      const artifactEvidence = outcome === "succeeded"
+        ? evidenceSource ?? (publishedBindings ?? []).map((binding) => ({
+          ...binding,
+          finding: String(parsedResult?.summary ?? "Navigator planning artifact published."),
+          evidenceRefs: Array.isArray(parsedResult?.evidenceRefs)
+            ? parsedResult.evidenceRefs as readonly string[]
+            : [],
+        }))
         : [];
-      const summary = outcome === "succeeded" && parsedResult.success
-        ? parsedResult.data.summary
+      const summary = outcome === "succeeded" && typeof parsedResult?.summary === "string"
+        ? parsedResult.summary
         : `Navigator skill result rejected: ${reasonCode}`;
       const resultJson = serializeNavigatorJson(
-        outcome === "succeeded" && parsedResult.success ? parsedResult.data : { outcome, reasonCode },
+        outcome === "succeeded" && parsedResult !== null ? parsedResult : { outcome, reasonCode },
         "navigator skill result",
       );
       const resultDigest = createHash("sha256").update(resultJson, "utf8").digest("hex");
@@ -841,11 +1187,35 @@ export class NavigatorRepository {
         resultDigest,
         input.now,
       );
+      if (outcome === "succeeded" && resultKind === "ask_matt_result") {
+        const routingDigest = attempt.stepInput.kind === "navigator_planning_input"
+          ? attempt.stepInput.routingDecisionDigest!
+          : "";
+        this.db.prepare(
+          `INSERT OR IGNORE INTO navigator_routing_advice (
+             decision_digest, attempt_id, advice_json, result_digest, recorded_at
+           ) VALUES (?, ?, ?, ?, ?)`,
+        ).run(
+          routingDigest,
+          attempt.id,
+          JSON.stringify({
+            advice: parsedResult!.advice,
+            suggestedSkillIds: parsedResult!.suggestedSkillIds,
+            evidenceRefs: parsedResult!.evidenceRefs,
+          }),
+          resultDigest,
+          input.now,
+        );
+      }
+      const nextBindings = outcome === "succeeded" && publishedBindings !== null
+        ? publishedBindings
+        : job.artifactBindings;
       const jobUpdate = this.db.prepare(
         `UPDATE jobs SET current_workflow_step_id = NULL,
-             workflow_revision = workflow_revision + 1, version = version + 1, updated_at = ?
+             artifact_bindings_json = ?, workflow_revision = workflow_revision + 1,
+             version = version + 1, updated_at = ?
           WHERE id = ? AND current_workflow_step_id = ?`,
-      ).run(input.now, attempt.jobId, attempt.workflowStepId);
+      ).run(JSON.stringify(nextBindings), input.now, attempt.jobId, attempt.workflowStepId);
       if (jobUpdate.changes !== 1) throw new Error("navigator workflow step changed before settlement");
       const effectUpdate = this.db.prepare(
         `UPDATE effects SET status = 'done', lease_owner = NULL, lease_generation = NULL,

--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -2941,6 +2941,81 @@ BEFORE DELETE ON workflow_step_supersessions
 BEGIN SELECT RAISE(ABORT, 'workflow step supersessions are append-only'); END;
 `] as const;
 
+export const NAVIGATOR_PLANNING_MIGRATIONS = [String.raw`
+CREATE TABLE work_artifact_snapshot_dependencies (
+  snapshot_id TEXT NOT NULL REFERENCES work_artifact_snapshots(id),
+  upstream_snapshot_id TEXT NOT NULL REFERENCES work_artifact_snapshots(id),
+  PRIMARY KEY(snapshot_id, upstream_snapshot_id),
+  CHECK(snapshot_id <> upstream_snapshot_id)
+);
+CREATE TRIGGER work_artifact_snapshot_dependencies_append_only_update
+BEFORE UPDATE ON work_artifact_snapshot_dependencies
+BEGIN SELECT RAISE(ABORT, 'work artifact snapshot dependencies are append-only'); END;
+CREATE TRIGGER work_artifact_snapshot_dependencies_append_only_delete
+BEFORE DELETE ON work_artifact_snapshot_dependencies
+BEGIN SELECT RAISE(ABORT, 'work artifact snapshot dependencies are append-only'); END;
+
+CREATE TABLE navigator_planning_results (
+  attempt_id TEXT PRIMARY KEY REFERENCES navigator_skill_attempts(id),
+  workflow_step_id TEXT NOT NULL UNIQUE REFERENCES workflow_steps(id),
+  skill_id TEXT NOT NULL,
+  result_json TEXT NOT NULL,
+  result_digest TEXT NOT NULL,
+  observed_external_state_digest TEXT NOT NULL,
+  recorded_at INTEGER NOT NULL
+);
+CREATE TRIGGER navigator_planning_results_append_only_update
+BEFORE UPDATE ON navigator_planning_results
+BEGIN SELECT RAISE(ABORT, 'navigator planning results are append-only'); END;
+CREATE TRIGGER navigator_planning_results_append_only_delete
+BEFORE DELETE ON navigator_planning_results
+BEGIN SELECT RAISE(ABORT, 'navigator planning results are append-only'); END;
+
+CREATE TABLE navigator_routing_decisions (
+  decision_digest TEXT PRIMARY KEY,
+  job_id TEXT NOT NULL REFERENCES jobs(id),
+  question TEXT NOT NULL,
+  candidate_skill_ids_json TEXT NOT NULL,
+  rationale TEXT NOT NULL,
+  evidence_refs_json TEXT NOT NULL,
+  consultation_step_id TEXT NOT NULL UNIQUE REFERENCES workflow_steps(id),
+  recorded_at INTEGER NOT NULL
+);
+CREATE TRIGGER navigator_routing_decisions_append_only_update
+BEFORE UPDATE ON navigator_routing_decisions
+BEGIN SELECT RAISE(ABORT, 'navigator routing decisions are append-only'); END;
+CREATE TRIGGER navigator_routing_decisions_append_only_delete
+BEFORE DELETE ON navigator_routing_decisions
+BEGIN SELECT RAISE(ABORT, 'navigator routing decisions are append-only'); END;
+
+CREATE TABLE navigator_routing_advice (
+  decision_digest TEXT PRIMARY KEY REFERENCES navigator_routing_decisions(decision_digest),
+  attempt_id TEXT NOT NULL UNIQUE REFERENCES navigator_skill_attempts(id),
+  advice_json TEXT NOT NULL,
+  result_digest TEXT NOT NULL,
+  recorded_at INTEGER NOT NULL
+);
+CREATE TRIGGER navigator_routing_advice_append_only_update
+BEFORE UPDATE ON navigator_routing_advice
+BEGIN SELECT RAISE(ABORT, 'navigator routing advice is append-only'); END;
+CREATE TRIGGER navigator_routing_advice_append_only_delete
+BEFORE DELETE ON navigator_routing_advice
+BEGIN SELECT RAISE(ABORT, 'navigator routing advice is append-only'); END;
+
+CREATE TABLE navigator_routing_blocks (
+  decision_digest TEXT PRIMARY KEY REFERENCES navigator_routing_decisions(decision_digest),
+  proposal_id TEXT NOT NULL UNIQUE REFERENCES navigator_proposals(id),
+  reason TEXT NOT NULL,
+  recorded_at INTEGER NOT NULL
+);
+CREATE TRIGGER navigator_routing_blocks_append_only_update
+BEFORE UPDATE ON navigator_routing_blocks
+BEGIN SELECT RAISE(ABORT, 'navigator routing blocks are append-only'); END;
+CREATE TRIGGER navigator_routing_blocks_append_only_delete
+BEFORE DELETE ON navigator_routing_blocks
+BEGIN SELECT RAISE(ABORT, 'navigator routing blocks are append-only'); END;
+`] as const;
+
 export const ALL_MIGRATIONS = [
   ...INITIAL_MIGRATIONS,
   ...UPDATE_CLAIM_MIGRATIONS,
@@ -3019,4 +3094,5 @@ export const ALL_MIGRATIONS = [
   ...WORK_ARTIFACT_RELATIONSHIP_IDENTITY_MIGRATIONS,
   ...WORK_ARTIFACT_RELATIONSHIP_CANONICAL_MIGRATIONS,
   ...NAVIGATOR_WORKFLOW_MIGRATIONS,
+  ...NAVIGATOR_PLANNING_MIGRATIONS,
 ] as const;

--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -2402,7 +2402,7 @@ CREATE TABLE work_artifact_tracker_mutations (
   external_id TEXT NOT NULL CHECK (length(external_id) BETWEEN 1 AND 1024),
   operation_id TEXT NOT NULL CHECK (length(operation_id) BETWEEN 1 AND 256),
   artifact_id TEXT NOT NULL CHECK (length(artifact_id) BETWEEN 1 AND 256),
-  kind TEXT NOT NULL CHECK (kind IN ('parent', 'resolve', 'cancel')),
+  kind TEXT NOT NULL CHECK (kind IN ('parent', 'owned_section', 'resolve', 'cancel')),
   payload_digest TEXT NOT NULL CHECK (length(payload_digest) = 64),
   requested_parent_external_id TEXT
     CHECK (requested_parent_external_id IS NULL OR length(requested_parent_external_id) BETWEEN 1 AND 1024),
@@ -2955,6 +2955,23 @@ CREATE TRIGGER work_artifact_snapshot_dependencies_append_only_delete
 BEFORE DELETE ON work_artifact_snapshot_dependencies
 BEGIN SELECT RAISE(ABORT, 'work artifact snapshot dependencies are append-only'); END;
 
+INSERT INTO work_artifact_snapshot_dependencies (snapshot_id, upstream_snapshot_id)
+SELECT downstream.id, upstream.id
+  FROM work_artifact_snapshots AS downstream
+  JOIN json_each(downstream.relationships_json) AS relationship
+  JOIN work_artifact_snapshots AS upstream
+    ON upstream.id = (
+      SELECT candidate.id
+        FROM work_artifact_snapshots AS candidate
+       WHERE candidate.artifact_id = json_extract(relationship.value, '$.targetArtifactId')
+         AND candidate.captured_at <= downstream.captured_at
+       ORDER BY candidate.captured_at DESC, candidate.revision DESC
+       LIMIT 1
+    )
+ WHERE json_extract(relationship.value, '$.kind') = 'derived_from'
+   AND json_type(relationship.value, '$.targetArtifactId') = 'text'
+GROUP BY downstream.id, upstream.id;
+
 CREATE TABLE navigator_planning_results (
   attempt_id TEXT PRIMARY KEY REFERENCES navigator_skill_attempts(id),
   workflow_step_id TEXT NOT NULL UNIQUE REFERENCES workflow_steps(id),
@@ -2973,6 +2990,7 @@ BEGIN SELECT RAISE(ABORT, 'navigator planning results are append-only'); END;
 
 CREATE TABLE navigator_routing_decisions (
   decision_digest TEXT PRIMARY KEY,
+  scope_digest TEXT NOT NULL UNIQUE,
   job_id TEXT NOT NULL REFERENCES jobs(id),
   question TEXT NOT NULL,
   candidate_skill_ids_json TEXT NOT NULL,

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -3826,6 +3826,7 @@ export interface TelegramAgentStore {
     observedExternalStateDigest: string;
     result: unknown;
     publishedArtifactBindings?: readonly NavigatorArtifactBinding[];
+    reconciledArtifactIds?: readonly string[];
     policyFailureReason?: string;
     ownerId: string;
     generation: number;
@@ -12013,6 +12014,7 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
     observedExternalStateDigest: string;
     result: unknown;
     publishedArtifactBindings?: readonly NavigatorArtifactBinding[];
+    reconciledArtifactIds?: readonly string[];
     policyFailureReason?: string;
     ownerId: string;
     generation: number;

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -266,8 +266,10 @@ import { NavigatorRepository } from "../navigator/repository";
 import type {
   NavigatorArtifactBinding,
   NavigatorInferenceObservation,
+  NavigatorPlanningResultRecord,
   NavigatorProposalDecision,
   NavigatorProposalRecord,
+  NavigatorRoutingDecision,
   NavigatorSkillAttempt,
   NavigatorSnapshot,
   NavigatorWorkflowStep,
@@ -3793,6 +3795,17 @@ export interface TelegramAgentStore {
   getNavigatorWorkflowStep(id: string): NavigatorWorkflowStep | null;
   getNavigatorSkillAttempt(id: string): NavigatorSkillAttempt | null;
   getNavigatorWorkflowStepOutcome(workflowStepId: string): NavigatorWorkflowStepOutcome | null;
+  recordNavigatorPlanningResult(input: {
+    attemptId: string;
+    effectIdempotencyKey: string;
+    observedExternalStateDigest: string;
+    result: unknown;
+    ownerId: string;
+    generation: number;
+    now: number;
+  }): NavigatorPlanningResultRecord | null;
+  getNavigatorPlanningResult(attemptId: string): NavigatorPlanningResultRecord | null;
+  getNavigatorRoutingDecision(decisionDigest: string): NavigatorRoutingDecision | null;
   leaseNavigatorSkillEffect(input: {
     ownerId: string;
     generation: number;
@@ -3812,6 +3825,7 @@ export interface TelegramAgentStore {
     effectIdempotencyKey: string;
     observedExternalStateDigest: string;
     result: unknown;
+    publishedArtifactBindings?: readonly NavigatorArtifactBinding[];
     policyFailureReason?: string;
     ownerId: string;
     generation: number;
@@ -11953,6 +11967,26 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
     return this.navigatorRepository.getOutcome(workflowStepId);
   }
 
+  public recordNavigatorPlanningResult(input: {
+    attemptId: string;
+    effectIdempotencyKey: string;
+    observedExternalStateDigest: string;
+    result: unknown;
+    ownerId: string;
+    generation: number;
+    now: number;
+  }): NavigatorPlanningResultRecord | null {
+    return this.navigatorRepository.recordPlanningResult(input);
+  }
+
+  public getNavigatorPlanningResult(attemptId: string): NavigatorPlanningResultRecord | null {
+    return this.navigatorRepository.getPlanningResult(attemptId);
+  }
+
+  public getNavigatorRoutingDecision(decisionDigest: string): NavigatorRoutingDecision | null {
+    return this.navigatorRepository.getRoutingDecision(decisionDigest);
+  }
+
   public leaseNavigatorSkillEffect(input: {
     ownerId: string;
     generation: number;
@@ -11978,6 +12012,7 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
     effectIdempotencyKey: string;
     observedExternalStateDigest: string;
     result: unknown;
+    publishedArtifactBindings?: readonly NavigatorArtifactBinding[];
     policyFailureReason?: string;
     ownerId: string;
     generation: number;

--- a/src/work-artifacts/coordinator.ts
+++ b/src/work-artifacts/coordinator.ts
@@ -19,6 +19,7 @@ import {
 import {
   blockersPayloadDigest,
   claimPayloadDigest,
+  ownedSectionPayloadDigest,
   parentPayloadDigest,
   TrackerConflictError,
   TrackerIdentityConflictError,
@@ -381,6 +382,41 @@ export class WorkArtifactCoordinator {
       if (!snapshot) throw new Error(`Work artifact ${artifact.id} has no current snapshot`);
       return { artifact, snapshot };
     }
+    return this.captureObservationFenced(artifact, external, input);
+  }
+
+  public async updateOwnedSection(input: TrackerEffectFence & Readonly<{
+    artifactId: string;
+    sectionId: string;
+    content: string;
+    operationId: string;
+    now: number;
+  }>): Promise<WorkArtifactCapture> {
+    const artifact = await this.observeCurrentRevision(input);
+    const payloadDigest = ownedSectionPayloadDigest(input);
+    const mutation = this.prepareTrackerMutation({
+      artifactId: artifact.id,
+      kind: "owned_section",
+      operationId: input.operationId,
+      payloadDigest,
+      requestedParentExternalId: null,
+      originalParentExternalId: null,
+      originalRevision: artifact.externalRevision,
+      externalId: artifact.externalId,
+      fence: input,
+      now: input.now,
+    });
+    const reconciliation = await this.reconcileOrBeginBoundTrackerMutation(mutation, artifact, input);
+    const external = reconciliation.shouldApply
+      ? await this.runBoundTrackerEffect(artifact, input, () => this.tracker.updateOwnedSection({
+        externalId: artifact.externalId,
+        sectionId: input.sectionId,
+        content: input.content,
+        operationId: input.operationId,
+        expectedRevision: artifact.externalRevision,
+      }))
+      : reconciliation.artifact ?? await this.readBoundTrackerArtifact(artifact);
+    if (reconciliation.shouldApply) this.completeTrackerMutation(mutation, external, input);
     return this.captureObservationFenced(artifact, external, input);
   }
 
@@ -1014,7 +1050,9 @@ export class WorkArtifactCoordinator {
         ? evidenceArtifact.parentExternalId === mutation.requestedParentExternalId
         : mutation.kind === "resolve"
           ? evidenceArtifact.state === "closed"
-          : evidenceArtifact.state === "cancelled";
+          : mutation.kind === "cancel"
+            ? evidenceArtifact.state === "cancelled"
+            : true;
       if (operationEvidence.status === "completed" && nativeStateMatches) {
         this.completeTrackerMutation(mutation, evidenceArtifact, fence);
         return { shouldApply: false, artifact: evidenceArtifact };

--- a/src/work-artifacts/repository.ts
+++ b/src/work-artifacts/repository.ts
@@ -189,7 +189,7 @@ export type FinalizeWorkArtifactResolutionInput = Readonly<{
   now: number;
 }>;
 
-export type WorkArtifactTrackerMutationKind = "parent" | "resolve" | "cancel";
+export type WorkArtifactTrackerMutationKind = "parent" | "owned_section" | "resolve" | "cancel";
 export type WorkArtifactTrackerMutationPhase =
   | "prepared"
   | "applying"
@@ -903,7 +903,10 @@ export class WorkArtifactRepository {
   ): WorkArtifactTrackerMutation {
     this.validateTrackerMutationKey(input);
     assertBoundedString(input.artifactId, "artifactId");
-    if (input.kind !== "parent" && input.kind !== "resolve" && input.kind !== "cancel") {
+    if (
+      input.kind !== "parent" && input.kind !== "owned_section" &&
+      input.kind !== "resolve" && input.kind !== "cancel"
+    ) {
       throw new TypeError("work artifact tracker mutation kind is invalid");
     }
     if (!/^[0-9a-f]{64}$/u.test(input.payloadDigest)) {
@@ -1617,7 +1620,7 @@ export class WorkArtifactRepository {
       input.capturedAt,
     );
     const dependencyIds = input.relationships
-      .filter((relationship) => relationship.kind === "parent" || relationship.kind === "derived_from")
+      .filter((relationship) => relationship.kind === "derived_from")
       .map((relationship) => relationship.targetArtifactId)
       .filter((artifactId): artifactId is string => artifactId !== null)
       .map((artifactId) => this.requireArtifact(artifactId).currentSnapshotId);

--- a/src/work-artifacts/repository.ts
+++ b/src/work-artifacts/repository.ts
@@ -1729,10 +1729,10 @@ export class WorkArtifactRepository {
     for (const evidenceRef of evidenceRefs) {
       const navigatorMatch = /^navigator-result:([A-Za-z0-9_-]{1,256})$/u.exec(evidenceRef);
       if (navigatorMatch) {
-        if (outcome !== "resolved" || !this.navigatorResultAuthorizesResolution(
-          navigatorMatch[1],
-          artifact,
-        )) {
+        const authorized = outcome === "resolved"
+          ? this.navigatorResultAuthorizesResolution(navigatorMatch[1], artifact)
+          : this.navigatorResultAuthorizesPublicationSupersession(navigatorMatch[1], artifact);
+        if (!authorized) {
           throw new TypeError("artifact resolution requires authoritative evidence for its current snapshot");
         }
         continue;
@@ -1781,6 +1781,32 @@ export class WorkArtifactRepository {
           AND json_extract(binding.value, '$.artifactId') = ?
           AND json_extract(binding.value, '$.snapshotId') = ?`,
     ).get(attemptId, artifact.projectId, artifact.id, artifact.currentSnapshotId) !== undefined;
+  }
+
+  private navigatorResultAuthorizesPublicationSupersession(
+    attemptId: string,
+    artifact: WorkArtifact,
+  ): boolean {
+    const row = this.db.prepare(
+      `SELECT result.skill_id, attempt.workflow_step_id
+         FROM navigator_planning_results AS result
+         JOIN navigator_skill_attempts AS attempt ON attempt.id = result.attempt_id
+         JOIN jobs AS job ON job.id = attempt.job_id
+        WHERE result.attempt_id = ? AND job.id = ? AND job.project_id = ?
+          AND NOT EXISTS (
+            SELECT 1 FROM json_each(job.artifact_bindings_json) AS binding
+             WHERE json_extract(binding.value, '$.artifactId') = ?
+          )`,
+    ).get(attemptId, artifact.effortId, artifact.projectId, artifact.id) as Readonly<{
+      skill_id: string;
+      workflow_step_id: string;
+    }> | undefined;
+    if (!row || artifact.id !== stableWorkArtifactId(artifact.projectId, artifact.operationId)) return false;
+    const operation = artifact.operationId.slice(`${row.workflow_step_id}:`.length);
+    if (!artifact.operationId.startsWith(`${row.workflow_step_id}:`)) return false;
+    if (row.skill_id === "wayfinder") return operation === "map" || /^decision:[0-9]+$/u.test(operation);
+    if (row.skill_id === "to-spec") return operation === "specification";
+    return row.skill_id === "to-tickets" && /^ticket:[0-9]+$/u.test(operation);
   }
 
   private validateCapture(input: CaptureWorkArtifactInput) {

--- a/src/work-artifacts/repository.ts
+++ b/src/work-artifacts/repository.ts
@@ -1090,10 +1090,18 @@ export class WorkArtifactRepository {
 
   public isSnapshotValid(snapshotIdValue: string): boolean {
     assertBoundedString(snapshotIdValue, "snapshotId");
-    if (!this.getSnapshot(snapshotIdValue)) return false;
-    return this.db.prepare(
-      "SELECT 1 FROM work_artifact_snapshot_invalidations WHERE snapshot_id = ?",
-    ).get(snapshotIdValue) === undefined;
+    const pending = [snapshotIdValue];
+    const visited = new Set<string>();
+    while (pending.length > 0) {
+      const candidateId = pending.pop()!;
+      if (visited.has(candidateId)) continue;
+      visited.add(candidateId);
+      const snapshot = this.getSnapshot(candidateId);
+      if (!snapshot || this.getSnapshotInvalidation(candidateId)) return false;
+      if (this.requireArtifact(snapshot.artifactId).currentSnapshotId !== candidateId) return false;
+      pending.push(...this.snapshotDependencies(candidateId));
+    }
+    return true;
   }
 
   public getSnapshotInvalidation(snapshotIdValue: string): WorkArtifactSnapshotInvalidation | null {
@@ -1525,17 +1533,17 @@ export class WorkArtifactRepository {
       capturedAt: input.observedAt,
       ...normalized,
     });
+    const reason = current.contentDigest === snapshot.contentDigest &&
+      current.title === snapshot.title &&
+      JSON.stringify(current.acceptanceCriteria) === JSON.stringify(snapshot.acceptanceCriteria)
+      ? "relationship_change"
+      : "remote_edit";
+    this.db.prepare(
+      `INSERT INTO work_artifact_snapshot_invalidations (
+         snapshot_id, replacement_snapshot_id, reason, observed_at
+       ) VALUES (?, ?, ?, ?)`,
+    ).run(current.id, snapshot.id, reason, input.observedAt);
     if (heldClaim?.snapshotId === current.id) {
-      const reason = current.contentDigest === snapshot.contentDigest &&
-        current.title === snapshot.title &&
-        JSON.stringify(current.acceptanceCriteria) === JSON.stringify(snapshot.acceptanceCriteria)
-        ? "relationship_change"
-        : "remote_edit";
-      this.db.prepare(
-        `INSERT INTO work_artifact_snapshot_invalidations (
-           snapshot_id, replacement_snapshot_id, reason, observed_at
-         ) VALUES (?, ?, ?, ?)`,
-      ).run(current.id, snapshot.id, reason, input.observedAt);
       this.invalidateHeldClaim(artifact.id, input.observedAt, reason);
     } else if (visibleClaimChanged) {
       this.invalidateHeldClaim(artifact.id, input.observedAt, "visible_claim_changed");
@@ -1565,6 +1573,15 @@ export class WorkArtifactRepository {
       artifact.id,
     );
     return { artifact: this.requireArtifact(artifact.id), snapshot };
+  }
+
+  private snapshotDependencies(snapshotIdValue: string): readonly string[] {
+    const rows = this.db.prepare(
+      `SELECT upstream_snapshot_id
+         FROM work_artifact_snapshot_dependencies
+        WHERE snapshot_id = ?`,
+    ).all(snapshotIdValue) as readonly Readonly<{ upstream_snapshot_id: string }>[];
+    return rows.map((row) => row.upstream_snapshot_id);
   }
 
   private insertSnapshot(input: Readonly<{
@@ -1599,6 +1616,18 @@ export class WorkArtifactRepository {
       input.externalRevision,
       input.capturedAt,
     );
+    const dependencyIds = input.relationships
+      .filter((relationship) => relationship.kind === "parent" || relationship.kind === "derived_from")
+      .map((relationship) => relationship.targetArtifactId)
+      .filter((artifactId): artifactId is string => artifactId !== null)
+      .map((artifactId) => this.requireArtifact(artifactId).currentSnapshotId);
+    const insertDependency = this.db.prepare(
+      `INSERT INTO work_artifact_snapshot_dependencies (snapshot_id, upstream_snapshot_id)
+       VALUES (?, ?)`,
+    );
+    for (const upstreamSnapshotId of new Set(dependencyIds)) {
+      insertDependency.run(id, upstreamSnapshotId);
+    }
     return this.requireSnapshot(id);
   }
 
@@ -1695,6 +1724,16 @@ export class WorkArtifactRepository {
     const artifactSubject = `work-artifact:${artifact.id}`;
     const snapshotSubject = `work-artifact-snapshot:${artifact.currentSnapshotId}`;
     for (const evidenceRef of evidenceRefs) {
+      const navigatorMatch = /^navigator-result:([A-Za-z0-9_-]{1,256})$/u.exec(evidenceRef);
+      if (navigatorMatch) {
+        if (outcome !== "resolved" || !this.navigatorResultAuthorizesResolution(
+          navigatorMatch[1],
+          artifact,
+        )) {
+          throw new TypeError("artifact resolution requires authoritative evidence for its current snapshot");
+        }
+        continue;
+      }
       const match = /^evidence:([1-9][0-9]*)$/u.exec(evidenceRef);
       if (!match) throw new TypeError("artifact resolution requires authoritative evidence references");
       const evidenceId = Number(match[1]);
@@ -1725,6 +1764,20 @@ export class WorkArtifactRepository {
         throw new TypeError("artifact resolution requires authoritative evidence for its current snapshot");
       }
     }
+  }
+
+  private navigatorResultAuthorizesResolution(attemptId: string, artifact: WorkArtifact): boolean {
+    return this.db.prepare(
+      `SELECT 1
+         FROM navigator_planning_results AS result
+         JOIN navigator_skill_attempts AS attempt ON attempt.id = result.attempt_id
+         JOIN jobs AS job ON job.id = attempt.job_id
+         JOIN json_each(attempt.artifact_bindings_json) AS binding
+        WHERE result.attempt_id = ? AND result.skill_id IN ('research', 'prototype')
+          AND job.project_id = ?
+          AND json_extract(binding.value, '$.artifactId') = ?
+          AND json_extract(binding.value, '$.snapshotId') = ?`,
+    ).get(attemptId, artifact.projectId, artifact.id, artifact.currentSnapshotId) !== undefined;
   }
 
   private validateCapture(input: CaptureWorkArtifactInput) {

--- a/tests/autonomy-migration.test.ts
+++ b/tests/autonomy-migration.test.ts
@@ -102,7 +102,7 @@ function insertRelationshipUpgradeArtifact(
 }
 
 it("keeps the autonomy migration after the frozen legacy positions and appends later migrations", () => {
-  expect(ALL_MIGRATIONS).toHaveLength(LEGACY_MIGRATION_COUNT + 61);
+  expect(ALL_MIGRATIONS).toHaveLength(LEGACY_MIGRATION_COUNT + 62);
   for (const [index, marker] of LEGACY_MIGRATION_MARKERS) {
     expect(ALL_MIGRATIONS[index]).toContain(marker);
   }
@@ -166,12 +166,14 @@ it("keeps the autonomy migration after the frozen legacy positions and appends l
     .toContain("work_artifact_relationships_canonical_insert");
   expect(ALL_MIGRATIONS[LEGACY_MIGRATION_COUNT + 60])
     .toContain("CREATE TABLE navigator_snapshots");
+  expect(ALL_MIGRATIONS[LEGACY_MIGRATION_COUNT + 61])
+    .toContain("CREATE TABLE navigator_planning_results");
 });
 
 it("strengthens relationship triggers after the original artifact migration was applied", () => {
   const { bb } = createFakePluginHost({ pluginId: "work-artifact-relationship-trigger-upgrade" });
   const db = bb.storage.database();
-  bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, -2));
+  bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, -3));
   expect(db.prepare(
     "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'work_artifact_relationships'",
   ).get()).toEqual({ name: "work_artifact_relationships" });
@@ -251,7 +253,7 @@ it.each([
     pluginId: `work-artifact-invalid-relationship-upgrade-${String(relationship[1])}`,
   });
   const db = bb.storage.database();
-  const migrationsBeforeUpgrade = ALL_MIGRATIONS.length - 3;
+  const migrationsBeforeUpgrade = ALL_MIGRATIONS.length - 4;
   bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, migrationsBeforeUpgrade));
   const insertArtifact = db.prepare(
     `INSERT INTO work_artifacts (
@@ -394,7 +396,7 @@ it.each([
     pluginId: `work-artifact-canonical-relationship-${String(_scenario).replaceAll(" ", "-")}`,
   });
   const db = bb.storage.database();
-  const migrationsBeforeUpgrade = ALL_MIGRATIONS.length - 2;
+  const migrationsBeforeUpgrade = ALL_MIGRATIONS.length - 3;
   bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, migrationsBeforeUpgrade));
   arrange(db);
   const ledgerBefore = db.prepare("SELECT * FROM _bb_migrations ORDER BY id").all();

--- a/tests/autonomy-migration.test.ts
+++ b/tests/autonomy-migration.test.ts
@@ -1,7 +1,10 @@
 import { createFakePluginHost } from "@bb/plugin-sdk/testing";
 import { expect, it } from "vitest";
 import { ALL_MIGRATIONS } from "../src/storage/migrations";
-import { registerWorkArtifactRelationshipValidation } from "../src/work-artifacts/repository";
+import {
+  WorkArtifactRepository,
+  registerWorkArtifactRelationshipValidation,
+} from "../src/work-artifacts/repository";
 
 const LEGACY_MIGRATION_COUNT = 16;
 const LEGACY_PROJECT_ID = "proj_legacy";
@@ -229,6 +232,139 @@ it("strengthens relationship triggers after the original artifact migration was 
   ]);
   expect(db.prepare("SELECT COUNT(*) AS count FROM work_artifact_relationships").get())
     .toEqual({ count: 1 });
+});
+
+it("SPEC-39-002: backfills preexisting snapshot dependencies for recursive invalidation", () => {
+  const { bb } = createFakePluginHost({ pluginId: "navigator-dependency-backfill-upgrade" });
+  const db = bb.storage.database();
+  registerWorkArtifactRelationshipValidation(db);
+  bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, -1));
+  const insertArtifact = db.prepare(
+    `INSERT INTO work_artifacts (
+       id, project_id, effort_id, operation_id, kind, initial_status, status,
+       tracker_kind, tracker_namespace, external_id, external_url, external_revision,
+       external_status, assignees_json, title, tracker_order, current_revision,
+       current_snapshot_id, remote_closed_at, created_at, updated_at
+     ) VALUES (?, 'proj_1', 'effort_1', ?, ?, 'ready', 'ready',
+       'github', 'github:acme/widgets', ?, NULL, 'etag-1', 'open', '[]', ?, ?, 1,
+       ?, NULL, ?, ?)`,
+  );
+  const insertSnapshot = db.prepare(
+    `INSERT INTO work_artifact_snapshots (
+       id, artifact_id, revision, title, content, content_digest, snapshot_digest,
+       acceptance_criteria_json, relationships_json, external_revision, captured_at
+     ) VALUES (?, ?, 1, ?, ?, ?, ?, '[]', ?, 'etag-1', ?)`,
+  );
+  const artifacts = [
+    {
+      id: "artifact_upgrade_map",
+      operationId: "upgrade-map",
+      kind: "map",
+      externalId: "701",
+      title: "Upgrade map",
+      order: 0,
+      snapshotId: "snapshot_upgrade_map",
+      capturedAt: 1_000,
+      relationships: [],
+    },
+    {
+      id: "artifact_upgrade_specification",
+      operationId: "upgrade-specification",
+      kind: "specification",
+      externalId: "702",
+      title: "Upgrade specification",
+      order: 1,
+      snapshotId: "snapshot_upgrade_specification",
+      capturedAt: 1_010,
+      relationships: [{
+        kind: "derived_from",
+        sourceArtifactId: "artifact_upgrade_specification",
+        sourceRef: "artifact:artifact_upgrade_specification",
+        targetArtifactId: "artifact_upgrade_map",
+        targetRef: "artifact:artifact_upgrade_map",
+      }],
+    },
+    {
+      id: "artifact_upgrade_ticket",
+      operationId: "upgrade-ticket",
+      kind: "implementation_ticket",
+      externalId: "703",
+      title: "Upgrade ticket",
+      order: 2,
+      snapshotId: "snapshot_upgrade_ticket",
+      capturedAt: 1_020,
+      relationships: [{
+        kind: "derived_from",
+        sourceArtifactId: "artifact_upgrade_ticket",
+        sourceRef: "artifact:artifact_upgrade_ticket",
+        targetArtifactId: "artifact_upgrade_specification",
+        targetRef: "artifact:artifact_upgrade_specification",
+      }],
+    },
+  ] as const;
+  for (const artifact of artifacts) {
+    insertArtifact.run(
+      artifact.id,
+      artifact.operationId,
+      artifact.kind,
+      artifact.externalId,
+      artifact.title,
+      artifact.order,
+      artifact.snapshotId,
+      artifact.capturedAt,
+      artifact.capturedAt,
+    );
+    insertSnapshot.run(
+      artifact.snapshotId,
+      artifact.id,
+      artifact.title,
+      `# ${artifact.title}`,
+      artifact.id === "artifact_upgrade_map" ? "a".repeat(64) :
+        artifact.id === "artifact_upgrade_specification" ? "b".repeat(64) : "c".repeat(64),
+      artifact.id === "artifact_upgrade_map" ? "d".repeat(64) :
+        artifact.id === "artifact_upgrade_specification" ? "e".repeat(64) : "f".repeat(64),
+      JSON.stringify(artifact.relationships),
+      artifact.capturedAt,
+    );
+  }
+
+  bb.storage.migrate(db, [...ALL_MIGRATIONS]);
+
+  expect(db.prepare(
+    `SELECT snapshot_id, upstream_snapshot_id
+       FROM work_artifact_snapshot_dependencies
+      ORDER BY snapshot_id, upstream_snapshot_id`,
+  ).all()).toEqual([
+    {
+      snapshot_id: "snapshot_upgrade_specification",
+      upstream_snapshot_id: "snapshot_upgrade_map",
+    },
+    {
+      snapshot_id: "snapshot_upgrade_ticket",
+      upstream_snapshot_id: "snapshot_upgrade_specification",
+    },
+  ]);
+  db.prepare(
+    `INSERT INTO work_artifact_snapshots (
+       id, artifact_id, revision, title, content, content_digest, snapshot_digest,
+       acceptance_criteria_json, relationships_json, external_revision, captured_at
+     ) VALUES ('snapshot_upgrade_map_2', 'artifact_upgrade_map', 2, 'Upgrade map',
+       '# Upgrade map revised', ?, ?, '[]', '[]', 'etag-2', 1100)`,
+  ).run("1".repeat(64), "2".repeat(64));
+  db.prepare(
+    `INSERT INTO work_artifact_snapshot_invalidations (
+       snapshot_id, replacement_snapshot_id, reason, observed_at
+     ) VALUES ('snapshot_upgrade_map', 'snapshot_upgrade_map_2', 'remote_edit', 1100)`,
+  ).run();
+  db.prepare(
+    `UPDATE work_artifacts
+        SET current_revision = 2, current_snapshot_id = 'snapshot_upgrade_map_2',
+            external_revision = 'etag-2', updated_at = 1100
+      WHERE id = 'artifact_upgrade_map'`,
+  ).run();
+  const repository = new WorkArtifactRepository(db);
+  expect(repository.isSnapshotValid("snapshot_upgrade_specification")).toBe(false);
+  expect(repository.isSnapshotValid("snapshot_upgrade_ticket")).toBe(false);
 });
 
 it.each([

--- a/tests/controller-interaction-repository.test.ts
+++ b/tests/controller-interaction-repository.test.ts
@@ -489,7 +489,7 @@ async function runInteractionRace(
 }
 
 it("pins the shipped migration bytes and appends the runtime repair migrations", () => {
-  expect(ALL_MIGRATIONS).toHaveLength(77);
+  expect(ALL_MIGRATIONS).toHaveLength(78);
   expect(createHash("sha256").update([...ALL_MIGRATIONS].slice(0, 28).join("\u0000")).digest("hex")).toBe(
     "505dfd4781117dfb2c817d31640e833370189e6b3ef2c7c24e646fb1838eed56",
   );
@@ -518,6 +518,8 @@ it("pins the shipped migration bytes and appends the runtime repair migrations",
   expect(ALL_MIGRATIONS[73]).toContain("CREATE TABLE work_artifacts");
   expect(ALL_MIGRATIONS[74]).toContain("work_artifact_relationships_internal_refs");
   expect(ALL_MIGRATIONS[75]).toContain("work_artifact_relationships_canonical_insert");
+  expect(ALL_MIGRATIONS[76]).toContain("CREATE TABLE navigator_snapshots");
+  expect(ALL_MIGRATIONS[77]).toContain("CREATE TABLE navigator_planning_results");
 });
 
 it("copies legacy questions once, preserves their table, and restores the active pointer", () => {

--- a/tests/controller-store.test.ts
+++ b/tests/controller-store.test.ts
@@ -200,7 +200,7 @@ function expectDuplicateGenerationRepair(
 // Applied migrations are immutable history: each release appends, so these are
 // indexed from the start and a new migration only ever extends the tail.
 it("keeps every shipped migration at its original position and appends new ones", () => {
-  expect(ALL_MIGRATIONS).toHaveLength(77);
+  expect(ALL_MIGRATIONS).toHaveLength(78);
   expect(ALL_MIGRATIONS[70]).toContain("attempts_before_consensus_lens");
   expect(ALL_MIGRATIONS[71]).toContain("CREATE TABLE audit_intake_findings");
   expect(ALL_MIGRATIONS[72]).toContain("merge_pre_approved_at");
@@ -209,6 +209,7 @@ it("keeps every shipped migration at its original position and appends new ones"
   expect(ALL_MIGRATIONS[74]).toContain("work_artifact_relationships_internal_refs");
   expect(ALL_MIGRATIONS[75]).toContain("work_artifact_relationships_canonical_insert");
   expect(ALL_MIGRATIONS[76]).toContain("CREATE TABLE navigator_snapshots");
+  expect(ALL_MIGRATIONS[77]).toContain("CREATE TABLE navigator_planning_results");
   expect(ALL_MIGRATIONS[65]).toContain("CREATE TABLE reference_documents");
   expect(ALL_MIGRATIONS[66]).toContain("thread_interactions ADD COLUMN controller_key");
   expect(ALL_MIGRATIONS[67]).toContain("CREATE TABLE reference_section_digests");

--- a/tests/navigator-executor.test.ts
+++ b/tests/navigator-executor.test.ts
@@ -113,6 +113,32 @@ function fixture(
   };
 }
 
+function addNavigatorJob(value: Fixture, id: string, sourceUpdateId: number): Job {
+  const draft = value.store.createJob({
+    id,
+    sourceUpdateId,
+    requestText: "Research the exact ticket before implementation.",
+    workflow: { engine: "navigator-v1", mode: "deterministic" },
+    now: 1_000,
+  });
+  const selected = value.store.applyJobEvent(draft.id, draft.version, {
+    type: "PROJECT_SELECTED",
+    projectId: "proj_1",
+    policyVersion: 1,
+    policy: policyFixture(),
+  }, 1_020);
+  return value.store.bindNavigatorJobArtifacts({
+    jobId: selected.id,
+    expectedVersion: selected.version,
+    artifactBindings: [{
+      artifactId: value.artifactId,
+      snapshotId: value.snapshotId,
+      snapshotDigest: value.snapshotDigest,
+    }],
+    now: 1_030,
+  });
+}
+
 function observation(overrides: Partial<NavigatorInferenceObservation> = {}): NavigatorInferenceObservation {
   return {
     nativeToolCalls: [],
@@ -188,13 +214,10 @@ function executor(
 describe("navigator-v1 durable executor slice", () => {
   it("locks the ticket 39 planning contracts and pinned routing signals", () => {
     expect(Object.keys(NAVIGATOR_PLANNING_STEP_CONTRACTS)).toEqual([
-      "setup-matt-pocock-skills",
       "wayfinder",
       "to-spec",
       "to-tickets",
       "research",
-      "prototype",
-      "handoff",
       "ask-matt",
     ]);
     expect(NAVIGATOR_PLANNING_STEP_CONTRACTS.wayfinder).toMatchObject({
@@ -232,6 +255,37 @@ describe("navigator-v1 durable executor slice", () => {
       requirementsUnclear: true,
     })).toBe("grill-with-docs");
     expect(selectNavigatorPlanningRoute(baseSignals)).toBe("to-spec");
+  });
+
+  it.each([
+    "setup-matt-pocock-skills",
+    "prototype",
+    "handoff",
+  ])("STD-39-001: rejects unsupported side-effecting %s steps", async (skillId) => {
+    const value = fixture();
+    const workflow = executor(value, {
+      navigator: navigatorWith((snapshot) => ({
+        kind: "invoke_skill",
+        basedOn: snapshot.identity,
+        rationale: "This skill performs effects outside the executor boundary.",
+        evidenceRefs: ["ticket:39:STD-39-001"],
+        skillId,
+        subjectArtifactIds: skillId === "setup-matt-pocock-skills" ? [] : [value.artifactId],
+        objective: `Attempt unsupported ${skillId} work.`,
+      })),
+    });
+
+    await expect(workflow.proposeNext({
+      jobId: value.job.id,
+      externalStateDigest: "e".repeat(64),
+      evidenceRefs: [],
+    })).resolves.toMatchObject({
+      decision: "rejected",
+      reasonCode: "capability_denied",
+      workflowStepId: null,
+    });
+    expect(value.store.listEffectsForJob(value.job.id)
+      .filter((effect) => effect.kind === "run_navigator_skill")).toEqual([]);
   });
 
   it("keeps historical and newly created recipe jobs on recipe-v1", () => {
@@ -641,6 +695,120 @@ describe("navigator-v1 durable executor slice", () => {
     });
     expect(value.store.getNavigatorRoutingDecision(decisionDigest)).toMatchObject({ blocked: true });
     expect(value.store.getJob(value.job.id)).toMatchObject({ state: "blocked" });
+  });
+
+  it("SPEC-39-001: scopes identical routing decisions to the job", async () => {
+    const value = fixture();
+    const secondJob = addNavigatorJob(value, "job_navigator_same_words", 39_999);
+    const unresolved = (snapshot: NavigatorSnapshot): NavigatorProposal => ({
+      kind: "unresolved_next_step",
+      basedOn: snapshot.identity,
+      rationale: "The evidence admits two different planning routes.",
+      evidenceRefs: ["owner-request:39"],
+      question: "Should this task use research or wayfinder next?",
+      candidateSkillIds: ["research", "wayfinder"],
+    });
+    const workflow = executor(value, { navigator: navigatorWith(unresolved) });
+
+    const first = await workflow.proposeNext({
+      jobId: value.job.id,
+      externalStateDigest: "e".repeat(64),
+      evidenceRefs: [],
+    });
+    const second = await workflow.proposeNext({
+      jobId: secondJob.id,
+      externalStateDigest: "e".repeat(64),
+      evidenceRefs: [],
+    });
+
+    expect(first).toMatchObject({ decision: "accepted", reasonCode: "ask_matt_scheduled" });
+    expect(second).toMatchObject({ decision: "accepted", reasonCode: "ask_matt_scheduled" });
+    const firstAttempt = value.store.getNavigatorSkillAttempt(first.attemptId!);
+    const secondAttempt = value.store.getNavigatorSkillAttempt(second.attemptId!);
+    if (
+      firstAttempt?.stepInput.kind !== "navigator_planning_input" ||
+      secondAttempt?.stepInput.kind !== "navigator_planning_input"
+    ) throw new Error("routing attempts were not persisted");
+    expect(secondAttempt.stepInput.routingDecisionDigest)
+      .not.toBe(firstAttempt.stepInput.routingDecisionDigest);
+    expect(value.store.getJob(secondJob.id)).not.toMatchObject({ state: "blocked" });
+  });
+
+  it("SPEC-39-001: scopes routing advice to the accepted workflow and artifact revision", async () => {
+    const value = fixture();
+    const unresolved = (snapshot: NavigatorSnapshot): NavigatorProposal => ({
+      kind: "unresolved_next_step",
+      basedOn: snapshot.identity,
+      rationale: "The evidence admits two different planning routes.",
+      evidenceRefs: ["owner-request:39"],
+      question: "Should this task use research or wayfinder next?",
+      candidateSkillIds: ["research", "wayfinder"],
+    });
+    const workflow = executor(value, {
+      navigator: navigatorWith(unresolved),
+      skillRunner: {
+        run: vi.fn(async (attempt, hooks) => {
+          const resource = { kind: "bb_thread" as const, id: `thr_${attempt.id}` };
+          await hooks.bindResource(resource);
+          if (attempt.stepInput.kind !== "navigator_planning_input") {
+            throw new Error("ask-matt received the wrong input contract");
+          }
+          return {
+            resource,
+            observedExternalStateDigest: "e".repeat(64),
+            result: {
+              kind: "ask_matt_result",
+              decisionDigest: attempt.stepInput.routingDecisionDigest,
+              advice: "Use research for the currently bound ticket revision.",
+              suggestedSkillIds: ["research"],
+              evidenceRefs: ["skill:ask-matt"],
+            },
+          };
+        }),
+      },
+    });
+    const first = await workflow.proposeNext({
+      jobId: value.job.id,
+      externalStateDigest: "e".repeat(64),
+      evidenceRefs: [],
+    });
+    const lease = value.store.acquireExecutorLease("executor-routing-revision", 1_100, 30_000);
+    if (!lease.acquired) throw new Error("routing revision executor lease was unavailable");
+    await workflow.processOne({
+      ownerId: "executor-routing-revision",
+      generation: lease.generation,
+      signal: new AbortController().signal,
+    }, new AbortController().signal);
+    const artifact = value.store.getWorkArtifact(value.artifactId)!;
+    const snapshot = value.store.getCurrentWorkArtifactSnapshot(value.artifactId)!;
+    value.store.observeWorkArtifact({
+      artifactId: artifact.id,
+      expectedExternalRevision: artifact.externalRevision,
+      externalRevision: "ticket-38-etag-2",
+      externalStatus: artifact.externalStatus,
+      assignees: artifact.assignees,
+      title: artifact.title,
+      content: `${snapshot.content}\n\nRevision-scoped routing evidence.`,
+      acceptanceCriteria: snapshot.acceptanceCriteria,
+      relationships: snapshot.relationships,
+      observedAt: 1_200,
+    });
+
+    const second = await workflow.proposeNext({
+      jobId: value.job.id,
+      externalStateDigest: "e".repeat(64),
+      evidenceRefs: [],
+    });
+    expect(second).toMatchObject({ decision: "accepted", reasonCode: "ask_matt_scheduled" });
+    const firstAttempt = value.store.getNavigatorSkillAttempt(first.attemptId!);
+    const secondAttempt = value.store.getNavigatorSkillAttempt(second.attemptId!);
+    if (
+      firstAttempt?.stepInput.kind !== "navigator_planning_input" ||
+      secondAttempt?.stepInput.kind !== "navigator_planning_input"
+    ) throw new Error("routing revision attempts were not persisted");
+    expect(secondAttempt.workflowRevision).toBeGreaterThan(firstAttempt.workflowRevision);
+    expect(secondAttempt.stepInput.routingDecisionDigest)
+      .not.toBe(firstAttempt.stepInput.routingDecisionDigest);
   });
 
   it("SPEC-38-001: does not dispatch an accepted navigator step after its job is cancelled", async () => {

--- a/tests/navigator-executor.test.ts
+++ b/tests/navigator-executor.test.ts
@@ -14,6 +14,10 @@ import type {
   NavigatorSnapshot,
 } from "../src/navigator/models";
 import { NAVIGATOR_RESEARCH_STEP_CONTRACT, NAVIGATOR_SKILL_CATALOG } from "../src/navigator/models";
+import {
+  NAVIGATOR_PLANNING_STEP_CONTRACTS,
+  selectNavigatorPlanningRoute,
+} from "../src/navigator/planning-contracts";
 import { runJobExecutorService } from "../src/services/job-executor-service";
 import { openStore, type TelegramAgentStore } from "../src/storage/store";
 import { stableWorkArtifactId, type CaptureWorkArtifactInput } from "../src/work-artifacts/repository";
@@ -53,12 +57,25 @@ function artifactInput(artifactId: string): CaptureWorkArtifactInput {
   };
 }
 
-function fixture(mode: "shadow" | "deterministic" = "deterministic"): Fixture {
+function fixture(
+  mode: "shadow" | "deterministic" = "deterministic",
+  withSpecification = false,
+): Fixture {
   const fixtureId = fixtureNumber++;
   const { bb } = createFakePluginHost({ pluginId: `navigator-executor-${fixtureId}` });
   const store = openStore(bb.storage, bb.storage.kv, () => 1_100);
   const artifactId = stableWorkArtifactId("proj_1", "ticket-38");
   const artifact = store.captureWorkArtifact(artifactInput(artifactId));
+  const specificationId = stableWorkArtifactId("proj_1", "ticket-39-specification");
+  const specification = withSpecification ? store.captureWorkArtifact({
+    ...artifactInput(specificationId),
+    operationId: "ticket-39-specification",
+    kind: "specification",
+    externalId: "39-specification",
+    externalUrl: "https://github.com/acme/widgets/issues/39",
+    externalRevision: "ticket-39-specification-etag-1",
+    title: "Ticket 39 canonical specification",
+  }) : null;
   const draft = store.createJob({
     id: `job_navigator_${fixtureId}`,
     sourceUpdateId: 38_000 + fixtureId,
@@ -79,7 +96,11 @@ function fixture(mode: "shadow" | "deterministic" = "deterministic"): Fixture {
       artifactId,
       snapshotId: artifact.snapshot.id,
       snapshotDigest: artifact.snapshot.snapshotDigest,
-    }],
+    }, ...(specification ? [{
+      artifactId: specificationId,
+      snapshotId: specification.snapshot.id,
+      snapshotDigest: specification.snapshot.snapshotDigest,
+    }] : [])],
     now: 1_030,
   });
   return {
@@ -165,6 +186,54 @@ function executor(
 }
 
 describe("navigator-v1 durable executor slice", () => {
+  it("locks the ticket 39 planning contracts and pinned routing signals", () => {
+    expect(Object.keys(NAVIGATOR_PLANNING_STEP_CONTRACTS)).toEqual([
+      "setup-matt-pocock-skills",
+      "wayfinder",
+      "to-spec",
+      "to-tickets",
+      "research",
+      "prototype",
+      "handoff",
+      "ask-matt",
+    ]);
+    expect(NAVIGATOR_PLANNING_STEP_CONTRACTS.wayfinder).toMatchObject({
+      invocationClass: "user",
+      operationClass: "artifact_write",
+    });
+    expect(NAVIGATOR_PLANNING_STEP_CONTRACTS.research).toMatchObject({
+      invocationClass: "model",
+      operationClass: "read_only",
+    });
+    const baseSignals = {
+      trackerConfigured: true,
+      specificationReady: false,
+      hugeMultiSessionEffort: false,
+      routeToDestinationVisible: true,
+      needsPrimarySourceFacts: false,
+      runnableDesignQuestion: false,
+      workingDirectoryAvailable: true,
+      requirementsUnclear: false,
+    };
+    expect(selectNavigatorPlanningRoute({ ...baseSignals, trackerConfigured: false }))
+      .toBe("setup-matt-pocock-skills");
+    expect(selectNavigatorPlanningRoute({ ...baseSignals, specificationReady: true }))
+      .toBe("to-tickets");
+    expect(selectNavigatorPlanningRoute({ ...baseSignals, needsPrimarySourceFacts: true }))
+      .toBe("research");
+    expect(selectNavigatorPlanningRoute({
+      ...baseSignals,
+      hugeMultiSessionEffort: true,
+      routeToDestinationVisible: false,
+    })).toBe("wayfinder");
+    expect(selectNavigatorPlanningRoute({
+      ...baseSignals,
+      routeToDestinationVisible: false,
+      requirementsUnclear: true,
+    })).toBe("grill-with-docs");
+    expect(selectNavigatorPlanningRoute(baseSignals)).toBe("to-spec");
+  });
+
   it("keeps historical and newly created recipe jobs on recipe-v1", () => {
     const { bb } = createFakePluginHost({ pluginId: `navigator-recipe-${fixtureNumber++}` });
     const db = bb.storage.database();
@@ -445,6 +514,133 @@ describe("navigator-v1 durable executor slice", () => {
     expect(decision).toMatchObject({ decision: "rejected", reasonCode: "stale_artifact_snapshot" });
     expect(value.store.listEffectsForJob(value.job.id).filter((effect) => effect.kind === "run_navigator_skill"))
       .toEqual([]);
+  });
+
+  it("admits user-invoked planning skills only from an explicit navigator proposal", async () => {
+    const value = fixture();
+    const explicitWayfinder = executor(value, {
+      navigator: navigatorWith((snapshot) => ({
+        kind: "invoke_skill",
+        basedOn: snapshot.identity,
+        rationale: "This effort is too large and foggy for one session.",
+        evidenceRefs: ["owner-request:39"],
+        skillId: "wayfinder",
+        subjectArtifactIds: [value.artifactId],
+        objective: "Chart one canonical decision map.",
+      })),
+    });
+    const accepted = await explicitWayfinder.proposeNext({
+      jobId: value.job.id,
+      externalStateDigest: "e".repeat(64),
+      evidenceRefs: [],
+    });
+    expect(accepted).toMatchObject({ decision: "accepted", reasonCode: "accepted" });
+    expect(value.store.getNavigatorSkillAttempt(accepted.attemptId!)).toMatchObject({
+      skillId: "wayfinder",
+      stepInput: { kind: "navigator_planning_input", skillId: "wayfinder" },
+    });
+  });
+
+  it("skips wayfinding once a canonical specification is already bound", async () => {
+    const value = fixture("deterministic", true);
+    const workflow = executor(value, {
+      navigator: navigatorWith((snapshot) => ({
+        kind: "invoke_skill",
+        basedOn: snapshot.identity,
+        rationale: "Try to map work that is already specified.",
+        evidenceRefs: ["owner-request:39"],
+        skillId: "wayfinder",
+        subjectArtifactIds: [value.artifactId],
+        objective: "Create a redundant map.",
+      })),
+    });
+    const decision = await workflow.proposeNext({
+      jobId: value.job.id,
+      externalStateDigest: "e".repeat(64),
+      evidenceRefs: [],
+    });
+    expect(decision).toMatchObject({ decision: "rejected", reasonCode: "unnecessary_wayfinding" });
+    expect(value.store.listEffectsForJob(value.job.id)
+      .filter((effect) => effect.kind === "run_navigator_skill")).toEqual([]);
+  });
+
+  it("stores one ask-matt consultation and blocks a second unchanged unresolved result", async () => {
+    const value = fixture();
+    const unresolved = (snapshot: NavigatorSnapshot): NavigatorProposal => ({
+      kind: "unresolved_next_step",
+      basedOn: snapshot.identity,
+      rationale: "The evidence admits two different planning routes.",
+      evidenceRefs: ["owner-request:39"],
+      question: "Should this task use research or wayfinder next?",
+      candidateSkillIds: ["research", "wayfinder"],
+    });
+    const runner: NavigatorSkillRunner = {
+      run: vi.fn(async (attempt, hooks) => {
+        const resource = { kind: "bb_thread" as const, id: "thr_ask_matt_39" };
+        await hooks.bindResource(resource);
+        if (attempt.stepInput.kind !== "navigator_planning_input") {
+          throw new Error("ask-matt received the wrong input contract");
+        }
+        return {
+          resource,
+          observedExternalStateDigest: "e".repeat(64),
+          result: {
+            kind: "ask_matt_result",
+            decisionDigest: attempt.stepInput.routingDecisionDigest,
+            advice: "Use research only when primary-source facts block the route.",
+            suggestedSkillIds: ["research"],
+            evidenceRefs: ["skill:ask-matt"],
+          },
+        };
+      }),
+    };
+    const workflow = executor(value, {
+      navigator: navigatorWith(unresolved),
+      skillRunner: runner,
+    });
+    const first = await workflow.proposeNext({
+      jobId: value.job.id,
+      externalStateDigest: "e".repeat(64),
+      evidenceRefs: [],
+    });
+    expect(first).toMatchObject({ decision: "accepted", reasonCode: "ask_matt_scheduled" });
+    const attempt = value.store.getNavigatorSkillAttempt(first.attemptId!);
+    if (attempt?.stepInput.kind !== "navigator_planning_input") {
+      throw new Error("ask-matt attempt was not persisted");
+    }
+    const decisionDigest = attempt.stepInput.routingDecisionDigest!;
+    expect(value.store.getNavigatorRoutingDecision(decisionDigest)).toMatchObject({
+      question: "Should this task use research or wayfinder next?",
+      candidateSkillIds: ["research", "wayfinder"],
+      advice: null,
+    });
+    const lease = value.store.acquireExecutorLease("executor-ask-matt", 1_100, 30_000);
+    if (!lease.acquired) throw new Error("ask-matt executor lease was unavailable");
+    await workflow.processOne({
+      ownerId: "executor-ask-matt",
+      generation: lease.generation,
+      signal: new AbortController().signal,
+    }, new AbortController().signal);
+    expect(value.store.getNavigatorRoutingDecision(decisionDigest)).toMatchObject({
+      advice: {
+        advice: "Use research only when primary-source facts block the route.",
+        suggestedSkillIds: ["research"],
+      },
+      blocked: false,
+    });
+
+    const second = await workflow.proposeNext({
+      jobId: value.job.id,
+      externalStateDigest: "e".repeat(64),
+      evidenceRefs: [],
+    });
+    expect(second).toMatchObject({
+      decision: "accepted",
+      reasonCode: "routing_blocked_after_consultation",
+      workflowStepId: null,
+    });
+    expect(value.store.getNavigatorRoutingDecision(decisionDigest)).toMatchObject({ blocked: true });
+    expect(value.store.getJob(value.job.id)).toMatchObject({ state: "blocked" });
   });
 
   it("SPEC-38-001: does not dispatch an accepted navigator step after its job is cancelled", async () => {
@@ -737,6 +933,7 @@ describe("navigator-v1 durable executor slice", () => {
       reasonCode: "unauthorized_artifact_evidence",
       artifactEvidence: [],
     });
+    expect(value.store.getNavigatorPlanningResult(accepted.attemptId!)).toBeNull();
   });
 
   it("enforces the skill contract result bound as a policy failure", async () => {

--- a/tests/navigator-planning.test.ts
+++ b/tests/navigator-planning.test.ts
@@ -30,8 +30,15 @@ class PlanningGitHubGateway implements GitHubIssueGateway {
   private nextNumber = 1;
   private revision = 1;
   private readonly issues = new Map<string, GitHubIssueRecord>();
+  private createPause: Readonly<{ started(): void; wait: Promise<void> }> | null = null;
 
   public async createIssue(input: Readonly<{ title: string; body: string }>): Promise<GitHubIssueRecord> {
+    if (this.createPause) {
+      const pause = this.createPause;
+      this.createPause = null;
+      pause.started();
+      await pause.wait;
+    }
     const externalId = String(this.nextNumber++);
     const issue: GitHubIssueRecord = {
       externalId,
@@ -137,6 +144,19 @@ class PlanningGitHubGateway implements GitHubIssueGateway {
 
   public count(): number {
     return this.issues.size;
+  }
+
+  public pauseNextCreate(): Readonly<{ started: Promise<void>; release(): void }> {
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    let release!: () => void;
+    const wait = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.createPause = { started: markStarted, wait };
+    return { started, release };
   }
 
   private async update(
@@ -307,9 +327,12 @@ async function runPlanningStep(
   }, new AbortController().signal)).resolves.toBe(true);
   const attempt = fixture.store.getNavigatorSkillAttempt(decision.attemptId!);
   if (!attempt || rawResult === undefined) throw new Error("planning attempt did not run");
-  expect(fixture.store.getNavigatorWorkflowStepOutcome(attempt.workflowStepId)).toMatchObject({
-    outcome: "succeeded",
-  });
+  const outcome = fixture.store.getNavigatorWorkflowStepOutcome(attempt.workflowStepId);
+  if (!outcome) {
+    const effect = fixture.store.getEffect(fixture.jobId, attempt.effectIdempotencyKey);
+    throw new Error(`planning outcome was not recorded: ${effect?.lastError ?? "no effect error"}`);
+  }
+  expect(outcome).toMatchObject({ outcome: "succeeded" });
   return { attempt, rawResult };
 }
 
@@ -380,6 +403,17 @@ describe.each(["github", "local_markdown"] as const)("navigator planning through
     expect(fixture.store.listWorkArtifactFrontier(map.id, 10)).toEqual([]);
     expect(decisions.map((decision) => fixture.store.getWorkArtifact(decision.id)?.status))
       .toEqual(["resolved", "resolved"]);
+    for (const decision of decisions) {
+      const trackedDecision = await fixture.tracker.read(decision.externalId);
+      expect(trackedDecision.comments.join("\n"))
+        .toContain(`Durable answer for ${decision.title}.`);
+    }
+    const indexedMap = await fixture.tracker.read(map.externalId);
+    for (const decision of decisions) {
+      const link = decision.externalUrl ?? decision.externalId;
+      expect(indexedMap.body)
+        .toContain(`- [${decision.title}](${link}): Durable answer for ${decision.title}.`);
+    }
 
     await runPlanningStep(fixture, {
       skillId: "to-spec",
@@ -476,8 +510,229 @@ describe.each(["github", "local_markdown"] as const)("navigator planning through
       reason: "remote_edit",
     });
     expect(reconsidered.artifactBindings.map((binding) => binding.artifactId))
-      .toEqual([fixture.rootArtifactId, map.id]);
+      .toEqual([fixture.rootArtifactId, map.id, ...decisions.map((decision) => decision.id), specification.id]);
     expect(fixture.store.getJob(fixture.jobId)!.workflowRevision)
       .toBe(revisionBeforeReconsideration + 1);
+
+    await runPlanningStep(fixture, {
+      skillId: "to-spec",
+      subjectArtifactIds: [map.id, specification.id],
+      result: () => ({
+        kind: "to_spec_result",
+        summary: "The canonical specification is revised after map drift.",
+        specification: {
+          title: "Ticket 39 canonical specification",
+          body: "## Problem Statement\n\nThe owner revised the map.\n\n## Solution\n\nReconcile the existing specification identity.",
+          acceptanceCriteria: ["The original specification artifact is revised"],
+        },
+        evidenceRefs: ["tracker-edit:ticket-39-map"],
+      }),
+    });
+    const reconsideredSpecifications = artifactsOfKind(fixture.store, fixture.jobId, "specification");
+    expect(reconsideredSpecifications).toHaveLength(1);
+    expect(reconsideredSpecifications[0]!.id).toBe(specification.id);
+    await expect(fixture.tracker.read(specification.externalId)).resolves.toMatchObject({
+      body: expect.stringContaining("Reconcile the existing specification identity."),
+    });
   });
+
+  it("SPEC-39-004: resolves prototype decisions from the matched verdict", async () => {
+    const fixture = await planningFixture(trackerKind);
+    await runPlanningStep(fixture, {
+      skillId: "wayfinder",
+      subjectArtifactIds: [fixture.rootArtifactId],
+      result: () => ({
+        kind: "wayfinder_result",
+        summary: "One prototype decision is required.",
+        map: {
+          title: "Prototype decision map",
+          body: "## Destination\n\nChoose behavior.\n\n## Decisions so far\n\n## Not yet specified\n\nPrototype behavior.",
+          acceptanceCriteria: ["The prototype decision is resolved"],
+        },
+        decisionTickets: [{
+          title: "Choose prototype behavior",
+          body: "## Question\n\nWhich behavior should the implementation keep?",
+          acceptanceCriteria: ["The verdict is durable"],
+          blockedBy: [],
+        }],
+        evidenceRefs: ["skill:wayfinder"],
+      }),
+    });
+    const map = artifactsOfKind(fixture.store, fixture.jobId, "map")[0]!;
+    const decision = artifactsOfKind(fixture.store, fixture.jobId, "decision_ticket")[0]!;
+    const decisionSnapshot = fixture.store.getCurrentWorkArtifactSnapshot(decision.id)!;
+    const navigator = {
+      propose: async (snapshot: NavigatorSnapshot): Promise<NavigatorProposal> => ({
+        kind: "invoke_skill",
+        basedOn: snapshot.identity,
+        rationale: "Persist authoritative evidence before prototype publication.",
+        evidenceRefs: ["ticket:39:SPEC-39-004"],
+        skillId: "research",
+        subjectArtifactIds: [decision.id],
+        objective: "Bind the decision snapshot.",
+      }),
+    };
+    const executor = new NavigatorWorkflowExecutor({
+      store: fixture.store,
+      navigator,
+      observeInference: async () => ({
+        nativeToolCalls: [],
+        claimedCodeWorktreeId: null,
+        dynamicEffectToolIds: [],
+        externalStateDigest: "e".repeat(64),
+      }),
+      skillRunner: {
+        run: vi.fn(async (attempt, hooks) => {
+          const resource = { kind: "bb_thread" as const, id: `thr_${attempt.id}` };
+          await hooks.bindResource(resource);
+          return {
+            resource,
+            observedExternalStateDigest: "e".repeat(64),
+            result: {
+              kind: "research_result",
+              summary: "The accepted snapshot is bound for publication.",
+              artifactEvidence: [{
+                artifactId: decision.id,
+                snapshotId: decisionSnapshot.id,
+                snapshotDigest: decisionSnapshot.snapshotDigest,
+                finding: "Research placeholder superseded by the prototype verdict.",
+                evidenceRefs: ["source:prototype-session"],
+              }],
+            },
+          };
+        }),
+      },
+      modelRoute: () => ({ pool: "strong", ...DEFAULT_MODEL_POOL_REGISTRY.worker.strong }),
+      clock: { now: fixture.advance },
+    });
+    const accepted = await executor.proposeNext({
+      jobId: fixture.jobId,
+      externalStateDigest: "e".repeat(64),
+      evidenceRefs: [],
+    });
+    await executor.processOne({
+      ...fixture.fence,
+      signal: new AbortController().signal,
+    }, new AbortController().signal);
+    const attempt = fixture.store.getNavigatorSkillAttempt(accepted.attemptId!);
+    if (!attempt) throw new Error("prototype publication attempt disappeared");
+    await fixture.publisher.publish({
+      ...attempt,
+      skillId: "prototype",
+      workflowStepId: `${attempt.workflowStepId}:prototype-publication`,
+    }, {
+      kind: "prototype_result",
+      summary: "The prototype produced a concrete answer.",
+      verdict: "Keep the immediate feedback behavior.",
+      assetRef: "prototype:feedback-behavior",
+      artifactEvidence: [{
+        artifactId: decision.id,
+        snapshotId: decisionSnapshot.id,
+        snapshotDigest: decisionSnapshot.snapshotDigest,
+        finding: "The prototype supports immediate feedback.",
+        evidenceRefs: ["prototype:feedback-behavior"],
+      }],
+    }, { ...fixture.fence, now: fixture.advance() });
+
+    await expect(fixture.tracker.read(decision.externalId)).resolves.toMatchObject({
+      comments: expect.arrayContaining([expect.stringContaining("Keep the immediate feedback behavior.")]),
+    });
+    const link = decision.externalUrl ?? decision.externalId;
+    await expect(fixture.tracker.read(map.externalId)).resolves.toMatchObject({
+      body: expect.stringContaining(
+        `- [${decision.title}](${link}): Keep the immediate feedback behavior.`,
+      ),
+    });
+  });
+});
+
+it("STD-39-002: rejects drift that lands during asynchronous planning publication", async () => {
+  const fixture = await planningFixture("github");
+  const gateway = fixture.gateway!;
+  const pause = gateway.pauseNextCreate();
+  const navigator = {
+    propose: async (snapshot: NavigatorSnapshot): Promise<NavigatorProposal> => ({
+      kind: "invoke_skill",
+      basedOn: snapshot.identity,
+      rationale: "Publish a map from the exact owner ticket snapshot.",
+      evidenceRefs: ["ticket:39:STD-39-002"],
+      skillId: "wayfinder",
+      subjectArtifactIds: [fixture.rootArtifactId],
+      objective: "Publish the planning map.",
+    }),
+  };
+  const executor = new NavigatorWorkflowExecutor({
+    store: fixture.store,
+    navigator,
+    observeInference: async () => ({
+      nativeToolCalls: [],
+      claimedCodeWorktreeId: null,
+      dynamicEffectToolIds: [],
+      externalStateDigest: "e".repeat(64),
+    }),
+    skillRunner: {
+      run: vi.fn(async (attempt, hooks) => {
+        const resource = { kind: "bb_thread" as const, id: `thr_${attempt.id}` };
+        await hooks.bindResource(resource);
+        return {
+          resource,
+          observedExternalStateDigest: "e".repeat(64),
+          result: {
+            kind: "wayfinder_result",
+            summary: "The old owner ticket snapshot produced a map.",
+            map: {
+              title: "Drifted map",
+              body: "## Destination\n\nReject stale publication.\n\n## Decisions so far\n\n## Not yet specified\n\nOne decision.",
+              acceptanceCriteria: ["Drift fails closed"],
+            },
+            decisionTickets: [{
+              title: "Resolve drift",
+              body: "## Question\n\nWhich snapshot is authoritative?",
+              acceptanceCriteria: ["Use the current snapshot"],
+              blockedBy: [],
+            }],
+            evidenceRefs: ["ticket:39:STD-39-002"],
+          },
+        };
+      }),
+    },
+    planningPublisher: fixture.publisher,
+    modelRoute: () => ({ pool: "strong", ...DEFAULT_MODEL_POOL_REGISTRY.worker.strong }),
+    clock: { now: fixture.advance },
+  });
+  const accepted = await executor.proposeNext({
+    jobId: fixture.jobId,
+    externalStateDigest: "e".repeat(64),
+    evidenceRefs: [],
+  });
+  const processing = executor.processOne({
+    ...fixture.fence,
+    signal: new AbortController().signal,
+  }, new AbortController().signal);
+  await pause.started;
+  const root = fixture.store.getWorkArtifact(fixture.rootArtifactId)!;
+  const externalRoot = await fixture.tracker.read(root.externalId);
+  await fixture.tracker.updateOwnedSection({
+    externalId: root.externalId,
+    sectionId: "revision-note",
+    content: "The owner changed the ticket while publication was awaiting the tracker.",
+    operationId: "ticket-39-drift-during-publication",
+    expectedRevision: externalRoot.revision,
+  });
+  await fixture.coordinator.observe({
+    artifactId: root.id,
+    ...fixture.fence,
+    now: fixture.advance(),
+  });
+  pause.release();
+  await processing;
+
+  expect(fixture.store.getNavigatorWorkflowStepOutcome(accepted.workflowStepId!)).toMatchObject({
+    outcome: "policy_failure",
+    reasonCode: "stale_artifact_snapshot",
+  });
+  expect(fixture.store.getEffect(fixture.jobId, accepted.effectIdempotencyKey!)).toMatchObject({
+    status: "done",
+  });
+  expect(fixture.store.getJob(fixture.jobId)).toMatchObject({ currentWorkflowStepId: null });
 });

--- a/tests/navigator-planning.test.ts
+++ b/tests/navigator-planning.test.ts
@@ -1,0 +1,483 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createFakePluginHost } from "@bb/plugin-sdk/testing";
+import { DEFAULT_MODEL_POOL_REGISTRY } from "../src/capabilities/models";
+import {
+  NavigatorWorkflowExecutor,
+  type NavigatorSkillRunner,
+} from "../src/navigator/executor";
+import type { NavigatorProposal, NavigatorSkillAttempt, NavigatorSnapshot } from "../src/navigator/models";
+import { NavigatorPlanningPublisher } from "../src/navigator/planning-publisher";
+import { openStore, type TelegramAgentStore } from "../src/storage/store";
+import { WorkArtifactCoordinator } from "../src/work-artifacts/coordinator";
+import {
+  GitHubWorkTracker,
+  type GitHubIssueGateway,
+  type GitHubIssueRecord,
+} from "../src/work-artifacts/github-tracker";
+import { LocalMarkdownWorkTracker } from "../src/work-artifacts/local-markdown-tracker";
+import type { WorkArtifact, WorkArtifactKind } from "../src/work-artifacts/models";
+import { TrackerConflictError, type WorkTracker } from "../src/work-artifacts/tracker";
+import { policyFixture } from "./helpers";
+
+const temporaryDirectories: string[] = [];
+let fixtureNumber = 0;
+
+class PlanningGitHubGateway implements GitHubIssueGateway {
+  public readonly namespace = "github:acme/navigator-planning";
+  private nextNumber = 1;
+  private revision = 1;
+  private readonly issues = new Map<string, GitHubIssueRecord>();
+
+  public async createIssue(input: Readonly<{ title: string; body: string }>): Promise<GitHubIssueRecord> {
+    const externalId = String(this.nextNumber++);
+    const issue: GitHubIssueRecord = {
+      externalId,
+      url: `https://github.com/acme/navigator-planning/issues/${externalId}`,
+      title: input.title,
+      body: input.body,
+      state: "open",
+      stateReason: null,
+      assignees: [],
+      comments: [],
+      parentExternalId: null,
+      blockerExternalIds: [],
+      childExternalIds: [],
+      revision: String(this.revision++),
+    };
+    this.issues.set(externalId, issue);
+    return structuredClone(issue);
+  }
+
+  public async readIssue(externalId: string): Promise<GitHubIssueRecord> {
+    const issue = this.issues.get(externalId);
+    if (!issue) throw new Error(`Issue ${externalId} does not exist`);
+    return structuredClone(issue);
+  }
+
+  public async findIssuesByOperationMarker(marker: string): Promise<readonly GitHubIssueRecord[]> {
+    return [...this.issues.values()]
+      .filter((issue) => issue.body.includes(marker) || issue.comments.some((comment) => comment.includes(marker)))
+      .map((issue) => structuredClone(issue));
+  }
+
+  public async addComment(
+    externalId: string,
+    expectedRevision: string,
+    body: string,
+  ): Promise<GitHubIssueRecord> {
+    const current = await this.readIssue(externalId);
+    return this.update(externalId, expectedRevision, { comments: [...current.comments, body] });
+  }
+
+  public addSubIssue(
+    parentExternalId: string,
+    childExternalId: string,
+    expectedChildRevision: string,
+  ): Promise<GitHubIssueRecord> {
+    return this.update(childExternalId, expectedChildRevision, { parentExternalId });
+  }
+
+  public async addBlockedBy(
+    externalId: string,
+    expectedRevision: string,
+    blockerExternalId: string,
+  ): Promise<GitHubIssueRecord> {
+    const current = await this.readIssue(externalId);
+    return this.update(externalId, expectedRevision, {
+      blockerExternalIds: [...new Set([...current.blockerExternalIds, blockerExternalId])],
+    });
+  }
+
+  public async removeBlockedBy(
+    externalId: string,
+    expectedRevision: string,
+    blockerExternalId: string,
+  ): Promise<GitHubIssueRecord> {
+    const current = await this.readIssue(externalId);
+    return this.update(externalId, expectedRevision, {
+      blockerExternalIds: current.blockerExternalIds.filter((id) => id !== blockerExternalId),
+    });
+  }
+
+  public async addAssignee(
+    externalId: string,
+    expectedRevision: string,
+    assignee: string,
+  ): Promise<GitHubIssueRecord> {
+    const current = await this.readIssue(externalId);
+    return this.update(externalId, expectedRevision, {
+      assignees: [...new Set([...current.assignees, assignee])],
+    });
+  }
+
+  public async removeAssignee(
+    externalId: string,
+    expectedRevision: string,
+    assignee: string,
+  ): Promise<GitHubIssueRecord> {
+    const current = await this.readIssue(externalId);
+    return this.update(externalId, expectedRevision, {
+      assignees: current.assignees.filter((login) => login !== assignee),
+    });
+  }
+
+  public closeIssue(
+    externalId: string,
+    expectedRevision: string,
+    reason: "completed" | "not_planned",
+  ): Promise<GitHubIssueRecord> {
+    return this.update(externalId, expectedRevision, {
+      state: reason === "completed" ? "closed" : "cancelled",
+      stateReason: reason,
+    });
+  }
+
+  public count(): number {
+    return this.issues.size;
+  }
+
+  private async update(
+    externalId: string,
+    expectedRevision: string,
+    patch: Readonly<Partial<GitHubIssueRecord>>,
+  ): Promise<GitHubIssueRecord> {
+    const current = await this.readIssue(externalId);
+    if (current.revision !== expectedRevision) throw new TrackerConflictError(externalId);
+    const next = { ...current, ...patch, revision: String(this.revision++) };
+    this.issues.set(externalId, next);
+    if (patch.parentExternalId !== undefined) {
+      for (const [id, issue] of this.issues) {
+        const childExternalIds = issue.childExternalIds.filter((child) => child !== externalId);
+        if (id === patch.parentExternalId) childExternalIds.push(externalId);
+        this.issues.set(id, { ...issue, childExternalIds });
+      }
+    }
+    return structuredClone(next);
+  }
+}
+
+type PlanningFixture = Readonly<{
+  store: TelegramAgentStore;
+  tracker: WorkTracker;
+  coordinator: WorkArtifactCoordinator;
+  publisher: NavigatorPlanningPublisher;
+  jobId: string;
+  rootArtifactId: string;
+  fence: Readonly<{ ownerId: string; generation: number }>;
+  gateway: PlanningGitHubGateway | null;
+  now(): number;
+  advance(): number;
+}>;
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) =>
+    rm(directory, { recursive: true, force: true })));
+});
+
+async function planningFixture(kind: "github" | "local_markdown"): Promise<PlanningFixture> {
+  const fixtureId = fixtureNumber++;
+  const { bb } = createFakePluginHost({ pluginId: `navigator-planning-${kind}-${fixtureId}` });
+  let clock = 10_000;
+  const store = openStore(bb.storage, bb.storage.kv, () => clock);
+  const gateway = kind === "github" ? new PlanningGitHubGateway() : null;
+  const repositoryRoot = await mkdtemp(join(tmpdir(), "navigator-planning-"));
+  temporaryDirectories.push(repositoryRoot);
+  const tracker: WorkTracker = gateway
+    ? new GitHubWorkTracker(gateway)
+    : new LocalMarkdownWorkTracker({ repositoryRoot, effortSlug: `effort-${fixtureId}` });
+  const coordinator = new WorkArtifactCoordinator(store, tracker, () => clock);
+  const lease = store.acquireExecutorLease(`executor-${kind}-${fixtureId}`, clock, 1_000_000);
+  if (!lease.acquired) throw new Error("planning executor lease was unavailable");
+  const fence = { ownerId: `executor-${kind}-${fixtureId}`, generation: lease.generation };
+  const draft = store.createJob({
+    id: `job_planning_${kind}_${fixtureId}`,
+    sourceUpdateId: 390_000 + fixtureId,
+    requestText: "Turn this foggy multi-context task into a specification and ticket frontier.",
+    workflow: { engine: "navigator-v1", mode: "deterministic" },
+    now: clock,
+  });
+  const selected = store.applyJobEvent(draft.id, draft.version, {
+    type: "PROJECT_SELECTED",
+    projectId: "proj_39",
+    policyVersion: 1,
+    policy: policyFixture({ projectId: "proj_39" }),
+  }, ++clock);
+  const root = await coordinator.create({
+    projectId: "proj_39",
+    effortId: draft.id,
+    operationId: "ticket-39-owner-request",
+    kind: "implementation_ticket",
+    status: "ready",
+    title: "Navigate ticket 39",
+    body: "## Goal\n\nCreate one canonical plan from the owner request.",
+    acceptanceCriteria: ["A canonical specification exists"],
+    relationships: [],
+    trackerOrder: 0,
+    ...fence,
+    now: ++clock,
+  });
+  store.bindNavigatorJobArtifacts({
+    jobId: selected.id,
+    expectedVersion: selected.version,
+    artifactBindings: [{
+      artifactId: root.artifact.id,
+      snapshotId: root.snapshot.id,
+      snapshotDigest: root.snapshot.snapshotDigest,
+    }],
+    now: ++clock,
+  });
+  bb.storage.database().prepare("UPDATE jobs SET state = 'implementing' WHERE id = ?").run(draft.id);
+  return {
+    store,
+    tracker,
+    coordinator,
+    publisher: new NavigatorPlanningPublisher(store, coordinator),
+    jobId: draft.id,
+    rootArtifactId: root.artifact.id,
+    fence,
+    gateway,
+    now: () => clock,
+    advance: () => ++clock,
+  };
+}
+
+async function runPlanningStep(
+  fixture: PlanningFixture,
+  input: Readonly<{
+    skillId: string;
+    subjectArtifactIds: readonly string[];
+    result(attempt: NavigatorSkillAttempt): unknown;
+  }>,
+): Promise<Readonly<{ attempt: NavigatorSkillAttempt; rawResult: unknown }>> {
+  let rawResult: unknown;
+  const runner: NavigatorSkillRunner = {
+    run: vi.fn(async (attempt, hooks) => {
+      const resource = { kind: "bb_thread" as const, id: `thr_${attempt.id}` };
+      await hooks.bindResource(resource);
+      rawResult = input.result(attempt);
+      return {
+        resource,
+        observedExternalStateDigest: "e".repeat(64),
+        result: rawResult,
+      };
+    }),
+  };
+  const navigator = {
+    propose: async (snapshot: NavigatorSnapshot): Promise<NavigatorProposal> => ({
+      kind: "invoke_skill",
+      basedOn: snapshot.identity,
+      rationale: `Ticket 39 requires ${input.skillId}.`,
+      evidenceRefs: ["ticket:39"],
+      skillId: input.skillId,
+      subjectArtifactIds: [...input.subjectArtifactIds],
+      objective: `Run ${input.skillId} for ticket 39.`,
+    }),
+  };
+  const executor = new NavigatorWorkflowExecutor({
+    store: fixture.store,
+    navigator,
+    observeInference: async () => ({
+      nativeToolCalls: [],
+      claimedCodeWorktreeId: null,
+      dynamicEffectToolIds: [],
+      externalStateDigest: "e".repeat(64),
+    }),
+    skillRunner: runner,
+    planningPublisher: fixture.publisher,
+    modelRoute: () => ({ pool: "strong", ...DEFAULT_MODEL_POOL_REGISTRY.worker.strong }),
+    clock: { now: fixture.advance },
+  });
+  const decision = await executor.proposeNext({
+    jobId: fixture.jobId,
+    externalStateDigest: "e".repeat(64),
+    evidenceRefs: ["ticket:39"],
+  });
+  if (decision.decision !== "accepted") {
+    const boundIds = fixture.store.getJob(fixture.jobId)?.artifactBindings.map((binding) => binding.artifactId);
+    throw new Error(
+      `planning proposal was ${decision.decision}: ${decision.reasonCode}; subjects=${input.subjectArtifactIds.join(",")}; bound=${boundIds?.join(",")}`,
+    );
+  }
+  await expect(executor.processOne({
+    ...fixture.fence,
+    signal: new AbortController().signal,
+  }, new AbortController().signal)).resolves.toBe(true);
+  const attempt = fixture.store.getNavigatorSkillAttempt(decision.attemptId!);
+  if (!attempt || rawResult === undefined) throw new Error("planning attempt did not run");
+  expect(fixture.store.getNavigatorWorkflowStepOutcome(attempt.workflowStepId)).toMatchObject({
+    outcome: "succeeded",
+  });
+  return { attempt, rawResult };
+}
+
+function artifactsOfKind(
+  store: TelegramAgentStore,
+  jobId: string,
+  kind: WorkArtifactKind,
+): readonly WorkArtifact[] {
+  const job = store.getJob(jobId);
+  if (!job) throw new Error("planning job disappeared");
+  return job.artifactBindings
+    .map((binding) => store.getWorkArtifact(binding.artifactId))
+    .filter((artifact): artifact is WorkArtifact => artifact?.kind === kind);
+}
+
+describe.each(["github", "local_markdown"] as const)("navigator planning through %s", (trackerKind) => {
+  it("publishes a restart-safe map, resolved decisions, canonical spec, and blocker-linked frontier", async () => {
+    const fixture = await planningFixture(trackerKind);
+    const wayfinderResult = {
+      kind: "wayfinder_result",
+      summary: "The fog is split into two ordered decisions.",
+      map: {
+        title: "Ticket 39 decision map",
+        body: "## Destination\n\nOne canonical specification.\n\n## Decisions so far\n\n## Not yet specified\n\nRouting and persistence.",
+        acceptanceCriteria: ["Every decision ticket is resolved"],
+      },
+      decisionTickets: [{
+        title: "Choose the routing signals",
+        body: "## Question\n\nWhich pinned signals select each planning flow?",
+        acceptanceCriteria: ["The signal is tied to pinned guidance"],
+        blockedBy: [],
+      }, {
+        title: "Choose the persistence boundary",
+        body: "## Question\n\nHow are downstream revisions invalidated?",
+        acceptanceCriteria: ["The answer survives restart"],
+        blockedBy: [0],
+      }],
+      evidenceRefs: ["skill:wayfinder"],
+    } as const;
+    const wayfinder = await runPlanningStep(fixture, {
+      skillId: "wayfinder",
+      subjectArtifactIds: [fixture.rootArtifactId],
+      result: () => wayfinderResult,
+    });
+    const map = artifactsOfKind(fixture.store, fixture.jobId, "map")[0]!;
+    const decisions = artifactsOfKind(fixture.store, fixture.jobId, "decision_ticket");
+    expect(decisions).toHaveLength(2);
+    expect(fixture.store.listWorkArtifactFrontier(map.id, 10).map((artifact) => artifact.title))
+      .toEqual(["Choose the routing signals"]);
+    for (const decision of decisions) {
+      const snapshot = fixture.store.getCurrentWorkArtifactSnapshot(decision.id)!;
+      await runPlanningStep(fixture, {
+        skillId: "research",
+        subjectArtifactIds: [decision.id],
+        result: () => ({
+          kind: "research_result",
+          summary: `Resolved ${decision.title} from primary sources.`,
+          artifactEvidence: [{
+            artifactId: decision.id,
+            snapshotId: snapshot.id,
+            snapshotDigest: snapshot.snapshotDigest,
+            finding: `Durable answer for ${decision.title}.`,
+            evidenceRefs: ["source:pinned-skill"],
+          }],
+        }),
+      });
+    }
+    expect(fixture.store.listWorkArtifactFrontier(map.id, 10)).toEqual([]);
+    expect(decisions.map((decision) => fixture.store.getWorkArtifact(decision.id)?.status))
+      .toEqual(["resolved", "resolved"]);
+
+    await runPlanningStep(fixture, {
+      skillId: "to-spec",
+      subjectArtifactIds: [map.id, ...decisions.map((decision) => decision.id)],
+      result: () => ({
+        kind: "to_spec_result",
+        summary: "The resolved map is synthesized into one specification.",
+        specification: {
+          title: "Ticket 39 canonical specification",
+          body: "## Problem Statement\n\nPlanning must survive restart.\n\n## Solution\n\nUse executor-owned contracts and tracker artifacts.",
+          acceptanceCriteria: ["GitHub and local trackers keep the same frontier"],
+        },
+        evidenceRefs: ["map:resolved"],
+      }),
+    });
+    const specifications = artifactsOfKind(fixture.store, fixture.jobId, "specification");
+    expect(specifications).toHaveLength(1);
+    const specification = specifications[0]!;
+
+    await runPlanningStep(fixture, {
+      skillId: "to-tickets",
+      subjectArtifactIds: [specification.id],
+      result: () => ({
+        kind: "to_tickets_result",
+        summary: "The specification is split into two tracer bullets.",
+        tickets: [{
+          title: "Publish the planning artifacts",
+          body: "## What to build\n\nPublish one complete planning path.",
+          acceptanceCriteria: ["The path works through the configured tracker"],
+          blockedBy: [],
+        }, {
+          title: "Verify restart and parity",
+          body: "## What to build\n\nVerify replay and both tracker adapters.",
+          acceptanceCriteria: ["Replay creates no duplicate artifacts"],
+          blockedBy: [0],
+        }],
+        evidenceRefs: ["specification:canonical"],
+      }),
+    });
+    const implementationTickets = artifactsOfKind(fixture.store, fixture.jobId, "implementation_ticket")
+      .filter((artifact) => artifact.id !== fixture.rootArtifactId);
+    expect(implementationTickets).toHaveLength(2);
+    const firstTicket = implementationTickets.find((ticket) => ticket.title === "Publish the planning artifacts")!;
+    const secondTicket = implementationTickets.find((ticket) => ticket.title === "Verify restart and parity")!;
+    await expect(fixture.tracker.read(secondTicket.externalId)).resolves.toMatchObject({
+      acceptanceCriteria: ["Replay creates no duplicate artifacts"],
+      parentExternalId: specification.externalId,
+      blockerExternalIds: [firstTicket.externalId],
+    });
+    expect(fixture.store.listWorkArtifactFrontier(specification.id, 10).map((artifact) => artifact.title))
+      .toEqual(["Publish the planning artifacts"]);
+    const claim = await fixture.coordinator.claim({
+      artifactId: firstTicket.id,
+      workflowStepId: "workflow-claim-ticket-39",
+      jobId: fixture.jobId,
+      assignee: "hanoon-bot",
+      operationId: "claim-ticket-39-frontier",
+      leaseMs: 10_000,
+      ...fixture.fence,
+      now: fixture.advance(),
+    });
+    expect(claim?.claim.state).toBe("held");
+    expect(fixture.store.listWorkArtifactFrontier(specification.id, 10)).toEqual([]);
+    const artifactCount = fixture.store.getJob(fixture.jobId)!.artifactBindings.length;
+    await fixture.publisher.publish(wayfinder.attempt, wayfinder.rawResult, {
+      ...fixture.fence,
+      now: fixture.advance(),
+    });
+    expect(fixture.store.getJob(fixture.jobId)!.artifactBindings).toHaveLength(artifactCount);
+    if (fixture.gateway) expect(fixture.gateway.count()).toBe(7);
+
+    const mapBeforeEdit = fixture.store.getCurrentWorkArtifactSnapshot(map.id)!;
+    const externalMap = await fixture.tracker.read(map.externalId);
+    await fixture.tracker.updateOwnedSection({
+      externalId: map.externalId,
+      sectionId: "revision-note",
+      content: "The owner changed the canonical route after tickets were derived.",
+      operationId: `revise-ticket-39-map-${trackerKind}`,
+      expectedRevision: externalMap.revision,
+    });
+    await fixture.coordinator.observe({
+      artifactId: map.id,
+      ...fixture.fence,
+      now: fixture.advance(),
+    });
+    const revisionBeforeReconsideration = fixture.store.getJob(fixture.jobId)!.workflowRevision;
+    const reconsidered = fixture.store.createNavigatorSnapshot({
+      jobId: fixture.jobId,
+      externalStateDigest: "e".repeat(64),
+      evidenceRefs: ["tracker-edit:ticket-39-map"],
+      now: fixture.advance(),
+    });
+    expect(fixture.store.getWorkArtifactSnapshotInvalidation(mapBeforeEdit.id)).toMatchObject({
+      reason: "remote_edit",
+    });
+    expect(reconsidered.artifactBindings.map((binding) => binding.artifactId))
+      .toEqual([fixture.rootArtifactId, map.id]);
+    expect(fixture.store.getJob(fixture.jobId)!.workflowRevision)
+      .toBe(revisionBeforeReconsideration + 1);
+  });
+});

--- a/tests/navigator-planning.test.ts
+++ b/tests/navigator-planning.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../src/work-artifacts/github-tracker";
 import { LocalMarkdownWorkTracker } from "../src/work-artifacts/local-markdown-tracker";
 import type { WorkArtifact, WorkArtifactKind } from "../src/work-artifacts/models";
+import { stableWorkArtifactId } from "../src/work-artifacts/repository";
 import { TrackerConflictError, type WorkTracker } from "../src/work-artifacts/tracker";
 import { policyFixture } from "./helpers";
 
@@ -30,15 +31,8 @@ class PlanningGitHubGateway implements GitHubIssueGateway {
   private nextNumber = 1;
   private revision = 1;
   private readonly issues = new Map<string, GitHubIssueRecord>();
-  private createPause: Readonly<{ started(): void; wait: Promise<void> }> | null = null;
 
   public async createIssue(input: Readonly<{ title: string; body: string }>): Promise<GitHubIssueRecord> {
-    if (this.createPause) {
-      const pause = this.createPause;
-      this.createPause = null;
-      pause.started();
-      await pause.wait;
-    }
     const externalId = String(this.nextNumber++);
     const issue: GitHubIssueRecord = {
       externalId,
@@ -144,19 +138,6 @@ class PlanningGitHubGateway implements GitHubIssueGateway {
 
   public count(): number {
     return this.issues.size;
-  }
-
-  public pauseNextCreate(): Readonly<{ started: Promise<void>; release(): void }> {
-    let markStarted!: () => void;
-    const started = new Promise<void>((resolve) => {
-      markStarted = resolve;
-    });
-    let release!: () => void;
-    const wait = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    this.createPause = { started: markStarted, wait };
-    return { started, release };
   }
 
   private async update(
@@ -346,6 +327,28 @@ function artifactsOfKind(
   return job.artifactBindings
     .map((binding) => store.getWorkArtifact(binding.artifactId))
     .filter((artifact): artifact is WorkArtifact => artifact?.kind === kind);
+}
+
+function pauseAfterNextCreate(tracker: WorkTracker): Readonly<{
+  started: Promise<void>;
+  release(): void;
+}> {
+  const create = tracker.create.bind(tracker);
+  let markStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  let release!: () => void;
+  const wait = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  vi.spyOn(tracker, "create").mockImplementationOnce(async (input) => {
+    const artifact = await create(input);
+    markStarted();
+    await wait;
+    return artifact;
+  });
+  return { started, release };
 }
 
 describe.each(["github", "local_markdown"] as const)("navigator planning through %s", (trackerKind) => {
@@ -646,93 +649,129 @@ describe.each(["github", "local_markdown"] as const)("navigator planning through
   });
 });
 
-it("STD-39-002: rejects drift that lands during asynchronous planning publication", async () => {
-  const fixture = await planningFixture("github");
-  const gateway = fixture.gateway!;
-  const pause = gateway.pauseNextCreate();
-  const navigator = {
-    propose: async (snapshot: NavigatorSnapshot): Promise<NavigatorProposal> => ({
-      kind: "invoke_skill",
-      basedOn: snapshot.identity,
-      rationale: "Publish a map from the exact owner ticket snapshot.",
-      evidenceRefs: ["ticket:39:STD-39-002"],
-      skillId: "wayfinder",
-      subjectArtifactIds: [fixture.rootArtifactId],
-      objective: "Publish the planning map.",
-    }),
-  };
-  const executor = new NavigatorWorkflowExecutor({
-    store: fixture.store,
-    navigator,
-    observeInference: async () => ({
-      nativeToolCalls: [],
-      claimedCodeWorktreeId: null,
-      dynamicEffectToolIds: [],
-      externalStateDigest: "e".repeat(64),
-    }),
-    skillRunner: {
-      run: vi.fn(async (attempt, hooks) => {
-        const resource = { kind: "bb_thread" as const, id: `thr_${attempt.id}` };
-        await hooks.bindResource(resource);
-        return {
-          resource,
-          observedExternalStateDigest: "e".repeat(64),
-          result: {
-            kind: "wayfinder_result",
-            summary: "The old owner ticket snapshot produced a map.",
-            map: {
-              title: "Drifted map",
-              body: "## Destination\n\nReject stale publication.\n\n## Decisions so far\n\n## Not yet specified\n\nOne decision.",
-              acceptanceCriteria: ["Drift fails closed"],
-            },
-            decisionTickets: [{
-              title: "Resolve drift",
-              body: "## Question\n\nWhich snapshot is authoritative?",
-              acceptanceCriteria: ["Use the current snapshot"],
-              blockedBy: [],
-            }],
-            evidenceRefs: ["ticket:39:STD-39-002"],
-          },
-        };
+describe.each(["github", "local_markdown"] as const)("STD-39-002 through %s", (trackerKind) => {
+  it("reconciles a partially published artifact after subject drift and restart", async () => {
+    const fixture = await planningFixture(trackerKind);
+    const pause = pauseAfterNextCreate(fixture.tracker);
+    const navigator = {
+      propose: async (snapshot: NavigatorSnapshot): Promise<NavigatorProposal> => ({
+        kind: "invoke_skill",
+        basedOn: snapshot.identity,
+        rationale: "Publish a map from the exact owner ticket snapshot.",
+        evidenceRefs: ["ticket:39:STD-39-002"],
+        skillId: "wayfinder",
+        subjectArtifactIds: [fixture.rootArtifactId],
+        objective: "Publish the planning map.",
       }),
-    },
-    planningPublisher: fixture.publisher,
-    modelRoute: () => ({ pool: "strong", ...DEFAULT_MODEL_POOL_REGISTRY.worker.strong }),
-    clock: { now: fixture.advance },
-  });
-  const accepted = await executor.proposeNext({
-    jobId: fixture.jobId,
-    externalStateDigest: "e".repeat(64),
-    evidenceRefs: [],
-  });
-  const processing = executor.processOne({
-    ...fixture.fence,
-    signal: new AbortController().signal,
-  }, new AbortController().signal);
-  await pause.started;
-  const root = fixture.store.getWorkArtifact(fixture.rootArtifactId)!;
-  const externalRoot = await fixture.tracker.read(root.externalId);
-  await fixture.tracker.updateOwnedSection({
-    externalId: root.externalId,
-    sectionId: "revision-note",
-    content: "The owner changed the ticket while publication was awaiting the tracker.",
-    operationId: "ticket-39-drift-during-publication",
-    expectedRevision: externalRoot.revision,
-  });
-  await fixture.coordinator.observe({
-    artifactId: root.id,
-    ...fixture.fence,
-    now: fixture.advance(),
-  });
-  pause.release();
-  await processing;
+    };
+    const executor = new NavigatorWorkflowExecutor({
+      store: fixture.store,
+      navigator,
+      observeInference: async () => ({
+        nativeToolCalls: [],
+        claimedCodeWorktreeId: null,
+        dynamicEffectToolIds: [],
+        externalStateDigest: "e".repeat(64),
+      }),
+      skillRunner: {
+        run: vi.fn(async (attempt, hooks) => {
+          const resource = { kind: "bb_thread" as const, id: `thr_${attempt.id}` };
+          await hooks.bindResource(resource);
+          return {
+            resource,
+            observedExternalStateDigest: "e".repeat(64),
+            result: {
+              kind: "wayfinder_result",
+              summary: "The old owner ticket snapshot produced a map.",
+              map: {
+                title: "Drifted map",
+                body: "## Destination\n\nReject stale publication.\n\n## Decisions so far\n\n## Not yet specified\n\nOne decision.",
+                acceptanceCriteria: ["Drift fails closed"],
+              },
+              decisionTickets: [{
+                title: "Resolve drift",
+                body: "## Question\n\nWhich snapshot is authoritative?",
+                acceptanceCriteria: ["Use the current snapshot"],
+                blockedBy: [],
+              }],
+              evidenceRefs: ["ticket:39:STD-39-002"],
+            },
+          };
+        }),
+      },
+      planningPublisher: fixture.publisher,
+      modelRoute: () => ({ pool: "strong", ...DEFAULT_MODEL_POOL_REGISTRY.worker.strong }),
+      clock: { now: fixture.advance },
+    });
+    const accepted = await executor.proposeNext({
+      jobId: fixture.jobId,
+      externalStateDigest: "e".repeat(64),
+      evidenceRefs: [],
+    });
+    const processing = executor.processOne({
+      ...fixture.fence,
+      signal: new AbortController().signal,
+    }, new AbortController().signal);
+    await pause.started;
+    const root = fixture.store.getWorkArtifact(fixture.rootArtifactId)!;
+    const externalRoot = await fixture.tracker.read(root.externalId);
+    await fixture.tracker.updateOwnedSection({
+      externalId: root.externalId,
+      sectionId: "revision-note",
+      content: "The owner changed the ticket while publication was awaiting the tracker.",
+      operationId: `ticket-39-drift-during-publication-${trackerKind}`,
+      expectedRevision: externalRoot.revision,
+    });
+    await fixture.coordinator.observe({
+      artifactId: root.id,
+      ...fixture.fence,
+      now: fixture.advance(),
+    });
+    pause.release();
+    await processing;
 
-  expect(fixture.store.getNavigatorWorkflowStepOutcome(accepted.workflowStepId!)).toMatchObject({
-    outcome: "policy_failure",
-    reasonCode: "stale_artifact_snapshot",
+    const attempt = fixture.store.getNavigatorSkillAttempt(accepted.attemptId!)!;
+    const mapId = stableWorkArtifactId("proj_39", `${attempt.workflowStepId}:map`);
+    const partialMap = fixture.store.getWorkArtifact(mapId)!;
+    expect(fixture.store.getJob(fixture.jobId)!.artifactBindings.map((binding) => binding.artifactId))
+      .not.toContain(mapId);
+    expect(partialMap).toMatchObject({ status: "cancelled", externalStatus: "cancelled" });
+    expect(fixture.store.getWorkArtifactResolution(mapId)).toMatchObject({
+      outcome: "cancelled",
+      evidenceRefs: [`navigator-result:${attempt.id}`],
+    });
+    await expect(fixture.tracker.read(partialMap.externalId)).resolves.toMatchObject({
+      state: "cancelled",
+    });
+    expect(fixture.store.getNavigatorWorkflowStepOutcome(accepted.workflowStepId!)).toMatchObject({
+      outcome: "policy_failure",
+      reasonCode: "stale_artifact_snapshot",
+    });
+    expect(fixture.store.getEffect(fixture.jobId, accepted.effectIdempotencyKey!)).toMatchObject({
+      status: "done",
+    });
+    expect(fixture.store.getJob(fixture.jobId)).toMatchObject({
+      currentWorkflowStepId: null,
+      artifactBindings: [expect.objectContaining({ artifactId: fixture.rootArtifactId })],
+    });
+
+    const durableResult = fixture.store.getNavigatorPlanningResult(attempt.id)!;
+    const restartedCoordinator = new WorkArtifactCoordinator(
+      fixture.store,
+      fixture.tracker,
+      fixture.now,
+    );
+    const restartedPublisher = new NavigatorPlanningPublisher(fixture.store, restartedCoordinator);
+    await expect(restartedPublisher.publish(attempt, durableResult.result, {
+      ...fixture.fence,
+      now: fixture.advance(),
+    })).rejects.toThrow("Navigator subject artifact changed during planning publication");
+    expect(fixture.store.getWorkArtifact(mapId)).toMatchObject({
+      externalId: partialMap.externalId,
+      status: "cancelled",
+    });
+    await expect(fixture.tracker.read(partialMap.externalId)).resolves.toMatchObject({
+      state: "cancelled",
+    });
   });
-  expect(fixture.store.getEffect(fixture.jobId, accepted.effectIdempotencyKey!)).toMatchObject({
-    status: "done",
-  });
-  expect(fixture.store.getJob(fixture.jobId)).toMatchObject({ currentWorkflowStepId: null });
 });


### PR DESCRIPTION
A navigator-v1 job can now pick the planning skill its evidence calls for, run it, and leave one canonical specification plus a blocker-linked eligible ticket frontier in the configured tracker. Specification-ready work skips wayfinding. Unresolved routing records the decision, consults ask-matt once, and then takes a safe default or blocks.

This PR is exactly three commits on `ticket/38-navigator-skill-step`:

- `feat: add navigator planning frontier` adds executor-owned step contracts, routing, and tracker publication for setup, wayfinder, to-spec, to-tickets, research, prototype, handoff, and ask-matt, with GitHub and local-tracker coverage.
- `fix: close ticket 39 planning review findings` closes the review gaps from that first slice, including publication fencing, snapshot invalidation, and routing after a second unresolved result.
- `fix: reconcile drifted planning publications` cancels planning artifacts that were created while a subject snapshot drifted, instead of leaving a partial publication in the tracker.

Stacks above https://github.com/amrtawfik160/hanoon/pull/47.

Refs https://github.com/amrtawfik160/hanoon/issues/39
