### PR TITLE
feat: add navigator ticket integration lane

### DIFF
--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -588,6 +588,7 @@ export interface JobEffect {
     | "stop_thread"
     | "steer_implementation"
     | "run_navigator_skill"
+    | "run_navigator_ticket_worker"
     | "reconcile_job";
   payload: Record<string, unknown>;
 }

--- a/src/navigator/implementation-contracts.ts
+++ b/src/navigator/implementation-contracts.ts
@@ -93,7 +93,7 @@ export const navigatorImplementationResultSchema = z.object({
   capabilityOutcomes: z.array(capabilityOutcomeSchema).min(1).max(16),
 }).strict();
 
-const reviewFindingSchema = z.object({
+export const navigatorReviewFindingSchema = z.object({
   ruleId: identifierSchema,
   severity: z.enum(["critical", "high", "medium", "low"]),
   summary: boundedTextSchema,
@@ -105,7 +105,7 @@ export const navigatorCodeReviewResultSchema = z.object({
   reviewedHeadSha: gitShaSchema,
   outcome: z.enum(["passed", "findings"]),
   summary: boundedTextSchema,
-  findings: z.array(reviewFindingSchema).max(128),
+  findings: z.array(navigatorReviewFindingSchema).max(128),
   capabilityOutcomes: z.array(capabilityOutcomeSchema).min(1).max(16),
 }).strict().superRefine((result, context) => {
   if ((result.outcome === "passed") !== (result.findings.length === 0)) {
@@ -124,6 +124,60 @@ export const navigatorTicketWorkerResultSchema = z.discriminatedUnion("kind", [
 
 export type NavigatorTicketWorkerResult = Readonly<z.infer<typeof navigatorTicketWorkerResultSchema>>;
 
+export const navigatorTicketRepairSnapshotSchema = z.object({
+  kind: z.literal("navigator_ticket_repair_snapshot"),
+  snapshotId: identifierSchema,
+  digest: sha256Schema,
+  jobId: identifierSchema,
+  sliceId: identifierSchema,
+  ticket: artifactBindingSchema,
+  reviewAttemptId: identifierSchema,
+  reviewedHeadSha: gitShaSchema,
+  reviewResultDigest: sha256Schema,
+  gitObservationDigest: sha256Schema,
+  findings: z.array(navigatorReviewFindingSchema).min(1).max(128),
+  evidenceRefs: requiredEvidenceRefsSchema,
+  createdAt: z.number().int().min(0),
+}).strict();
+
+export type NavigatorTicketRepairSnapshot = Readonly<z.infer<typeof navigatorTicketRepairSnapshotSchema>>;
+
+const repairProposalBase = {
+  basedOn: z.object({ snapshotId: identifierSchema, digest: sha256Schema }).strict(),
+  objective: boundedTextSchema,
+  evidenceRefs: requiredEvidenceRefsSchema,
+};
+
+export const navigatorTicketRepairProposalSchema = z.discriminatedUnion("kind", [
+  z.object({
+    ...repairProposalBase,
+    kind: z.literal("implementation"),
+    taskEvidence: taskEvidenceSchema,
+  }).strict(),
+  z.object({ ...repairProposalBase, kind: z.literal("diagnosis") }).strict(),
+  z.object({ ...repairProposalBase, kind: z.literal("research") }).strict(),
+  z.object({ ...repairProposalBase, kind: z.literal("owner_boundary") }).strict(),
+]);
+
+export type NavigatorTicketRepairProposal = Readonly<z.infer<typeof navigatorTicketRepairProposalSchema>>;
+
+export const navigatorGitObservationSchema = z.object({
+  kind: z.literal("navigator_git_observation"),
+  worktreeId: identifierSchema,
+  branch: identifierSchema,
+  headSha: gitShaSchema,
+  baseHeadSha: gitShaSchema,
+  baseHeadIsAncestor: z.boolean(),
+  comparisonBaseHeadSha: gitShaSchema,
+  comparisonBaseHeadIsAncestor: z.boolean(),
+  clean: z.boolean(),
+  changedPaths: z.array(projectPathSchema).max(512),
+  evidenceRef: z.string().trim().min(1).max(1_024),
+  observedAt: z.number().int().min(0),
+}).strict();
+
+export type NavigatorGitObservation = Readonly<z.infer<typeof navigatorGitObservationSchema>>;
+
 export const navigatorPullRequestRequestSchema = z.object({
   operationId: identifierSchema,
   jobId: identifierSchema,
@@ -132,8 +186,18 @@ export const navigatorPullRequestRequestSchema = z.object({
   headSha: gitShaSchema,
   title: z.string().trim().min(1).max(256),
   body: z.string().trim().min(1).max(65_536),
+  gitObservation: navigatorGitObservationSchema,
+  gitObservationDigest: sha256Schema,
   evidenceRefs: requiredEvidenceRefsSchema,
-}).strict();
+}).strict().superRefine((request, context) => {
+  if (navigatorJsonDigest(request.gitObservation) !== request.gitObservationDigest) {
+    context.addIssue({
+      code: "custom",
+      path: ["gitObservationDigest"],
+      message: "pull request Git observation digest must match its immutable evidence",
+    });
+  }
+});
 
 export type NavigatorPullRequestRequest = Readonly<z.infer<typeof navigatorPullRequestRequestSchema>>;
 
@@ -145,20 +209,26 @@ export type NavigatorPullRequestRecord = Readonly<{
   headSha: string;
 }>;
 
-export type NavigatorTicketStepContract = Readonly<{
-  id: string;
-  revision: number;
-  skillId: "implement" | "code-review";
-  freshContext: true;
-  codeWriting: boolean;
-  resourceClass: "managed_integration_worktree";
-  resultSchema: "navigator-implementation-result-v1" | "navigator-code-review-result-v1";
-  mandatoryEvidence: readonly string[];
-  modelPools: readonly ("standard" | "strong")[];
-  timeoutMs: number;
-  maximumResultBytes: number;
-  digest: string;
-}>;
+export const navigatorTicketStepContractSchema = z.object({
+  id: identifierSchema,
+  revision: z.number().int().positive(),
+  skillId: z.enum(["implement", "code-review"]),
+  freshContext: z.literal(true),
+  codeWriting: z.boolean(),
+  resourceClass: z.literal("managed_integration_worktree"),
+  resultSchema: z.enum(["navigator-implementation-result-v1", "navigator-code-review-result-v1"]),
+  mandatoryEvidence: z.array(identifierSchema).min(1).max(16),
+  modelPools: z.array(z.enum(["standard", "strong"])).min(1).max(2),
+  timeoutMs: z.number().int().positive(),
+  maximumResultBytes: z.number().int().positive(),
+  retryClass: z.literal("bounded_exponential"),
+  maximumAttempts: z.number().int().min(1).max(20),
+  backoffBaseMs: z.number().int().positive().max(30_000),
+  backoffMaximumMs: z.number().int().positive().max(300_000),
+  digest: sha256Schema,
+}).strict();
+
+export type NavigatorTicketStepContract = Readonly<z.infer<typeof navigatorTicketStepContractSchema>>;
 
 const DISCIPLINE_BY_EVIDENCE: Readonly<Record<NavigatorTicketTaskEvidence[number], string>> = {
   "reproducible-bug": "diagnosing-bugs",
@@ -181,7 +251,7 @@ function ticketStepContract(
 export const NAVIGATOR_TICKET_STEP_CONTRACTS = Object.freeze({
   implementation: ticketStepContract({
     id: "navigator-ticket-implementation",
-    revision: 1,
+    revision: 2,
     skillId: "implement",
     freshContext: true,
     codeWriting: true,
@@ -191,10 +261,14 @@ export const NAVIGATOR_TICKET_STEP_CONTRACTS = Object.freeze({
     modelPools: ["standard", "strong"],
     timeoutMs: 14_400_000,
     maximumResultBytes: 256_000,
+    retryClass: "bounded_exponential",
+    maximumAttempts: 5,
+    backoffBaseMs: 500,
+    backoffMaximumMs: 30_000,
   }),
   review: ticketStepContract({
     id: "navigator-ticket-code-review",
-    revision: 1,
+    revision: 2,
     skillId: "code-review",
     freshContext: true,
     codeWriting: false,
@@ -204,6 +278,10 @@ export const NAVIGATOR_TICKET_STEP_CONTRACTS = Object.freeze({
     modelPools: ["strong"],
     timeoutMs: 3_600_000,
     maximumResultBytes: 256_000,
+    retryClass: "bounded_exponential",
+    maximumAttempts: 5,
+    backoffBaseMs: 500,
+    backoffMaximumMs: 30_000,
   }),
 });
 

--- a/src/navigator/implementation-contracts.ts
+++ b/src/navigator/implementation-contracts.ts
@@ -209,7 +209,7 @@ export type NavigatorPullRequestRecord = Readonly<{
   headSha: string;
 }>;
 
-export const navigatorTicketStepContractSchema = z.object({
+const navigatorTicketStepContractBase = {
   id: identifierSchema,
   revision: z.number().int().positive(),
   skillId: z.enum(["implement", "code-review"]),
@@ -221,6 +221,15 @@ export const navigatorTicketStepContractSchema = z.object({
   modelPools: z.array(z.enum(["standard", "strong"])).min(1).max(2),
   timeoutMs: z.number().int().positive(),
   maximumResultBytes: z.number().int().positive(),
+} as const;
+
+const navigatorTicketStepContractV1Schema = z.object({
+  ...navigatorTicketStepContractBase,
+  digest: sha256Schema,
+}).strict();
+
+export const navigatorTicketStepContractSchema = z.object({
+  ...navigatorTicketStepContractBase,
   retryClass: z.literal("bounded_exponential"),
   maximumAttempts: z.number().int().min(1).max(20),
   backoffBaseMs: z.number().int().positive().max(30_000),
@@ -228,7 +237,13 @@ export const navigatorTicketStepContractSchema = z.object({
   digest: sha256Schema,
 }).strict();
 
+export const navigatorPersistedTicketStepContractSchema = z.union([
+  navigatorTicketStepContractSchema,
+  navigatorTicketStepContractV1Schema,
+]);
+
 export type NavigatorTicketStepContract = Readonly<z.infer<typeof navigatorTicketStepContractSchema>>;
+export type NavigatorPersistedTicketStepContract = Readonly<z.infer<typeof navigatorPersistedTicketStepContractSchema>>;
 
 const DISCIPLINE_BY_EVIDENCE: Readonly<Record<NavigatorTicketTaskEvidence[number], string>> = {
   "reproducible-bug": "diagnosing-bugs",

--- a/src/navigator/implementation-contracts.ts
+++ b/src/navigator/implementation-contracts.ts
@@ -1,0 +1,269 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import { SKILL_ADMISSION_CATALOG } from "../capabilities/catalog";
+import { modelRouteSchema } from "../capabilities/models";
+import { projectPolicySchema } from "../domain/models";
+import { artifactBindingSchema } from "./models";
+
+const identifierSchema = z.string().trim().min(1).max(256);
+const boundedTextSchema = z.string().trim().min(1).max(8_000);
+const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/u);
+const gitShaSchema = z.string().regex(/^[0-9a-f]{40}$/u);
+const requiredEvidenceRefsSchema = z.array(z.string().trim().min(1).max(1_024)).min(1).max(128);
+const projectPathSchema = z.string().trim().min(1).max(4_096).refine(
+  (path) => !path.startsWith("/") && !path.includes("\0") &&
+    path.split(/[\\/]/u).every((segment) => segment.length > 0 && segment !== "." && segment !== ".."),
+  "changed paths must be safe project-relative paths",
+);
+const taskEvidenceSchema = z.array(z.enum([
+  "reproducible-bug",
+  "behavioral-change",
+  "interface-design",
+  "merge-conflict",
+  "agent-instructions",
+])).max(5);
+
+const profileAssignmentSchema = z.object({
+  capabilityId: identifierSchema,
+  descriptorDigest: sha256Schema,
+  invocationClass: z.enum(["user", "model"]),
+  mandatory: z.boolean(),
+}).strict();
+
+export const navigatorTicketWorkerProfileSchema = z.object({
+  role: z.enum(["implementation", "review"]),
+  assignments: z.array(profileAssignmentSchema).min(1).max(16),
+  denials: z.array(z.object({
+    capabilityId: identifierSchema,
+    reasonCode: identifierSchema,
+  }).strict()).max(16),
+  digest: sha256Schema,
+}).strict();
+
+export type NavigatorTicketWorkerProfile = Readonly<z.infer<typeof navigatorTicketWorkerProfileSchema>>;
+export type NavigatorTicketTaskEvidence = Readonly<z.infer<typeof taskEvidenceSchema>>;
+
+export const navigatorTicketWorkOrderSchema = z.object({
+  kind: z.literal("navigator_ticket_work_order"),
+  jobId: identifierSchema,
+  integrationBranch: identifierSchema,
+  baseBranch: identifierSchema,
+  worktreeId: identifierSchema,
+  baseHeadSha: gitShaSchema,
+  comparisonBaseHeadSha: gitShaSchema,
+  projectPolicyVersion: z.number().int().positive(),
+  projectPolicy: projectPolicySchema,
+  projectPolicyDigest: sha256Schema,
+  specification: artifactBindingSchema,
+  ticket: artifactBindingSchema,
+  taskEvidence: taskEvidenceSchema,
+  evidenceRefs: requiredEvidenceRefsSchema,
+  changedPaths: z.array(projectPathSchema).max(512),
+}).strict().superRefine((workOrder, context) => {
+  if (navigatorJsonDigest(workOrder.projectPolicy) !== workOrder.projectPolicyDigest) {
+    context.addIssue({
+      code: "custom",
+      path: ["projectPolicyDigest"],
+      message: "project policy digest must match the immutable policy",
+    });
+  }
+});
+
+export type NavigatorTicketWorkOrder = Readonly<z.infer<typeof navigatorTicketWorkOrderSchema>>;
+
+const verificationReceiptSchema = z.object({
+  command: z.string().trim().min(1).max(8_000),
+  outcome: z.enum(["passed", "failed"]),
+}).strict();
+
+const capabilityOutcomeSchema = z.object({
+  capabilityId: identifierSchema,
+  outcome: z.enum(["passed", "findings", "blocked", "failed"]),
+  evidenceRefs: requiredEvidenceRefsSchema,
+}).strict();
+
+export const navigatorImplementationResultSchema = z.object({
+  kind: z.literal("implementation_result"),
+  baseHeadSha: gitShaSchema,
+  headSha: gitShaSchema,
+  summary: boundedTextSchema,
+  changedPaths: z.array(projectPathSchema).max(512),
+  focusedVerification: z.array(verificationReceiptSchema).min(1).max(64),
+  fullVerification: z.array(verificationReceiptSchema).min(1).max(64),
+  capabilityOutcomes: z.array(capabilityOutcomeSchema).min(1).max(16),
+}).strict();
+
+const reviewFindingSchema = z.object({
+  ruleId: identifierSchema,
+  severity: z.enum(["critical", "high", "medium", "low"]),
+  summary: boundedTextSchema,
+  evidenceRefs: requiredEvidenceRefsSchema,
+}).strict();
+
+export const navigatorCodeReviewResultSchema = z.object({
+  kind: z.literal("code_review_result"),
+  reviewedHeadSha: gitShaSchema,
+  outcome: z.enum(["passed", "findings"]),
+  summary: boundedTextSchema,
+  findings: z.array(reviewFindingSchema).max(128),
+  capabilityOutcomes: z.array(capabilityOutcomeSchema).min(1).max(16),
+}).strict().superRefine((result, context) => {
+  if ((result.outcome === "passed") !== (result.findings.length === 0)) {
+    context.addIssue({
+      code: "custom",
+      path: ["findings"],
+      message: "a passing review has no findings and a findings review has at least one",
+    });
+  }
+});
+
+export const navigatorTicketWorkerResultSchema = z.discriminatedUnion("kind", [
+  navigatorImplementationResultSchema,
+  navigatorCodeReviewResultSchema,
+]);
+
+export type NavigatorTicketWorkerResult = Readonly<z.infer<typeof navigatorTicketWorkerResultSchema>>;
+
+export const navigatorPullRequestRequestSchema = z.object({
+  operationId: identifierSchema,
+  jobId: identifierSchema,
+  baseBranch: identifierSchema,
+  integrationBranch: identifierSchema,
+  headSha: gitShaSchema,
+  title: z.string().trim().min(1).max(256),
+  body: z.string().trim().min(1).max(65_536),
+  evidenceRefs: requiredEvidenceRefsSchema,
+}).strict();
+
+export type NavigatorPullRequestRequest = Readonly<z.infer<typeof navigatorPullRequestRequestSchema>>;
+
+export type NavigatorPullRequestRecord = Readonly<{
+  operationId: string;
+  jobId: string;
+  number: number;
+  url: string;
+  headSha: string;
+}>;
+
+export type NavigatorTicketStepContract = Readonly<{
+  id: string;
+  revision: number;
+  skillId: "implement" | "code-review";
+  freshContext: true;
+  codeWriting: boolean;
+  resourceClass: "managed_integration_worktree";
+  resultSchema: "navigator-implementation-result-v1" | "navigator-code-review-result-v1";
+  mandatoryEvidence: readonly string[];
+  modelPools: readonly ("standard" | "strong")[];
+  timeoutMs: number;
+  maximumResultBytes: number;
+  digest: string;
+}>;
+
+const DISCIPLINE_BY_EVIDENCE: Readonly<Record<NavigatorTicketTaskEvidence[number], string>> = {
+  "reproducible-bug": "diagnosing-bugs",
+  "behavioral-change": "tdd",
+  "interface-design": "codebase-design",
+  "merge-conflict": "resolving-merge-conflicts",
+  "agent-instructions": "writing-for-agents",
+};
+
+function digestJson(subject: unknown): string {
+  return createHash("sha256").update(JSON.stringify(subject), "utf8").digest("hex");
+}
+
+function ticketStepContract(
+  input: Omit<NavigatorTicketStepContract, "digest">,
+): NavigatorTicketStepContract {
+  return Object.freeze({ ...input, digest: digestJson(input) });
+}
+
+export const NAVIGATOR_TICKET_STEP_CONTRACTS = Object.freeze({
+  implementation: ticketStepContract({
+    id: "navigator-ticket-implementation",
+    revision: 1,
+    skillId: "implement",
+    freshContext: true,
+    codeWriting: true,
+    resourceClass: "managed_integration_worktree",
+    resultSchema: "navigator-implementation-result-v1",
+    mandatoryEvidence: ["ticket_snapshot", "specification_snapshot", "focused_verification", "full_verification"],
+    modelPools: ["standard", "strong"],
+    timeoutMs: 14_400_000,
+    maximumResultBytes: 256_000,
+  }),
+  review: ticketStepContract({
+    id: "navigator-ticket-code-review",
+    revision: 1,
+    skillId: "code-review",
+    freshContext: true,
+    codeWriting: false,
+    resourceClass: "managed_integration_worktree",
+    resultSchema: "navigator-code-review-result-v1",
+    mandatoryEvidence: ["ticket_snapshot", "specification_snapshot", "exact_head_review"],
+    modelPools: ["strong"],
+    timeoutMs: 3_600_000,
+    maximumResultBytes: 256_000,
+  }),
+});
+
+function assignment(capabilityId: string) {
+  const descriptor = SKILL_ADMISSION_CATALOG.find((entry) => entry.id === capabilityId);
+  if (!descriptor) throw new Error(`navigator ticket capability ${capabilityId} is not admitted`);
+  return {
+    capabilityId,
+    descriptorDigest: descriptor.bundleDescriptorDigest,
+    invocationClass: descriptor.invocationClass,
+    mandatory: true,
+  } as const;
+}
+
+function reviewGuardIds(changedPaths: readonly string[]): string[] {
+  const selected = new Set<string>(["code-review"]);
+  if (changedPaths.some((path) => /(?:^|\/)src\//u.test(path) || /\.(?:[cm]?[jt]sx?|py|go|rs|php)$/u.test(path))) {
+    selected.add("clean-code-guard");
+  }
+  if (changedPaths.some((path) => /(?:^|\/)(?:tests?|__tests__|spec)(?:\/|$)|\.(?:test|spec)\.[cm]?[jt]sx?$/u.test(path))) {
+    selected.add("test-guard");
+  }
+  if (changedPaths.some((path) => /(?:^|\/)(?:docs?|README|CONTRIBUTING|CHANGELOG)(?:[./]|$)|\.md$/iu.test(path))) {
+    selected.add("docs-guard");
+  }
+  return [...selected].sort((left, right) => left.localeCompare(right));
+}
+
+export function navigatorTicketWorkerProfile(input: Readonly<{
+  kind: "implementation" | "review";
+  taskEvidence: readonly string[];
+  changedPaths: readonly string[];
+}>): NavigatorTicketWorkerProfile {
+  const taskEvidence = taskEvidenceSchema.parse(input.taskEvidence);
+  const capabilityIds = input.kind === "implementation"
+    ? [
+      "implement",
+      ...taskEvidence.map((evidence) => DISCIPLINE_BY_EVIDENCE[evidence]),
+    ].sort((left, right) => left.localeCompare(right))
+    : reviewGuardIds(input.changedPaths);
+  const assignments = [...new Set(capabilityIds)].map(assignment);
+  const unsigned = {
+    role: input.kind,
+    assignments,
+    denials: [],
+  } as const;
+  return navigatorTicketWorkerProfileSchema.parse({ ...unsigned, digest: digestJson(unsigned) });
+}
+
+export function parseNavigatorTicketModelRoute(route: unknown, kind: "implementation" | "review") {
+  const parsed = modelRouteSchema.parse(route);
+  if (kind === "implementation" && parsed.pool === "fast") {
+    throw new TypeError("navigator ticket implementation requires a standard or strong model route");
+  }
+  if (kind === "review" && parsed.pool !== "strong") {
+    throw new TypeError("navigator ticket review requires a strong model route");
+  }
+  return parsed;
+}
+
+export function navigatorJsonDigest(subject: unknown): string {
+  return digestJson(subject);
+}

--- a/src/navigator/implementation-executor.ts
+++ b/src/navigator/implementation-executor.ts
@@ -11,11 +11,11 @@ import {
   navigatorGitObservationSchema,
   navigatorImplementationResultSchema,
   navigatorJsonDigest,
+  navigatorPersistedTicketStepContractSchema,
   navigatorPullRequestRequestSchema,
   navigatorTicketWorkerProfile,
   navigatorTicketWorkerProfileSchema,
   navigatorTicketWorkerResultSchema,
-  navigatorTicketStepContractSchema,
   navigatorTicketRepairProposalSchema,
   navigatorTicketRepairSnapshotSchema,
   navigatorTicketWorkOrderSchema,
@@ -23,7 +23,7 @@ import {
   type NavigatorPullRequestRecord,
   type NavigatorPullRequestRequest,
   type NavigatorGitObservation,
-  type NavigatorTicketStepContract,
+  type NavigatorPersistedTicketStepContract,
   type NavigatorTicketRepairSnapshot,
   type NavigatorTicketTaskEvidence,
   type NavigatorTicketWorkerProfile,
@@ -44,7 +44,7 @@ export type NavigatorTicketWorkerAttempt = Readonly<{
   effectIdempotencyKey: string;
   workOrder: NavigatorTicketWorkOrder;
   workOrderDigest: string;
-  stepContract: NavigatorTicketStepContract;
+  stepContract: NavigatorPersistedTicketStepContract;
   profile: NavigatorTicketWorkerProfile;
   modelRoute: ModelRoute;
   resource: { kind: "bb_thread"; id: string } | null;
@@ -266,6 +266,41 @@ function mergeEvidenceRefs(...groups: readonly (readonly string[])[]): readonly 
   return boundedRefs([...new Set(groups.flat())]);
 }
 
+type NavigatorTicketRetryPolicy = Readonly<{
+  retryClass: "bounded_exponential";
+  maximumAttempts: number;
+  backoffBaseMs: number;
+  backoffMaximumMs: number;
+}>;
+
+function retryPolicy(contract: NavigatorPersistedTicketStepContract): NavigatorTicketRetryPolicy {
+  if (
+    "retryClass" in contract &&
+    contract.retryClass !== undefined && contract.maximumAttempts !== undefined &&
+    contract.backoffBaseMs !== undefined && contract.backoffMaximumMs !== undefined
+  ) return {
+    retryClass: contract.retryClass,
+    maximumAttempts: contract.maximumAttempts,
+    backoffBaseMs: contract.backoffBaseMs,
+    backoffMaximumMs: contract.backoffMaximumMs,
+  };
+  return {
+    retryClass: "bounded_exponential",
+    maximumAttempts: 1,
+    backoffBaseMs: 1,
+    backoffMaximumMs: 1,
+  };
+}
+
+function retryDelay(
+  contract: NavigatorPersistedTicketStepContract,
+  attempts: number,
+): number {
+  const policy = retryPolicy(contract);
+  const exponential = policy.backoffBaseMs * 2 ** Math.max(0, attempts - 1);
+  return Math.min(policy.backoffMaximumMs, exponential);
+}
+
 function stableId(prefix: string, ...parts: readonly string[]): string {
   return `${prefix}_${createHash("sha256").update(parts.join("\0"), "utf8").digest("base64url").slice(0, 24)}`;
 }
@@ -283,7 +318,7 @@ function parseRepairSnapshot(rawSnapshot: unknown): NavigatorTicketRepairSnapsho
 function parseAttempt(row: AttemptRow): NavigatorTicketWorkerAttempt {
   const workOrder = navigatorTicketWorkOrderSchema.parse(JSON.parse(row.work_order_json));
   const profile = navigatorTicketWorkerProfileSchema.parse(JSON.parse(row.profile_json));
-  const stepContract = navigatorTicketStepContractSchema.parse(JSON.parse(row.step_contract_json));
+  const stepContract = navigatorPersistedTicketStepContractSchema.parse(JSON.parse(row.step_contract_json));
   const { digest: _digest, ...unsignedContract } = stepContract;
   if (
     navigatorJsonDigest(workOrder) !== row.work_order_digest ||
@@ -492,6 +527,9 @@ export class NavigatorImplementationExecutor {
         externalAssignee: claim.externalAssignee,
         ownerId: input.ownerId,
         generation: input.generation,
+        expectedOwnerId: claim.ownerId,
+        expectedGeneration: claim.generation,
+        expectedLeaseExpiresAt: claim.leaseExpiresAt,
         now: this.dependencies.clock.now(),
         leaseMs,
       })
@@ -826,7 +864,7 @@ export class NavigatorImplementationExecutor {
           const observation = await this.reconcileUnavailableResource(attempt, error.reason, runSignal);
           this.replaceUnavailableAttempt(
             attempt,
-            effect.idempotencyKey,
+            effect,
             error.reason,
             observation,
             fence,
@@ -1050,6 +1088,9 @@ export class NavigatorImplementationExecutor {
       externalAssignee: claim.externalAssignee,
       ownerId: fence.ownerId,
       generation: fence.generation,
+      expectedOwnerId: claim.ownerId,
+      expectedGeneration: claim.generation,
+      expectedLeaseExpiresAt: claim.leaseExpiresAt,
       now,
       leaseMs,
     });
@@ -1130,6 +1171,8 @@ export class NavigatorImplementationExecutor {
     baseHeadSha: string;
     comparisonBaseHeadSha: string;
     now: number;
+    effectAttempts?: number;
+    nextAttemptAt?: number;
   }>): NavigatorTicketWorkerAttempt {
     const workOrder = navigatorTicketWorkOrderSchema.parse({
       kind: "navigator_ticket_work_order",
@@ -1169,12 +1212,13 @@ export class NavigatorImplementationExecutor {
       `INSERT INTO effects (
          idempotency_key, job_id, kind, payload_json, status, attempts,
          next_attempt_at, created_at, updated_at
-       ) VALUES (?, ?, 'run_navigator_ticket_worker', ?, 'pending', 0, ?, ?, ?)`,
+       ) VALUES (?, ?, 'run_navigator_ticket_worker', ?, 'pending', ?, ?, ?, ?)`,
     ).run(
       effectKey,
       input.integration.job_id,
       JSON.stringify({ attemptId, sliceId: input.sliceId }),
-      input.now,
+      input.effectAttempts ?? 0,
+      input.nextAttemptAt ?? input.now,
       input.now,
       input.now,
     );
@@ -1490,7 +1534,7 @@ export class NavigatorImplementationExecutor {
 
   private replaceUnavailableAttempt(
     attempt: NavigatorTicketWorkerAttempt,
-    effectKey: string,
+    effect: StoredEffect,
     reason: "missing" | "stale",
     resourceObservation: Readonly<{
       resource: { kind: "bb_thread"; id: string } | null;
@@ -1502,7 +1546,7 @@ export class NavigatorImplementationExecutor {
     now: number,
   ): void {
     this.db.transaction(() => {
-      if (!this.effectLeaseCurrent(effectKey, fence, now) || this.getOutcome(attempt.id) !== null) return;
+      if (!this.effectLeaseCurrent(effect.idempotencyKey, fence, now) || this.getOutcome(attempt.id) !== null) return;
       const integration = this.integrationRow(attempt.jobId);
       if (!integration || integration.state !== "implementing") return;
       const staleReason = !this.bindingIsCurrent(attempt.workOrder.specification)
@@ -1527,7 +1571,19 @@ export class NavigatorImplementationExecutor {
           now,
         );
         this.invalidateIntegration(integration, staleReason, now);
-        this.finishEffectByKey(effectKey, fence, now, "done", null);
+        this.finishEffect(effect, fence, now, "done", null);
+        return;
+      }
+      if (effect.attempts >= retryPolicy(attempt.stepContract).maximumAttempts) {
+        this.deadLetterAttempt(
+          attempt,
+          effect,
+          "retry_exhausted",
+          `Navigator ticket worker remained unavailable (${reason})`,
+          fence,
+          now,
+          { reason, resourceObservation },
+        );
         return;
       }
       const result = { kind: "worker_unavailable", reason, resourceObservation } as const;
@@ -1545,7 +1601,7 @@ export class NavigatorImplementationExecutor {
         navigatorJsonDigest(result),
         now,
       );
-      this.finishEffectByKey(effectKey, fence, now, "done", null);
+      this.finishEffect(effect, fence, now, "done", null);
       this.createAttempt({
         integration,
         sliceId: attempt.sliceId,
@@ -1558,6 +1614,8 @@ export class NavigatorImplementationExecutor {
         baseHeadSha: attempt.workOrder.baseHeadSha,
         comparisonBaseHeadSha: attempt.workOrder.comparisonBaseHeadSha,
         now,
+        effectAttempts: effect.attempts,
+        nextAttemptAt: now + retryDelay(attempt.stepContract, effect.attempts),
       });
       this.db.prepare(
         "UPDATE navigator_ticket_slices SET state = ?, updated_at = ? WHERE id = ?",
@@ -1609,7 +1667,7 @@ export class NavigatorImplementationExecutor {
     const rawSummary = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
     const summary = rawSummary.replace(/\s+/gu, " ").trim().slice(0, 500) || "Navigator ticket worker failed";
     const permanent = error instanceof NavigatorTicketWorkerPermanentError;
-    if (permanent || effect.attempts >= attempt.stepContract.maximumAttempts) {
+    if (permanent || effect.attempts >= retryPolicy(attempt.stepContract).maximumAttempts) {
       this.deadLetterAttempt(
         attempt,
         effect,
@@ -1620,9 +1678,7 @@ export class NavigatorImplementationExecutor {
       );
       return;
     }
-    const exponential = attempt.stepContract.backoffBaseMs * 2 ** Math.max(0, effect.attempts - 1);
-    const delay = Math.min(attempt.stepContract.backoffMaximumMs, exponential);
-    this.finishEffect(effect, fence, now, "failed", summary, now + delay);
+    this.finishEffect(effect, fence, now, "failed", summary, now + retryDelay(attempt.stepContract, effect.attempts));
   }
 
   private deadLetterAttempt(
@@ -1632,15 +1688,17 @@ export class NavigatorImplementationExecutor {
     summary: string,
     fence: EffectFence,
     now: number,
+    details: Readonly<Record<string, unknown>> = {},
   ): void {
-    this.db.transaction(() => {
+    const settle = () => {
       if (!this.effectLeaseCurrent(effect.idempotencyKey, fence, now) || this.getOutcome(attempt.id)) return;
       const result = {
         kind: "worker_failure",
-        retryClass: attempt.stepContract.retryClass,
+        retryClass: retryPolicy(attempt.stepContract).retryClass,
         attempts: effect.attempts,
         summary,
-      } as const;
+        ...details,
+      };
       this.db.prepare(
         `INSERT INTO navigator_ticket_worker_outcomes (
            attempt_id, slice_id, outcome, reason_code, exact_head_sha,
@@ -1657,7 +1715,9 @@ export class NavigatorImplementationExecutor {
       );
       this.invalidateIntegration(this.integrationRow(attempt.jobId)!, reasonCode, now);
       this.finishEffect(effect, fence, now, "dead", summary);
-    }).immediate();
+    };
+    if (this.db.inTransaction) settle();
+    else this.db.transaction(settle).immediate();
   }
 
   private async preparePullRequest(

--- a/src/navigator/implementation-executor.ts
+++ b/src/navigator/implementation-executor.ts
@@ -8,17 +8,23 @@ import type { WorkArtifactClaim } from "../work-artifacts/models";
 import {
   NAVIGATOR_TICKET_STEP_CONTRACTS,
   navigatorCodeReviewResultSchema,
+  navigatorGitObservationSchema,
   navigatorImplementationResultSchema,
   navigatorJsonDigest,
   navigatorPullRequestRequestSchema,
   navigatorTicketWorkerProfile,
   navigatorTicketWorkerProfileSchema,
   navigatorTicketWorkerResultSchema,
+  navigatorTicketStepContractSchema,
+  navigatorTicketRepairProposalSchema,
+  navigatorTicketRepairSnapshotSchema,
   navigatorTicketWorkOrderSchema,
   parseNavigatorTicketModelRoute,
   type NavigatorPullRequestRecord,
   type NavigatorPullRequestRequest,
+  type NavigatorGitObservation,
   type NavigatorTicketStepContract,
+  type NavigatorTicketRepairSnapshot,
   type NavigatorTicketTaskEvidence,
   type NavigatorTicketWorkerProfile,
   type NavigatorTicketWorkerResult,
@@ -49,11 +55,12 @@ export type NavigatorTicketWorkerAttempt = Readonly<{
 export type NavigatorTicketWorkerOutcome = Readonly<{
   attemptId: string;
   sliceId: string;
-  outcome: "succeeded" | "findings" | "worker_unavailable" | "policy_failure";
+  outcome: "succeeded" | "findings" | "worker_unavailable" | "policy_failure" | "dead_letter";
   reasonCode: string;
   exactHeadSha: string;
   result: unknown;
   resultDigest: string;
+  gitObservation: NavigatorGitObservation | null;
   recordedAt: number;
 }>;
 
@@ -100,6 +107,30 @@ export interface NavigatorTicketWorkerRunner {
     resource: { kind: "bb_thread"; id: string };
     result: unknown;
   }>>;
+  reconcileUnavailableResource(
+    resource: { kind: "bb_thread"; id: string },
+    reason: "missing" | "stale",
+    signal: AbortSignal,
+  ): Promise<Readonly<{
+    resource: { kind: "bb_thread"; id: string };
+    state: "terminal" | "missing";
+    evidenceRef: string;
+    observedAt: number;
+  }>>;
+}
+
+export type NavigatorGitObservationRequest = Readonly<{
+  purpose: "implementation" | "review" | "pull_request";
+  worktreeId: string;
+  integrationBranch: string;
+  expectedHeadSha: string;
+  baseHeadSha: string;
+  comparisonBaseHeadSha: string;
+  expectedChangedPaths: readonly string[];
+}>;
+
+export interface NavigatorGitObserver {
+  observe(request: NavigatorGitObservationRequest): Promise<unknown>;
 }
 
 export class NavigatorTicketWorkerUnavailableError extends Error {
@@ -108,6 +139,14 @@ export class NavigatorTicketWorkerUnavailableError extends Error {
   public constructor(public readonly reason: "missing" | "stale") {
     super(`navigator ticket worker is ${reason}`);
   }
+}
+
+export class NavigatorTicketWorkerRetryableError extends Error {
+  public readonly name = "NavigatorTicketWorkerRetryableError";
+}
+
+export class NavigatorTicketWorkerPermanentError extends Error {
+  public readonly name = "NavigatorTicketWorkerPermanentError";
 }
 
 export interface NavigatorPullRequestPublisher {
@@ -126,6 +165,7 @@ type AttemptRow = Readonly<{
   step_contract_id: string;
   step_contract_revision: number;
   step_contract_digest: string;
+  step_contract_json: string;
   profile_json: string;
   profile_digest: string;
   model_route_json: string;
@@ -185,6 +225,8 @@ type OutcomeRow = Readonly<{
   exact_head_sha: string;
   result_json: string;
   result_digest: string;
+  git_observation_json: string | null;
+  git_observation_digest: string | null;
   recorded_at: number;
 }>;
 
@@ -192,6 +234,7 @@ type NavigatorImplementationExecutorDependencies = Readonly<{
   store: TelegramAgentStore;
   database: Database.Database;
   workerRunner: NavigatorTicketWorkerRunner;
+  gitObserver: NavigatorGitObserver;
   pullRequests: NavigatorPullRequestPublisher;
   modelRoute(kind: "implementation" | "review"): ModelRoute;
   clock: { now(): number };
@@ -227,15 +270,27 @@ function stableId(prefix: string, ...parts: readonly string[]): string {
   return `${prefix}_${createHash("sha256").update(parts.join("\0"), "utf8").digest("base64url").slice(0, 24)}`;
 }
 
+function parseRepairSnapshot(rawSnapshot: unknown): NavigatorTicketRepairSnapshot {
+  const snapshot = navigatorTicketRepairSnapshotSchema.parse(rawSnapshot);
+  const { snapshotId: _snapshotId, digest: _digest, ...payload } = snapshot;
+  if (
+    navigatorJsonDigest(payload) !== snapshot.digest ||
+    stableId("navrepair", snapshot.sliceId, snapshot.reviewAttemptId, snapshot.digest) !== snapshot.snapshotId
+  ) throw new Error(`navigator repair snapshot ${snapshot.snapshotId} has invalid durable identity`);
+  return snapshot;
+}
+
 function parseAttempt(row: AttemptRow): NavigatorTicketWorkerAttempt {
   const workOrder = navigatorTicketWorkOrderSchema.parse(JSON.parse(row.work_order_json));
   const profile = navigatorTicketWorkerProfileSchema.parse(JSON.parse(row.profile_json));
-  const stepContract = NAVIGATOR_TICKET_STEP_CONTRACTS[row.kind];
+  const stepContract = navigatorTicketStepContractSchema.parse(JSON.parse(row.step_contract_json));
+  const { digest: _digest, ...unsignedContract } = stepContract;
   if (
     navigatorJsonDigest(workOrder) !== row.work_order_digest ||
     stepContract.id !== row.step_contract_id ||
     stepContract.revision !== row.step_contract_revision ||
     stepContract.digest !== row.step_contract_digest ||
+    navigatorJsonDigest(unsignedContract) !== stepContract.digest ||
     profile.digest !== row.profile_digest
   ) {
     throw new Error(`navigator ticket attempt ${row.id} has invalid durable identity`);
@@ -263,6 +318,13 @@ function parseOutcome(row: OutcomeRow): NavigatorTicketWorkerOutcome {
   if (navigatorJsonDigest(result) !== row.result_digest) {
     throw new Error(`navigator ticket outcome ${row.attempt_id} has invalid digest`);
   }
+  const gitObservation = row.git_observation_json === null
+    ? null
+    : navigatorGitObservationSchema.parse(JSON.parse(row.git_observation_json));
+  if (
+    (gitObservation === null) !== (row.git_observation_digest === null) ||
+    (gitObservation !== null && navigatorJsonDigest(gitObservation) !== row.git_observation_digest)
+  ) throw new Error(`navigator ticket outcome ${row.attempt_id} has invalid Git observation`);
   return {
     attemptId: row.attempt_id,
     sliceId: row.slice_id,
@@ -271,6 +333,7 @@ function parseOutcome(row: OutcomeRow): NavigatorTicketWorkerOutcome {
     exactHeadSha: row.exact_head_sha,
     result,
     resultDigest: row.result_digest,
+    gitObservation,
     recordedAt: row.recorded_at,
   };
 }
@@ -405,11 +468,34 @@ export class NavigatorImplementationExecutor {
     claimId: number;
     taskEvidence: readonly string[];
     evidenceRefs: readonly string[];
+    ownerId: string;
+    generation: number;
   }>) {
     assertIdentifier(input.jobId, "jobId");
     assertIdentifier(input.ticketArtifactId, "ticketArtifactId");
     if (!Number.isSafeInteger(input.claimId) || input.claimId < 1) throw new TypeError("claimId is invalid");
     const claimEvidenceRefs = boundedRefs(input.evidenceRefs);
+    const leaseMs = this.dependencies.leaseMs ?? 30_000;
+    const claim = this.dependencies.store.getWorkArtifactClaim(input.claimId);
+    const ticketBeforeAdoption = this.requireTicket(input.jobId, input.ticketArtifactId);
+    if (
+      !claim || claim.jobId !== input.jobId || claim.artifactId !== ticketBeforeAdoption.artifact_id ||
+      claim.snapshotId !== ticketBeforeAdoption.snapshot_id ||
+      !this.bindingIsCurrent({
+        artifactId: ticketBeforeAdoption.artifact_id,
+        snapshotId: ticketBeforeAdoption.snapshot_id,
+        snapshotDigest: ticketBeforeAdoption.snapshot_digest,
+      }) || !this.dependencies.store.adoptWorkArtifactClaim({
+        artifactId: claim.artifactId,
+        workflowStepId: claim.workflowStepId,
+        jobId: input.jobId,
+        externalAssignee: claim.externalAssignee,
+        ownerId: input.ownerId,
+        generation: input.generation,
+        now: this.dependencies.clock.now(),
+        leaseMs,
+      })
+    ) throw new TypeError("implementation ticket claim could not be adopted by the current executor");
     return this.db.transaction(() => {
       const integration = this.requireWritableIntegration(input.jobId);
       const evidenceRefs = mergeEvidenceRefs(
@@ -426,9 +512,15 @@ export class NavigatorImplementationExecutor {
       if (!ticket || ticket.state !== "pending" || this.nextEligibleTicket(input.jobId)?.artifact_id !== ticket.artifact_id) {
         throw new TypeError("claimed ticket is not the next eligible implementation ticket");
       }
-      const claim = this.dependencies.store.getWorkArtifactClaim(input.claimId);
-      this.assertClaim(claim, input.jobId, ticket);
       const now = this.dependencies.clock.now();
+      this.assertClaim({
+        claim: this.dependencies.store.getWorkArtifactClaim(input.claimId),
+        jobId: input.jobId,
+        ticket,
+        ownerId: input.ownerId,
+        generation: input.generation,
+        now,
+      });
       const sliceId = stableId("navslice", input.jobId, ticket.artifact_id, ticket.snapshot_digest);
       this.db.prepare(
         `INSERT INTO navigator_ticket_slices (
@@ -469,25 +561,168 @@ export class NavigatorImplementationExecutor {
     }).immediate();
   }
 
+  public prepareRepairNavigation(input: Readonly<{
+    jobId: string;
+    ticketArtifactId: string;
+    evidenceRefs: readonly string[];
+  }>): NavigatorTicketRepairSnapshot {
+    return this.db.transaction(() => {
+      const integration = this.requireWritableIntegration(input.jobId);
+      const slice = this.requireSliceForTicket(input.jobId, input.ticketArtifactId);
+      if (slice.state !== "repair_pending" || integration.active_slice_id !== slice.id) {
+        throw new TypeError("ticket findings are not awaiting navigator reconsideration");
+      }
+      const priorReview = this.latestAttempt(slice.id, "review");
+      const reviewOutcome = this.getOutcome(priorReview.id);
+      if (
+        reviewOutcome?.outcome !== "findings" ||
+        reviewOutcome.exactHeadSha !== priorReview.workOrder.baseHeadSha ||
+        reviewOutcome.gitObservation === null
+      ) {
+        throw new TypeError("ticket repair navigation requires exact-head review findings");
+      }
+      const reviewResult = navigatorCodeReviewResultSchema.parse(reviewOutcome.result);
+      const existing = this.db.prepare(
+        "SELECT snapshot_json FROM navigator_ticket_repair_snapshots WHERE review_attempt_id = ?",
+      ).get(priorReview.id) as { snapshot_json: string } | undefined;
+      if (existing) return parseRepairSnapshot(JSON.parse(existing.snapshot_json));
+      const now = this.dependencies.clock.now();
+      const payload = {
+        kind: "navigator_ticket_repair_snapshot" as const,
+        jobId: input.jobId,
+        sliceId: slice.id,
+        ticket: priorReview.workOrder.ticket,
+        reviewAttemptId: priorReview.id,
+        reviewedHeadSha: reviewOutcome.exactHeadSha,
+        reviewResultDigest: reviewOutcome.resultDigest,
+        gitObservationDigest: navigatorJsonDigest(reviewOutcome.gitObservation),
+        findings: reviewResult.findings,
+        evidenceRefs: mergeEvidenceRefs(
+          priorReview.workOrder.evidenceRefs,
+          boundedRefs(input.evidenceRefs),
+          [`navigator-result:${priorReview.id}`],
+          [reviewOutcome.gitObservation.evidenceRef],
+        ),
+        createdAt: now,
+      };
+      const digest = navigatorJsonDigest(payload);
+      const snapshot = navigatorTicketRepairSnapshotSchema.parse({
+        ...payload,
+        snapshotId: stableId("navrepair", slice.id, priorReview.id, digest),
+        digest,
+      });
+      this.db.prepare(
+        `INSERT OR IGNORE INTO navigator_ticket_repair_snapshots (
+           id, job_id, slice_id, review_attempt_id, snapshot_json, snapshot_digest, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        snapshot.snapshotId,
+        input.jobId,
+        slice.id,
+        priorReview.id,
+        JSON.stringify(snapshot),
+        snapshot.digest,
+        now,
+      );
+      const stored = this.db.prepare(
+        "SELECT snapshot_json, snapshot_digest FROM navigator_ticket_repair_snapshots WHERE id = ?",
+      ).get(snapshot.snapshotId) as { snapshot_json: string; snapshot_digest: string } | undefined;
+      if (stored?.snapshot_json !== JSON.stringify(snapshot) || stored.snapshot_digest !== snapshot.digest) {
+        throw new Error("navigator repair snapshot changed during replay");
+      }
+      return snapshot;
+    }).immediate();
+  }
+
+  public recordRepairProposal(input: Readonly<{ snapshotId: string; rawProposal: unknown }>) {
+    return this.db.transaction(() => {
+      const row = this.db.prepare(
+        "SELECT snapshot_json FROM navigator_ticket_repair_snapshots WHERE id = ?",
+      ).get(input.snapshotId) as { snapshot_json: string } | undefined;
+      if (!row) throw new TypeError("navigator repair snapshot was not found");
+      const snapshot = parseRepairSnapshot(JSON.parse(row.snapshot_json));
+      const proposal = navigatorTicketRepairProposalSchema.parse(input.rawProposal);
+      if (proposal.basedOn.snapshotId !== snapshot.snapshotId || proposal.basedOn.digest !== snapshot.digest) {
+        throw new TypeError("navigator repair proposal is based on a stale finding snapshot");
+      }
+      const slice = this.requireSlice(snapshot.sliceId);
+      if (slice.state !== "repair_pending" || this.latestAttempt(slice.id, "review").id !== snapshot.reviewAttemptId) {
+        throw new TypeError("navigator repair proposal no longer matches the active findings");
+      }
+      const proposalDigest = navigatorJsonDigest(proposal);
+      const proposalId = stableId("navrepairproposal", snapshot.snapshotId, proposalDigest);
+      const now = this.dependencies.clock.now();
+      this.db.prepare(
+        `INSERT OR IGNORE INTO navigator_ticket_repair_proposals (
+           id, snapshot_id, route, proposal_json, proposal_digest, decision, accepted_at
+         ) VALUES (?, ?, ?, ?, ?, 'accepted', ?)`,
+      ).run(
+        proposalId,
+        snapshot.snapshotId,
+        proposal.kind,
+        JSON.stringify(proposal),
+        proposalDigest,
+        now,
+      );
+      const stored = this.db.prepare(
+        `SELECT route, proposal_json, proposal_digest, decision
+           FROM navigator_ticket_repair_proposals WHERE id = ?`,
+      ).get(proposalId) as {
+        route: string;
+        proposal_json: string;
+        proposal_digest: string;
+        decision: string;
+      } | undefined;
+      if (
+        stored?.route !== proposal.kind || stored.proposal_json !== JSON.stringify(proposal) ||
+        stored.proposal_digest !== proposalDigest || stored.decision !== "accepted"
+      ) throw new Error("navigator repair proposal changed during replay");
+      return { proposalId, decision: "accepted" as const, route: proposal.kind };
+    }).immediate();
+  }
+
   public scheduleRepair(input: Readonly<{
     jobId: string;
     ticketArtifactId: string;
-    taskEvidence: readonly string[];
-    evidenceRefs: readonly string[];
+    proposalId: string;
   }>): NavigatorTicketWorkerAttempt {
     return this.db.transaction(() => {
+      const replay = this.db.prepare(
+        "SELECT attempt_id FROM navigator_ticket_repair_dispatches WHERE proposal_id = ?",
+      ).get(input.proposalId) as { attempt_id: string } | undefined;
+      if (replay) return this.getAttempt(replay.attempt_id)!;
       const integration = this.requireWritableIntegration(input.jobId);
       const slice = this.requireSliceForTicket(input.jobId, input.ticketArtifactId);
       if (slice.state !== "repair_pending" || integration.active_slice_id !== slice.id) {
         throw new TypeError("ticket is not awaiting an agent-owned repair");
       }
+      const proposalRow = this.db.prepare(
+        `SELECT proposal.proposal_json, proposal.proposal_digest, snapshot.snapshot_json
+           FROM navigator_ticket_repair_proposals AS proposal
+           JOIN navigator_ticket_repair_snapshots AS snapshot ON snapshot.id = proposal.snapshot_id
+          WHERE proposal.id = ? AND proposal.decision = 'accepted'`,
+      ).get(input.proposalId) as {
+        proposal_json: string;
+        proposal_digest: string;
+        snapshot_json: string;
+      } | undefined;
+      if (!proposalRow) throw new TypeError("repair requires a newly accepted navigator proposal");
+      const proposal = navigatorTicketRepairProposalSchema.parse(JSON.parse(proposalRow.proposal_json));
+      const snapshot = parseRepairSnapshot(JSON.parse(proposalRow.snapshot_json));
+      if (
+        navigatorJsonDigest(proposal) !== proposalRow.proposal_digest ||
+        proposal.kind !== "implementation" || snapshot.jobId !== input.jobId || snapshot.sliceId !== slice.id ||
+        snapshot.ticket.artifactId !== input.ticketArtifactId ||
+        this.latestAttempt(slice.id, "review").id !== snapshot.reviewAttemptId
+      ) throw new TypeError("accepted navigator proposal does not select this exact-head repair");
       const ticket = this.requireTicket(input.jobId, input.ticketArtifactId);
       const ordinal = this.nextAttemptOrdinal(slice.id, "implementation");
       const priorReview = this.latestAttempt(slice.id, "review");
       const evidenceRefs = mergeEvidenceRefs(
         priorReview.workOrder.evidenceRefs,
-        boundedRefs(input.evidenceRefs),
+        proposal.evidenceRefs,
         [`navigator-result:${priorReview.id}`],
+        [`navigator-repair-proposal:${input.proposalId}`],
       );
       const now = this.dependencies.clock.now();
       const attempt = this.createAttempt({
@@ -496,7 +731,7 @@ export class NavigatorImplementationExecutor {
         ticket,
         kind: "implementation",
         ordinal,
-        taskEvidence: input.taskEvidence,
+        taskEvidence: proposal.taskEvidence,
         evidenceRefs,
         changedPaths: priorReview.workOrder.changedPaths,
         baseHeadSha: integration.current_head_sha,
@@ -506,6 +741,10 @@ export class NavigatorImplementationExecutor {
       this.db.prepare(
         "UPDATE navigator_ticket_slices SET state = 'implementation_pending', updated_at = ? WHERE id = ?",
       ).run(now, slice.id);
+      this.db.prepare(
+        `INSERT INTO navigator_ticket_repair_dispatches (proposal_id, attempt_id, dispatched_at)
+         VALUES (?, ?, ?)`,
+      ).run(input.proposalId, attempt.id, now);
       return attempt;
     }).immediate();
   }
@@ -521,6 +760,10 @@ export class NavigatorImplementationExecutor {
       return true;
     }
     const leaseMs = this.dependencies.leaseMs ?? 30_000;
+    if (!this.adoptAttemptClaim(attempt, fence, now, leaseMs)) {
+      this.settleClaimFenceFailure(attempt, effect, fence, now);
+      return true;
+    }
     const leaseAbort = new AbortController();
     const timeoutAbort = new AbortController();
     const runSignal = AbortSignal.any([signal, fence.signal, leaseAbort.signal, timeoutAbort.signal]);
@@ -538,7 +781,7 @@ export class NavigatorImplementationExecutor {
     }, attempt.stepContract.timeoutMs);
     const renewal = setInterval(() => {
       try {
-        const renewed = this.dependencies.store.renewJobOperationFences({
+        const operationRenewed = this.dependencies.store.renewJobOperationFences({
           jobId: effect.jobId,
           effectIdempotencyKey: effect.idempotencyKey,
           ownerId: fence.ownerId,
@@ -546,7 +789,8 @@ export class NavigatorImplementationExecutor {
           now: this.dependencies.clock.now(),
           leaseMs,
         });
-        if (!renewed && !leaseAbort.signal.aborted) {
+        const claimRenewed = this.renewAttemptClaim(attempt, fence, this.dependencies.clock.now(), leaseMs);
+        if ((!operationRenewed || !claimRenewed) && !leaseAbort.signal.aborted) {
           leaseAbort.abort(new Error("navigator ticket worker lease was lost"));
         }
       } catch (renewalError) {
@@ -567,23 +811,33 @@ export class NavigatorImplementationExecutor {
       if (!this.bindResource(attempt.id, effect.idempotencyKey, run.resource, fence, this.dependencies.clock.now())) {
         throw new Error("navigator ticket worker returned a different resource");
       }
-      this.settleAttempt(attempt.id, effect.idempotencyKey, run.result, fence, this.dependencies.clock.now());
+      const gitObservation = await this.observeAttemptGit(attempt, run.result);
+      this.settleAttempt(
+        attempt.id,
+        effect.idempotencyKey,
+        run.result,
+        gitObservation,
+        fence,
+        this.dependencies.clock.now(),
+      );
     } catch (error) {
       if (error instanceof NavigatorTicketWorkerUnavailableError) {
-        this.replaceUnavailableAttempt(
-          attempt,
-          effect.idempotencyKey,
-          error.reason,
-          fence,
-          this.dependencies.clock.now(),
-        );
+        try {
+          const observation = await this.reconcileUnavailableResource(attempt, error.reason, runSignal);
+          this.replaceUnavailableAttempt(
+            attempt,
+            effect.idempotencyKey,
+            error.reason,
+            observation,
+            fence,
+            this.dependencies.clock.now(),
+          );
+        } catch (reconciliationError) {
+          this.settleWorkerFailure(attempt, effect, reconciliationError, fence, this.dependencies.clock.now());
+        }
         return true;
       }
-      const summary = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
-      const failedAt = this.dependencies.clock.now();
-      if (this.effectLeaseCurrent(effect.idempotencyKey, fence, failedAt)) {
-        this.finishEffect(effect, fence, failedAt, "failed", summary.slice(0, 500));
-      }
+      this.settleWorkerFailure(attempt, effect, error, fence, this.dependencies.clock.now());
     } finally {
       clearInterval(renewal);
       clearTimeout(timeout);
@@ -602,6 +856,7 @@ export class NavigatorImplementationExecutor {
       const resolution = this.dependencies.store.getWorkArtifactResolution(input.ticketArtifactId);
       if (
         outcome?.outcome !== "succeeded" ||
+        outcome.gitObservation?.headSha !== review.workOrder.baseHeadSha ||
         resolution?.outcome !== "resolved" ||
         resolution.snapshotId !== slice.ticket_snapshot_id ||
         !resolution.evidenceRefs.includes(`navigator-result:${review.id}`)
@@ -632,7 +887,7 @@ export class NavigatorImplementationExecutor {
     title: string;
     body: string;
   }>): Promise<NavigatorPullRequestRecord> {
-    const request = this.preparePullRequest(input);
+    const request = await this.preparePullRequest(input);
     const existing = this.pullRequestRow(input.jobId);
     if (existing?.status === "published") return this.publishedPullRequest(existing);
     const published = await this.dependencies.pullRequests.createOrRefresh(request);
@@ -759,16 +1014,108 @@ export class NavigatorImplementationExecutor {
       ticket.state === "pending" && this.ticketIsEligible(jobId, ticket)) ?? null;
   }
 
-  private assertClaim(claim: WorkArtifactClaim | null, jobId: string, ticket: TicketRow): void {
+  private assertClaim(input: Readonly<{
+    claim: WorkArtifactClaim | null;
+    jobId: string;
+    ticket: TicketRow;
+    ownerId: string;
+    generation: number;
+    now: number;
+  }>): void {
     if (
-      !claim || claim.state !== "held" || claim.jobId !== jobId ||
-      claim.artifactId !== ticket.artifact_id || claim.snapshotId !== ticket.snapshot_id ||
+      !input.claim || input.claim.state !== "held" || input.claim.jobId !== input.jobId ||
+      input.claim.artifactId !== input.ticket.artifact_id || input.claim.snapshotId !== input.ticket.snapshot_id ||
+      input.claim.ownerId !== input.ownerId || input.claim.generation !== input.generation ||
+      input.claim.leaseExpiresAt <= input.now ||
       !this.bindingIsCurrent({
-        artifactId: ticket.artifact_id,
-        snapshotId: ticket.snapshot_id,
-        snapshotDigest: ticket.snapshot_digest,
+        artifactId: input.ticket.artifact_id,
+        snapshotId: input.ticket.snapshot_id,
+        snapshotDigest: input.ticket.snapshot_digest,
       })
     ) throw new TypeError("implementation ticket claim is stale or belongs to another lane");
+  }
+
+  private adoptAttemptClaim(
+    attempt: NavigatorTicketWorkerAttempt,
+    fence: EffectFence,
+    now: number,
+    leaseMs: number,
+  ): boolean {
+    const slice = this.requireSlice(attempt.sliceId);
+    const claim = this.dependencies.store.getWorkArtifactClaim(slice.claim_id);
+    return claim !== null && this.dependencies.store.adoptWorkArtifactClaim({
+      artifactId: claim.artifactId,
+      workflowStepId: claim.workflowStepId,
+      jobId: attempt.jobId,
+      externalAssignee: claim.externalAssignee,
+      ownerId: fence.ownerId,
+      generation: fence.generation,
+      now,
+      leaseMs,
+    });
+  }
+
+  private renewAttemptClaim(
+    attempt: NavigatorTicketWorkerAttempt,
+    fence: EffectFence,
+    now: number,
+    leaseMs: number,
+  ): boolean {
+    return this.dependencies.store.renewWorkArtifactClaim({
+      claimId: this.requireSlice(attempt.sliceId).claim_id,
+      ownerId: fence.ownerId,
+      generation: fence.generation,
+      now,
+      leaseMs,
+    });
+  }
+
+  private claimFenceIsCurrent(attempt: NavigatorTicketWorkerAttempt, fence: EffectFence, now: number): boolean {
+    const slice = this.requireSlice(attempt.sliceId);
+    const ticket = this.requireTicket(attempt.jobId, attempt.workOrder.ticket.artifactId);
+    try {
+      this.assertClaim({
+        claim: this.dependencies.store.getWorkArtifactClaim(slice.claim_id),
+        jobId: attempt.jobId,
+        ticket,
+        ownerId: fence.ownerId,
+        generation: fence.generation,
+        now,
+      });
+      return true;
+    } catch (error) {
+      if (error instanceof TypeError) return false;
+      throw error;
+    }
+  }
+
+  private settleClaimFenceFailure(
+    attempt: NavigatorTicketWorkerAttempt,
+    effect: StoredEffect,
+    fence: EffectFence,
+    now: number,
+  ): void {
+    const settle = () => {
+      if (!this.effectLeaseCurrent(effect.idempotencyKey, fence, now) || this.getOutcome(attempt.id)) return;
+      const result = { kind: "policy_failure", reasonCode: "claim_fence_lost" } as const;
+      this.db.prepare(
+        `INSERT INTO navigator_ticket_worker_outcomes (
+           attempt_id, slice_id, outcome, reason_code, exact_head_sha,
+           result_json, result_digest, recorded_at
+         ) VALUES (?, ?, 'policy_failure', 'claim_fence_lost', ?, ?, ?, ?)`,
+      ).run(
+        attempt.id,
+        attempt.sliceId,
+        attempt.workOrder.baseHeadSha,
+        JSON.stringify(result),
+        navigatorJsonDigest(result),
+        now,
+      );
+      this.invalidateIntegration(this.integrationRow(attempt.jobId)!, "claim_fence_lost", now);
+      this.finishEffect(effect, fence, now, "done", null);
+    };
+    if (this.db.inTransaction) settle();
+    else this.db.transaction(settle).immediate();
   }
 
   private createAttempt(input: Readonly<{
@@ -835,9 +1182,9 @@ export class NavigatorImplementationExecutor {
       `INSERT INTO navigator_ticket_worker_attempts (
          id, job_id, slice_id, kind, ordinal, effect_idempotency_key,
          work_order_json, work_order_digest, step_contract_id, step_contract_revision,
-         step_contract_digest, profile_json, profile_digest, model_route_json,
+         step_contract_digest, step_contract_json, profile_json, profile_digest, model_route_json,
          resource_kind, resource_id, created_at, updated_at
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)`,
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)`,
     ).run(
       attemptId,
       input.integration.job_id,
@@ -850,6 +1197,7 @@ export class NavigatorImplementationExecutor {
       stepContract.id,
       stepContract.revision,
       stepContract.digest,
+      JSON.stringify(stepContract),
       JSON.stringify(profile),
       profile.digest,
       JSON.stringify(route),
@@ -954,6 +1302,7 @@ export class NavigatorImplementationExecutor {
     attemptId: string,
     effectKey: string,
     rawResult: unknown,
+    rawGitObservation: unknown,
     fence: EffectFence,
     now: number,
   ): NavigatorTicketWorkerOutcome | null {
@@ -963,10 +1312,18 @@ export class NavigatorImplementationExecutor {
       if (!attempt || attempt.effectIdempotencyKey !== effectKey || attempt.resource === null) return null;
       const existing = this.getOutcome(attemptId);
       if (existing) return existing;
+      if (!this.claimFenceIsCurrent(attempt, fence, now)) {
+        const effect = this.parseEffect(this.db.prepare(
+          "SELECT * FROM effects WHERE idempotency_key = ?",
+        ).get(effectKey) as Parameters<typeof this.parseEffect>[0]);
+        this.settleClaimFenceFailure(attempt, effect, fence, now);
+        return this.getOutcome(attempt.id);
+      }
       const rawResultJson = JSON.stringify(rawResult);
       const resultTooLarge = rawResultJson !== undefined &&
         Buffer.byteLength(rawResultJson, "utf8") > attempt.stepContract.maximumResultBytes;
       const parsed = navigatorTicketWorkerResultSchema.safeParse(resultTooLarge ? undefined : rawResult);
+      const parsedGit = navigatorGitObservationSchema.safeParse(rawGitObservation);
       const integration = this.integrationRow(attempt.jobId)!;
       let outcome: NavigatorTicketWorkerOutcome["outcome"] = "succeeded";
       let reasonCode = "accepted";
@@ -987,6 +1344,9 @@ export class NavigatorImplementationExecutor {
       } else if (!resultCapabilitiesAreAccepted(parsed.data, attempt.profile)) {
         outcome = "policy_failure";
         reasonCode = "capability_outcome_missing";
+      } else if (!parsedGit.success || !this.gitObservationMatches(attempt, parsed.data, parsedGit.data)) {
+        outcome = "policy_failure";
+        reasonCode = "git_observation_rejected";
       } else if (parsed.data.kind === "implementation_result") {
         if (
           parsed.data.baseHeadSha !== attempt.workOrder.baseHeadSha ||
@@ -1006,15 +1366,19 @@ export class NavigatorImplementationExecutor {
         outcome = "findings";
         reasonCode = "review_findings";
       }
-      const exactHeadSha = parsed.success && parsed.data.kind === "implementation_result"
-        ? parsed.data.headSha
-        : attempt.workOrder.baseHeadSha;
       const resultDigest = navigatorJsonDigest(result);
+      const gitObservation = parsedGit.success ? parsedGit.data : null;
+      const gitObservationDigest = gitObservation === null ? null : navigatorJsonDigest(gitObservation);
+      const exactHeadSha = gitObservation?.headSha ?? (
+        parsed.success && parsed.data.kind === "implementation_result"
+          ? parsed.data.headSha
+          : attempt.workOrder.baseHeadSha
+      );
       this.db.prepare(
         `INSERT INTO navigator_ticket_worker_outcomes (
            attempt_id, slice_id, outcome, reason_code, exact_head_sha,
-           result_json, result_digest, recorded_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+           result_json, result_digest, git_observation_json, git_observation_digest, recorded_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       ).run(
         attempt.id,
         attempt.sliceId,
@@ -1023,6 +1387,8 @@ export class NavigatorImplementationExecutor {
         exactHeadSha,
         JSON.stringify(result),
         resultDigest,
+        gitObservation === null ? null : JSON.stringify(gitObservation),
+        gitObservationDigest,
         now,
       );
       if (outcome === "policy_failure") {
@@ -1048,6 +1414,48 @@ export class NavigatorImplementationExecutor {
       this.finishEffectByKey(effectKey, fence, now, "done", null);
       return this.getOutcome(attempt.id);
     }).immediate();
+  }
+
+  private async observeAttemptGit(
+    attempt: NavigatorTicketWorkerAttempt,
+    rawResult: unknown,
+  ): Promise<unknown> {
+    const parsed = navigatorTicketWorkerResultSchema.safeParse(rawResult);
+    if (!parsed.success) return null;
+    const expectedHeadSha = parsed.data.kind === "implementation_result"
+      ? parsed.data.headSha
+      : parsed.data.reviewedHeadSha;
+    const expectedChangedPaths = parsed.data.kind === "implementation_result"
+      ? parsed.data.changedPaths
+      : attempt.workOrder.changedPaths;
+    return this.dependencies.gitObserver.observe({
+      purpose: attempt.kind,
+      worktreeId: attempt.workOrder.worktreeId,
+      integrationBranch: attempt.workOrder.integrationBranch,
+      expectedHeadSha,
+      baseHeadSha: attempt.workOrder.baseHeadSha,
+      comparisonBaseHeadSha: attempt.workOrder.comparisonBaseHeadSha,
+      expectedChangedPaths,
+    });
+  }
+
+  private gitObservationMatches(
+    attempt: NavigatorTicketWorkerAttempt,
+    result: NavigatorTicketWorkerResult,
+    observation: NavigatorGitObservation,
+  ): boolean {
+    const expectedHeadSha = result.kind === "implementation_result" ? result.headSha : result.reviewedHeadSha;
+    const expectedChangedPaths = result.kind === "implementation_result"
+      ? result.changedPaths
+      : attempt.workOrder.changedPaths;
+    return observation.worktreeId === attempt.workOrder.worktreeId &&
+      observation.branch === attempt.workOrder.integrationBranch &&
+      observation.headSha === expectedHeadSha &&
+      observation.baseHeadSha === attempt.workOrder.baseHeadSha &&
+      observation.baseHeadIsAncestor &&
+      observation.comparisonBaseHeadSha === attempt.workOrder.comparisonBaseHeadSha &&
+      observation.comparisonBaseHeadIsAncestor && observation.clean &&
+      JSON.stringify(observation.changedPaths) === JSON.stringify(expectedChangedPaths);
   }
 
   private acceptImplementation(
@@ -1084,6 +1492,12 @@ export class NavigatorImplementationExecutor {
     attempt: NavigatorTicketWorkerAttempt,
     effectKey: string,
     reason: "missing" | "stale",
+    resourceObservation: Readonly<{
+      resource: { kind: "bb_thread"; id: string } | null;
+      state: "terminal" | "missing";
+      evidenceRef: string;
+      observedAt: number;
+    }>,
     fence: EffectFence,
     now: number,
   ): void {
@@ -1116,7 +1530,7 @@ export class NavigatorImplementationExecutor {
         this.finishEffectByKey(effectKey, fence, now, "done", null);
         return;
       }
-      const result = { kind: "worker_unavailable", reason } as const;
+      const result = { kind: "worker_unavailable", reason, resourceObservation } as const;
       this.db.prepare(
         `INSERT INTO navigator_ticket_worker_outcomes (
            attempt_id, slice_id, outcome, reason_code, exact_head_sha,
@@ -1151,7 +1565,131 @@ export class NavigatorImplementationExecutor {
     }).immediate();
   }
 
-  private preparePullRequest(input: Readonly<{ jobId: string; title: string; body: string }>): NavigatorPullRequestRequest {
+  private async reconcileUnavailableResource(
+    attempt: NavigatorTicketWorkerAttempt,
+    reason: "missing" | "stale",
+    signal: AbortSignal,
+  ): Promise<Readonly<{
+    resource: { kind: "bb_thread"; id: string } | null;
+    state: "terminal" | "missing";
+    evidenceRef: string;
+    observedAt: number;
+  }>> {
+    if (attempt.resource === null) {
+      return {
+        resource: null,
+        state: "missing",
+        evidenceRef: `navigator-resource:${attempt.id}:unbound`,
+        observedAt: this.dependencies.clock.now(),
+      };
+    }
+    const observation = await this.dependencies.workerRunner.reconcileUnavailableResource(
+      attempt.resource,
+      reason,
+      signal,
+    );
+    if (
+      observation.resource.kind !== "bb_thread" ||
+      observation.resource.id !== attempt.resource.id ||
+      (observation.state !== "terminal" && observation.state !== "missing") ||
+      observation.evidenceRef.trim().length === 0 || observation.evidenceRef.length > 1_024 ||
+      !Number.isSafeInteger(observation.observedAt) || observation.observedAt < 0
+    ) throw new TypeError("unavailable worker reconciliation returned invalid terminal evidence");
+    return observation;
+  }
+
+  private settleWorkerFailure(
+    attempt: NavigatorTicketWorkerAttempt,
+    effect: StoredEffect,
+    error: unknown,
+    fence: EffectFence,
+    now: number,
+  ): void {
+    if (!this.effectLeaseCurrent(effect.idempotencyKey, fence, now)) return;
+    const rawSummary = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+    const summary = rawSummary.replace(/\s+/gu, " ").trim().slice(0, 500) || "Navigator ticket worker failed";
+    const permanent = error instanceof NavigatorTicketWorkerPermanentError;
+    if (permanent || effect.attempts >= attempt.stepContract.maximumAttempts) {
+      this.deadLetterAttempt(
+        attempt,
+        effect,
+        permanent ? "permanent_failure" : "retry_exhausted",
+        summary,
+        fence,
+        now,
+      );
+      return;
+    }
+    const exponential = attempt.stepContract.backoffBaseMs * 2 ** Math.max(0, effect.attempts - 1);
+    const delay = Math.min(attempt.stepContract.backoffMaximumMs, exponential);
+    this.finishEffect(effect, fence, now, "failed", summary, now + delay);
+  }
+
+  private deadLetterAttempt(
+    attempt: NavigatorTicketWorkerAttempt,
+    effect: StoredEffect,
+    reasonCode: "permanent_failure" | "retry_exhausted",
+    summary: string,
+    fence: EffectFence,
+    now: number,
+  ): void {
+    this.db.transaction(() => {
+      if (!this.effectLeaseCurrent(effect.idempotencyKey, fence, now) || this.getOutcome(attempt.id)) return;
+      const result = {
+        kind: "worker_failure",
+        retryClass: attempt.stepContract.retryClass,
+        attempts: effect.attempts,
+        summary,
+      } as const;
+      this.db.prepare(
+        `INSERT INTO navigator_ticket_worker_outcomes (
+           attempt_id, slice_id, outcome, reason_code, exact_head_sha,
+           result_json, result_digest, recorded_at
+         ) VALUES (?, ?, 'dead_letter', ?, ?, ?, ?, ?)`,
+      ).run(
+        attempt.id,
+        attempt.sliceId,
+        reasonCode,
+        attempt.workOrder.baseHeadSha,
+        JSON.stringify(result),
+        navigatorJsonDigest(result),
+        now,
+      );
+      this.invalidateIntegration(this.integrationRow(attempt.jobId)!, reasonCode, now);
+      this.finishEffect(effect, fence, now, "dead", summary);
+    }).immediate();
+  }
+
+  private async preparePullRequest(
+    input: Readonly<{ jobId: string; title: string; body: string }>,
+  ): Promise<NavigatorPullRequestRequest> {
+    const observedIntegration = this.integrationRow(input.jobId);
+    if (!observedIntegration || !["ready_for_pull_request", "publishing_pull_request", "ready_for_release"].includes(observedIntegration.state)) {
+      throw new TypeError("navigator integration is not ready for one final pull request");
+    }
+    const existingRequest = this.pullRequestRow(input.jobId);
+    if (existingRequest) return navigatorPullRequestRequestSchema.parse(JSON.parse(existingRequest.request_json));
+    const expectedChangedPaths = this.acceptedGitObservations(input.jobId)
+      .flatMap((observation) => observation.changedPaths)
+      .filter((path, index, paths) => paths.indexOf(path) === index)
+      .sort((left, right) => left.localeCompare(right));
+    const rawGitObservation = await this.dependencies.gitObserver.observe({
+      purpose: "pull_request",
+      worktreeId: observedIntegration.worktree_id,
+      integrationBranch: observedIntegration.integration_branch,
+      expectedHeadSha: observedIntegration.current_head_sha,
+      baseHeadSha: observedIntegration.base_head_sha,
+      comparisonBaseHeadSha: observedIntegration.base_head_sha,
+      expectedChangedPaths,
+    });
+    const gitObservation = navigatorGitObservationSchema.parse(rawGitObservation);
+    if (!this.integrationGitObservationMatches({
+      integration: observedIntegration,
+      observation: gitObservation,
+      expectedChangedPaths,
+    })) {
+      throw new TypeError("pull request Git observation does not match the owned integration branch");
+    }
     return this.db.transaction(() => {
       let integration = this.integrationRow(input.jobId);
       if (!integration || !["ready_for_pull_request", "publishing_pull_request", "ready_for_release"].includes(integration.state)) {
@@ -1167,6 +1705,9 @@ export class NavigatorImplementationExecutor {
       }
       const existing = this.pullRequestRow(input.jobId);
       if (existing) return navigatorPullRequestRequestSchema.parse(JSON.parse(existing.request_json));
+      if (integration.current_head_sha !== observedIntegration.current_head_sha) {
+        throw new Error("integration head changed during pull request Git observation");
+      }
       const outcomeRefs = this.db.prepare(
         `SELECT 'navigator-result:' || outcome.attempt_id AS evidence_ref
            FROM navigator_ticket_worker_outcomes AS outcome
@@ -1182,7 +1723,13 @@ export class NavigatorImplementationExecutor {
         headSha: integration.current_head_sha,
         title: input.title,
         body: input.body,
-        evidenceRefs: outcomeRefs.map((row) => row.evidence_ref),
+        gitObservation,
+        gitObservationDigest: navigatorJsonDigest(gitObservation),
+        evidenceRefs: mergeEvidenceRefs(
+          outcomeRefs.map((row) => row.evidence_ref),
+          this.acceptedGitObservations(input.jobId).map((observation) => observation.evidenceRef),
+          [gitObservation.evidenceRef],
+        ),
       });
       const now = this.dependencies.clock.now();
       this.db.prepare(
@@ -1204,6 +1751,33 @@ export class NavigatorImplementationExecutor {
       integration = this.integrationRow(input.jobId)!;
       return request;
     }).immediate();
+  }
+
+  private acceptedGitObservations(jobId: string): NavigatorGitObservation[] {
+    const rows = this.db.prepare(
+      `SELECT outcome.git_observation_json
+         FROM navigator_ticket_worker_outcomes AS outcome
+         JOIN navigator_ticket_worker_attempts AS attempt ON attempt.id = outcome.attempt_id
+        WHERE attempt.job_id = ? AND outcome.outcome = 'succeeded'
+          AND outcome.git_observation_json IS NOT NULL
+        ORDER BY outcome.recorded_at, outcome.attempt_id`,
+    ).all(jobId) as Array<{ git_observation_json: string }>;
+    return rows.map((row) => navigatorGitObservationSchema.parse(JSON.parse(row.git_observation_json)));
+  }
+
+  private integrationGitObservationMatches(input: Readonly<{
+    integration: IntegrationRow;
+    observation: NavigatorGitObservation;
+    expectedChangedPaths: readonly string[];
+  }>): boolean {
+    const { integration, observation } = input;
+    return observation.worktreeId === integration.worktree_id &&
+      observation.branch === integration.integration_branch &&
+      observation.headSha === integration.current_head_sha &&
+      observation.baseHeadSha === integration.base_head_sha && observation.baseHeadIsAncestor &&
+      observation.comparisonBaseHeadSha === integration.base_head_sha &&
+      observation.comparisonBaseHeadIsAncestor && observation.clean &&
+      JSON.stringify(observation.changedPaths) === JSON.stringify(input.expectedChangedPaths);
   }
 
   private publishedPullRequest(row: Readonly<{
@@ -1348,8 +1922,9 @@ export class NavigatorImplementationExecutor {
     now: number,
     status: "done" | "failed" | "dead",
     error: string | null,
+    nextAttemptAt = now,
   ): void {
-    this.finishEffectByKey(effect.idempotencyKey, fence, now, status, error);
+    this.finishEffectByKey(effect.idempotencyKey, fence, now, status, error, nextAttemptAt);
   }
 
   private finishEffectByKey(
@@ -1358,13 +1933,14 @@ export class NavigatorImplementationExecutor {
     now: number,
     status: "done" | "failed" | "dead",
     error: string | null,
+    nextAttemptAt = now,
   ): void {
     const changed = this.db.prepare(
       `UPDATE effects SET status = ?, lease_owner = NULL, lease_generation = NULL,
            lease_expires_at = NULL, next_attempt_at = ?, last_error = ?, updated_at = ?
         WHERE idempotency_key = ? AND status = 'leased' AND lease_owner = ?
           AND lease_generation = ? AND lease_expires_at > ?`,
-    ).run(status, now, error, now, effectKey, fence.ownerId, fence.generation, now);
+    ).run(status, nextAttemptAt, error, now, effectKey, fence.ownerId, fence.generation, now);
     if (changed.changes !== 1) throw new Error("navigator ticket effect lease changed before settlement");
   }
 }

--- a/src/navigator/implementation-executor.ts
+++ b/src/navigator/implementation-executor.ts
@@ -1,0 +1,1370 @@
+import { createHash } from "node:crypto";
+import type Database from "better-sqlite3";
+import type { ModelRoute } from "../capabilities/models";
+import type { StoredEffect } from "../domain/models";
+import type { EffectFence } from "../services/effect-runner";
+import type { TelegramAgentStore } from "../storage/store";
+import type { WorkArtifactClaim } from "../work-artifacts/models";
+import {
+  NAVIGATOR_TICKET_STEP_CONTRACTS,
+  navigatorCodeReviewResultSchema,
+  navigatorImplementationResultSchema,
+  navigatorJsonDigest,
+  navigatorPullRequestRequestSchema,
+  navigatorTicketWorkerProfile,
+  navigatorTicketWorkerProfileSchema,
+  navigatorTicketWorkerResultSchema,
+  navigatorTicketWorkOrderSchema,
+  parseNavigatorTicketModelRoute,
+  type NavigatorPullRequestRecord,
+  type NavigatorPullRequestRequest,
+  type NavigatorTicketStepContract,
+  type NavigatorTicketTaskEvidence,
+  type NavigatorTicketWorkerProfile,
+  type NavigatorTicketWorkerResult,
+  type NavigatorTicketWorkOrder,
+} from "./implementation-contracts";
+import { artifactBindingSchema, type NavigatorArtifactBinding } from "./models";
+
+const GIT_SHA = /^[0-9a-f]{40}$/u;
+const IDENTIFIER = /^[A-Za-z0-9_.:/-]{1,256}$/u;
+
+export type NavigatorTicketWorkerAttempt = Readonly<{
+  id: string;
+  jobId: string;
+  sliceId: string;
+  kind: "implementation" | "review";
+  ordinal: number;
+  effectIdempotencyKey: string;
+  workOrder: NavigatorTicketWorkOrder;
+  workOrderDigest: string;
+  stepContract: NavigatorTicketStepContract;
+  profile: NavigatorTicketWorkerProfile;
+  modelRoute: ModelRoute;
+  resource: { kind: "bb_thread"; id: string } | null;
+  createdAt: number;
+  updatedAt: number;
+}>;
+
+export type NavigatorTicketWorkerOutcome = Readonly<{
+  attemptId: string;
+  sliceId: string;
+  outcome: "succeeded" | "findings" | "worker_unavailable" | "policy_failure";
+  reasonCode: string;
+  exactHeadSha: string;
+  result: unknown;
+  resultDigest: string;
+  recordedAt: number;
+}>;
+
+export type NavigatorIntegrationSnapshot = Readonly<{
+  integration: Readonly<{
+    jobId: string;
+    specification: NavigatorArtifactBinding;
+    baseBranch: string;
+    integrationBranch: string;
+    worktreeId: string;
+    baseHeadSha: string;
+    currentHeadSha: string;
+    state: "implementing" | "invalidated" | "ready_for_pull_request" | "publishing_pull_request" | "ready_for_release";
+    activeSliceId: string | null;
+    pullRequestNumber: number | null;
+    pullRequestUrl: string | null;
+    evidenceRefs: readonly string[];
+  }>;
+  tickets: readonly Readonly<{
+    artifactId: string;
+    snapshotId: string;
+    snapshotDigest: string;
+    order: number;
+    state: "pending" | "active" | "accepted" | "resolved" | "invalidated";
+    acceptedHeadSha: string | null;
+  }>[];
+  activeSlice: Readonly<{
+    id: string;
+    ticketArtifactId: string;
+    claimId: number;
+    state: string;
+    acceptedHeadSha: string | null;
+  }> | null;
+  attempts: readonly NavigatorTicketWorkerAttempt[];
+  outcomes: readonly NavigatorTicketWorkerOutcome[];
+}>;
+
+export interface NavigatorTicketWorkerRunner {
+  run(
+    attempt: NavigatorTicketWorkerAttempt,
+    hooks: Readonly<{ bindResource(resource: { kind: "bb_thread"; id: string }): Promise<void> }>,
+    signal: AbortSignal,
+  ): Promise<Readonly<{
+    resource: { kind: "bb_thread"; id: string };
+    result: unknown;
+  }>>;
+}
+
+export class NavigatorTicketWorkerUnavailableError extends Error {
+  public readonly name = "NavigatorTicketWorkerUnavailableError";
+
+  public constructor(public readonly reason: "missing" | "stale") {
+    super(`navigator ticket worker is ${reason}`);
+  }
+}
+
+export interface NavigatorPullRequestPublisher {
+  createOrRefresh(request: NavigatorPullRequestRequest): Promise<NavigatorPullRequestRecord>;
+}
+
+type AttemptRow = Readonly<{
+  id: string;
+  job_id: string;
+  slice_id: string;
+  kind: "implementation" | "review";
+  ordinal: number;
+  effect_idempotency_key: string;
+  work_order_json: string;
+  work_order_digest: string;
+  step_contract_id: string;
+  step_contract_revision: number;
+  step_contract_digest: string;
+  profile_json: string;
+  profile_digest: string;
+  model_route_json: string;
+  resource_kind: "bb_thread" | null;
+  resource_id: string | null;
+  created_at: number;
+  updated_at: number;
+}>;
+
+type IntegrationRow = Readonly<{
+  job_id: string;
+  specification_artifact_id: string;
+  specification_snapshot_id: string;
+  specification_snapshot_digest: string;
+  base_branch: string;
+  integration_branch: string;
+  worktree_id: string;
+  project_policy_version: number;
+  project_policy_json: string;
+  project_policy_digest: string;
+  base_head_sha: string;
+  current_head_sha: string;
+  state: NavigatorIntegrationSnapshot["integration"]["state"];
+  active_slice_id: string | null;
+  pull_request_number: number | null;
+  pull_request_url: string | null;
+  evidence_refs_json: string;
+}>;
+
+type TicketRow = Readonly<{
+  job_id: string;
+  artifact_id: string;
+  snapshot_id: string;
+  snapshot_digest: string;
+  ticket_order: number;
+  state: NavigatorIntegrationSnapshot["tickets"][number]["state"];
+  accepted_head_sha: string | null;
+}>;
+
+type SliceRow = Readonly<{
+  id: string;
+  job_id: string;
+  ticket_artifact_id: string;
+  ticket_snapshot_id: string;
+  ticket_snapshot_digest: string;
+  claim_id: number;
+  integration_base_head_sha: string;
+  state: string;
+  accepted_head_sha: string | null;
+}>;
+
+type OutcomeRow = Readonly<{
+  attempt_id: string;
+  slice_id: string;
+  outcome: NavigatorTicketWorkerOutcome["outcome"];
+  reason_code: string;
+  exact_head_sha: string;
+  result_json: string;
+  result_digest: string;
+  recorded_at: number;
+}>;
+
+type NavigatorImplementationExecutorDependencies = Readonly<{
+  store: TelegramAgentStore;
+  database: Database.Database;
+  workerRunner: NavigatorTicketWorkerRunner;
+  pullRequests: NavigatorPullRequestPublisher;
+  modelRoute(kind: "implementation" | "review"): ModelRoute;
+  clock: { now(): number };
+  leaseMs?: number;
+}>;
+
+function assertIdentifier(value: string, field: string): string {
+  if (!IDENTIFIER.test(value)) throw new TypeError(`${field} is invalid`);
+  return value;
+}
+
+function assertGitSha(value: string, field: string): string {
+  if (!GIT_SHA.test(value)) throw new TypeError(`${field} must be a full Git SHA`);
+  return value;
+}
+
+function boundedRefs(values: readonly string[]): readonly string[] {
+  if (!Array.isArray(values) || values.length > 128) throw new TypeError("evidenceRefs must be bounded");
+  const refs = values.map((value) => {
+    const normalized = value.trim();
+    if (normalized.length === 0 || normalized.length > 1_024) throw new TypeError("evidence ref is invalid");
+    return normalized;
+  });
+  if (new Set(refs).size !== refs.length) throw new TypeError("evidence refs contain duplicates");
+  return refs;
+}
+
+function mergeEvidenceRefs(...groups: readonly (readonly string[])[]): readonly string[] {
+  return boundedRefs([...new Set(groups.flat())]);
+}
+
+function stableId(prefix: string, ...parts: readonly string[]): string {
+  return `${prefix}_${createHash("sha256").update(parts.join("\0"), "utf8").digest("base64url").slice(0, 24)}`;
+}
+
+function parseAttempt(row: AttemptRow): NavigatorTicketWorkerAttempt {
+  const workOrder = navigatorTicketWorkOrderSchema.parse(JSON.parse(row.work_order_json));
+  const profile = navigatorTicketWorkerProfileSchema.parse(JSON.parse(row.profile_json));
+  const stepContract = NAVIGATOR_TICKET_STEP_CONTRACTS[row.kind];
+  if (
+    navigatorJsonDigest(workOrder) !== row.work_order_digest ||
+    stepContract.id !== row.step_contract_id ||
+    stepContract.revision !== row.step_contract_revision ||
+    stepContract.digest !== row.step_contract_digest ||
+    profile.digest !== row.profile_digest
+  ) {
+    throw new Error(`navigator ticket attempt ${row.id} has invalid durable identity`);
+  }
+  return {
+    id: row.id,
+    jobId: row.job_id,
+    sliceId: row.slice_id,
+    kind: row.kind,
+    ordinal: row.ordinal,
+    effectIdempotencyKey: row.effect_idempotency_key,
+    workOrder,
+    workOrderDigest: row.work_order_digest,
+    stepContract,
+    profile,
+    modelRoute: parseNavigatorTicketModelRoute(JSON.parse(row.model_route_json), row.kind),
+    resource: row.resource_kind === null ? null : { kind: row.resource_kind, id: row.resource_id! },
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function parseOutcome(row: OutcomeRow): NavigatorTicketWorkerOutcome {
+  const result = JSON.parse(row.result_json) as unknown;
+  if (navigatorJsonDigest(result) !== row.result_digest) {
+    throw new Error(`navigator ticket outcome ${row.attempt_id} has invalid digest`);
+  }
+  return {
+    attemptId: row.attempt_id,
+    sliceId: row.slice_id,
+    outcome: row.outcome,
+    reasonCode: row.reason_code,
+    exactHeadSha: row.exact_head_sha,
+    result,
+    resultDigest: row.result_digest,
+    recordedAt: row.recorded_at,
+  };
+}
+
+function effectPayload(effect: StoredEffect, key: string): string {
+  const value = effect.payload[key];
+  if (typeof value !== "string" || !IDENTIFIER.test(value)) {
+    throw new TypeError(`navigator ticket effect ${key} is invalid`);
+  }
+  return value;
+}
+
+function resultCapabilitiesAreAccepted(
+  result: NavigatorTicketWorkerResult,
+  profile: NavigatorTicketWorkerProfile,
+): boolean {
+  const outcomes = new Map(result.capabilityOutcomes.map((outcome) => [outcome.capabilityId, outcome]));
+  return outcomes.size === result.capabilityOutcomes.length &&
+    profile.assignments.every((selected) => {
+      const outcome = outcomes.get(selected.capabilityId)?.outcome;
+      return outcome === "passed" || (result.kind === "code_review_result" && result.outcome === "findings" && outcome === "findings");
+    }) &&
+    result.capabilityOutcomes.every((outcome) =>
+      profile.assignments.some((selected) => selected.capabilityId === outcome.capabilityId));
+}
+
+export class NavigatorImplementationExecutor {
+  private readonly db: Database.Database;
+
+  public constructor(private readonly dependencies: NavigatorImplementationExecutorDependencies) {
+    this.db = dependencies.database;
+  }
+
+  public startIntegration(input: Readonly<{
+    jobId: string;
+    specificationArtifactId: string;
+    implementationTicketIds: readonly string[];
+    baseBranch: string;
+    integrationBranch: string;
+    worktreeId: string;
+    baseHeadSha: string;
+    evidenceRefs: readonly string[];
+  }>): NavigatorIntegrationSnapshot {
+    assertIdentifier(input.jobId, "jobId");
+    assertIdentifier(input.specificationArtifactId, "specificationArtifactId");
+    assertIdentifier(input.baseBranch, "baseBranch");
+    assertIdentifier(input.integrationBranch, "integrationBranch");
+    assertIdentifier(input.worktreeId, "worktreeId");
+    assertGitSha(input.baseHeadSha, "baseHeadSha");
+    const evidenceRefs = boundedRefs(input.evidenceRefs);
+    if (evidenceRefs.length === 0) throw new TypeError("navigator integration evidence is required");
+    if (input.implementationTicketIds.length === 0 || input.implementationTicketIds.length > 128 ||
+      new Set(input.implementationTicketIds).size !== input.implementationTicketIds.length) {
+      throw new TypeError("implementation ticket ids must be a bounded unique list");
+    }
+    const job = this.dependencies.store.getJob(input.jobId);
+    if (!job || job.workflowEngine !== "navigator-v1" || job.workflowMode !== "deterministic") {
+      throw new TypeError("navigator integration requires a deterministic navigator job");
+    }
+    if (job.policyVersion === null || job.policy === null) {
+      throw new TypeError("navigator integration requires an immutable project policy");
+    }
+    const projectPolicyJson = JSON.stringify(job.policy);
+    const projectPolicyDigest = navigatorJsonDigest(job.policy);
+    const specification = this.boundCurrentArtifact(job.artifactBindings, input.specificationArtifactId, "specification");
+    const tickets = input.implementationTicketIds.map((artifactId) =>
+      this.boundCurrentArtifact(job.artifactBindings, artifactId, "implementation_ticket"));
+    this.db.transaction(() => {
+      const existing = this.integrationRow(input.jobId);
+      if (existing) {
+        const storedTicketIds = this.ticketRows(input.jobId).map((ticket) => ticket.artifact_id);
+        if (
+          existing.specification_artifact_id !== specification.artifactId ||
+          existing.specification_snapshot_id !== specification.snapshotId ||
+          existing.specification_snapshot_digest !== specification.snapshotDigest ||
+          existing.project_policy_version !== job.policyVersion ||
+          existing.project_policy_digest !== projectPolicyDigest ||
+          existing.base_branch !== input.baseBranch ||
+          existing.integration_branch !== input.integrationBranch || existing.worktree_id !== input.worktreeId ||
+          existing.base_head_sha !== input.baseHeadSha ||
+          existing.evidence_refs_json !== JSON.stringify(evidenceRefs) ||
+          JSON.stringify(storedTicketIds) !== JSON.stringify(input.implementationTicketIds)
+        ) throw new TypeError("navigator integration identity changed during replay");
+        return;
+      }
+      const now = this.dependencies.clock.now();
+      this.db.prepare(
+        `INSERT INTO navigator_integrations (
+           job_id, specification_artifact_id, specification_snapshot_id,
+           specification_snapshot_digest, base_branch, integration_branch, worktree_id,
+           project_policy_version, project_policy_json, project_policy_digest,
+           base_head_sha, current_head_sha, state, active_slice_id,
+           pull_request_number, pull_request_url, evidence_refs_json, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'implementing', NULL, NULL, NULL, ?, ?, ?)`,
+      ).run(
+        input.jobId,
+        specification.artifactId,
+        specification.snapshotId,
+        specification.snapshotDigest,
+        input.baseBranch,
+        input.integrationBranch,
+        input.worktreeId,
+        job.policyVersion,
+        projectPolicyJson,
+        projectPolicyDigest,
+        input.baseHeadSha,
+        input.baseHeadSha,
+        JSON.stringify(evidenceRefs),
+        now,
+        now,
+      );
+      const insertTicket = this.db.prepare(
+        `INSERT INTO navigator_integration_tickets (
+           job_id, artifact_id, snapshot_id, snapshot_digest, ticket_order,
+           state, accepted_head_sha, resolved_at
+         ) VALUES (?, ?, ?, ?, ?, 'pending', NULL, NULL)`,
+      );
+      tickets.forEach((ticket, order) => insertTicket.run(
+        input.jobId,
+        ticket.artifactId,
+        ticket.snapshotId,
+        ticket.snapshotDigest,
+        order,
+      ));
+    }).immediate();
+    return this.snapshot(input.jobId);
+  }
+
+  public beginClaimedTicket(input: Readonly<{
+    jobId: string;
+    ticketArtifactId: string;
+    claimId: number;
+    taskEvidence: readonly string[];
+    evidenceRefs: readonly string[];
+  }>) {
+    assertIdentifier(input.jobId, "jobId");
+    assertIdentifier(input.ticketArtifactId, "ticketArtifactId");
+    if (!Number.isSafeInteger(input.claimId) || input.claimId < 1) throw new TypeError("claimId is invalid");
+    const claimEvidenceRefs = boundedRefs(input.evidenceRefs);
+    return this.db.transaction(() => {
+      const integration = this.requireWritableIntegration(input.jobId);
+      const evidenceRefs = mergeEvidenceRefs(
+        JSON.parse(integration.evidence_refs_json) as readonly string[],
+        claimEvidenceRefs,
+      );
+      const existing = this.sliceForTicket(input.jobId, input.ticketArtifactId);
+      if (existing) {
+        if (existing.claim_id !== input.claimId) throw new TypeError("ticket claim changed during replay");
+        return this.sliceValue(existing);
+      }
+      if (integration.active_slice_id !== null) throw new Error("navigator integration already has an active writer");
+      const ticket = this.ticketRows(input.jobId).find((candidate) => candidate.artifact_id === input.ticketArtifactId);
+      if (!ticket || ticket.state !== "pending" || this.nextEligibleTicket(input.jobId)?.artifact_id !== ticket.artifact_id) {
+        throw new TypeError("claimed ticket is not the next eligible implementation ticket");
+      }
+      const claim = this.dependencies.store.getWorkArtifactClaim(input.claimId);
+      this.assertClaim(claim, input.jobId, ticket);
+      const now = this.dependencies.clock.now();
+      const sliceId = stableId("navslice", input.jobId, ticket.artifact_id, ticket.snapshot_digest);
+      this.db.prepare(
+        `INSERT INTO navigator_ticket_slices (
+           id, job_id, ticket_artifact_id, ticket_snapshot_id, ticket_snapshot_digest,
+           claim_id, integration_base_head_sha, state, accepted_head_sha, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, 'implementation_pending', NULL, ?, ?)`,
+      ).run(
+        sliceId,
+        input.jobId,
+        ticket.artifact_id,
+        ticket.snapshot_id,
+        ticket.snapshot_digest,
+        input.claimId,
+        integration.current_head_sha,
+        now,
+        now,
+      );
+      this.db.prepare(
+        "UPDATE navigator_integration_tickets SET state = 'active' WHERE job_id = ? AND artifact_id = ?",
+      ).run(input.jobId, ticket.artifact_id);
+      this.db.prepare(
+        "UPDATE navigator_integrations SET active_slice_id = ?, updated_at = ? WHERE job_id = ?",
+      ).run(sliceId, now, input.jobId);
+      this.createAttempt({
+        integration,
+        sliceId,
+        ticket,
+        kind: "implementation",
+        ordinal: 1,
+        taskEvidence: input.taskEvidence,
+        evidenceRefs,
+        changedPaths: [],
+        baseHeadSha: integration.current_head_sha,
+        comparisonBaseHeadSha: integration.current_head_sha,
+        now,
+      });
+      return this.sliceValue(this.requireSlice(sliceId));
+    }).immediate();
+  }
+
+  public scheduleRepair(input: Readonly<{
+    jobId: string;
+    ticketArtifactId: string;
+    taskEvidence: readonly string[];
+    evidenceRefs: readonly string[];
+  }>): NavigatorTicketWorkerAttempt {
+    return this.db.transaction(() => {
+      const integration = this.requireWritableIntegration(input.jobId);
+      const slice = this.requireSliceForTicket(input.jobId, input.ticketArtifactId);
+      if (slice.state !== "repair_pending" || integration.active_slice_id !== slice.id) {
+        throw new TypeError("ticket is not awaiting an agent-owned repair");
+      }
+      const ticket = this.requireTicket(input.jobId, input.ticketArtifactId);
+      const ordinal = this.nextAttemptOrdinal(slice.id, "implementation");
+      const priorReview = this.latestAttempt(slice.id, "review");
+      const evidenceRefs = mergeEvidenceRefs(
+        priorReview.workOrder.evidenceRefs,
+        boundedRefs(input.evidenceRefs),
+        [`navigator-result:${priorReview.id}`],
+      );
+      const now = this.dependencies.clock.now();
+      const attempt = this.createAttempt({
+        integration,
+        sliceId: slice.id,
+        ticket,
+        kind: "implementation",
+        ordinal,
+        taskEvidence: input.taskEvidence,
+        evidenceRefs,
+        changedPaths: priorReview.workOrder.changedPaths,
+        baseHeadSha: integration.current_head_sha,
+        comparisonBaseHeadSha: slice.integration_base_head_sha,
+        now,
+      });
+      this.db.prepare(
+        "UPDATE navigator_ticket_slices SET state = 'implementation_pending', updated_at = ? WHERE id = ?",
+      ).run(now, slice.id);
+      return attempt;
+    }).immediate();
+  }
+
+  public async processOne(fence: EffectFence, signal: AbortSignal): Promise<boolean> {
+    const now = this.dependencies.clock.now();
+    const effect = this.leaseEffect(fence, now);
+    if (!effect) return false;
+    const attemptId = effectPayload(effect, "attemptId");
+    const attempt = this.getAttempt(attemptId);
+    if (!attempt || attempt.effectIdempotencyKey !== effect.idempotencyKey) {
+      this.finishEffect(effect, fence, now, "dead", "navigator ticket attempt identity is unavailable");
+      return true;
+    }
+    const leaseMs = this.dependencies.leaseMs ?? 30_000;
+    const leaseAbort = new AbortController();
+    const timeoutAbort = new AbortController();
+    const runSignal = AbortSignal.any([signal, fence.signal, leaseAbort.signal, timeoutAbort.signal]);
+    const interruption = new Promise<never>((_resolve, reject) => {
+      if (runSignal.aborted) {
+        reject(runSignal.reason ?? new Error("navigator ticket worker was aborted"));
+        return;
+      }
+      runSignal.addEventListener("abort", () => {
+        reject(runSignal.reason ?? new Error("navigator ticket worker was aborted"));
+      }, { once: true });
+    });
+    const timeout = setTimeout(() => {
+      timeoutAbort.abort(new Error("navigator ticket worker timed out"));
+    }, attempt.stepContract.timeoutMs);
+    const renewal = setInterval(() => {
+      try {
+        const renewed = this.dependencies.store.renewJobOperationFences({
+          jobId: effect.jobId,
+          effectIdempotencyKey: effect.idempotencyKey,
+          ownerId: fence.ownerId,
+          generation: fence.generation,
+          now: this.dependencies.clock.now(),
+          leaseMs,
+        });
+        if (!renewed && !leaseAbort.signal.aborted) {
+          leaseAbort.abort(new Error("navigator ticket worker lease was lost"));
+        }
+      } catch (renewalError) {
+        if (!leaseAbort.signal.aborted) leaseAbort.abort(renewalError);
+      }
+    }, Math.max(1, Math.min(10_000, Math.floor(leaseMs / 3))));
+    try {
+      const run = await Promise.race([
+        this.dependencies.workerRunner.run(attempt, {
+          bindResource: async (resource) => {
+            if (!this.bindResource(attempt.id, effect.idempotencyKey, resource, fence, this.dependencies.clock.now())) {
+              throw new Error("navigator ticket worker resource binding was lost");
+            }
+          },
+        }, runSignal),
+        interruption,
+      ]);
+      if (!this.bindResource(attempt.id, effect.idempotencyKey, run.resource, fence, this.dependencies.clock.now())) {
+        throw new Error("navigator ticket worker returned a different resource");
+      }
+      this.settleAttempt(attempt.id, effect.idempotencyKey, run.result, fence, this.dependencies.clock.now());
+    } catch (error) {
+      if (error instanceof NavigatorTicketWorkerUnavailableError) {
+        this.replaceUnavailableAttempt(
+          attempt,
+          effect.idempotencyKey,
+          error.reason,
+          fence,
+          this.dependencies.clock.now(),
+        );
+        return true;
+      }
+      const summary = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+      const failedAt = this.dependencies.clock.now();
+      if (this.effectLeaseCurrent(effect.idempotencyKey, fence, failedAt)) {
+        this.finishEffect(effect, fence, failedAt, "failed", summary.slice(0, 500));
+      }
+    } finally {
+      clearInterval(renewal);
+      clearTimeout(timeout);
+    }
+    return true;
+  }
+
+  public markTicketResolved(input: Readonly<{ jobId: string; ticketArtifactId: string }>): NavigatorIntegrationSnapshot {
+    return this.db.transaction(() => {
+      const integration = this.integrationRow(input.jobId);
+      if (!integration || integration.state !== "implementing") throw new TypeError("integration is not accepting ticket resolution");
+      const slice = this.requireSliceForTicket(input.jobId, input.ticketArtifactId);
+      if (slice.state !== "accepted") throw new TypeError("ticket has no accepted review outcome");
+      const review = this.latestAttempt(slice.id, "review");
+      const outcome = this.getOutcome(review.id);
+      const resolution = this.dependencies.store.getWorkArtifactResolution(input.ticketArtifactId);
+      if (
+        outcome?.outcome !== "succeeded" ||
+        resolution?.outcome !== "resolved" ||
+        resolution.snapshotId !== slice.ticket_snapshot_id ||
+        !resolution.evidenceRefs.includes(`navigator-result:${review.id}`)
+      ) throw new TypeError("ticket closure is not bound to its accepted review evidence");
+      const now = this.dependencies.clock.now();
+      this.db.prepare(
+        "UPDATE navigator_ticket_slices SET state = 'resolved', updated_at = ? WHERE id = ?",
+      ).run(now, slice.id);
+      this.db.prepare(
+        `UPDATE navigator_integration_tickets
+            SET state = 'resolved', resolved_at = ?
+          WHERE job_id = ? AND artifact_id = ?`,
+      ).run(now, input.jobId, input.ticketArtifactId);
+      const pending = this.db.prepare(
+        "SELECT 1 FROM navigator_integration_tickets WHERE job_id = ? AND state <> 'resolved' LIMIT 1",
+      ).get(input.jobId);
+      this.db.prepare(
+        `UPDATE navigator_integrations
+            SET active_slice_id = NULL, state = ?, updated_at = ?
+          WHERE job_id = ?`,
+      ).run(pending ? "implementing" : "ready_for_pull_request", now, input.jobId);
+      return this.snapshot(input.jobId);
+    }).immediate();
+  }
+
+  public async publishPullRequest(input: Readonly<{
+    jobId: string;
+    title: string;
+    body: string;
+  }>): Promise<NavigatorPullRequestRecord> {
+    const request = this.preparePullRequest(input);
+    const existing = this.pullRequestRow(input.jobId);
+    if (existing?.status === "published") return this.publishedPullRequest(existing);
+    const published = await this.dependencies.pullRequests.createOrRefresh(request);
+    if (
+      published.operationId !== request.operationId || published.jobId !== request.jobId ||
+      published.headSha !== request.headSha ||
+      !Number.isSafeInteger(published.number) || published.number < 1 || published.url.trim().length === 0
+    ) throw new TypeError("pull request publisher returned an invalid exact-head result");
+    return this.db.transaction(() => {
+      const current = this.pullRequestRow(input.jobId);
+      if (!current || current.request_digest !== navigatorJsonDigest(request)) {
+        throw new Error("pull request request changed before settlement");
+      }
+      if (current.status === "published") return this.publishedPullRequest(current);
+      const now = this.dependencies.clock.now();
+      this.db.prepare(
+        `UPDATE navigator_pull_requests
+            SET status = 'published', number = ?, url = ?, settled_at = ?
+          WHERE job_id = ? AND status = 'pending'`,
+      ).run(published.number, published.url, now, input.jobId);
+      this.db.prepare(
+        `UPDATE navigator_integrations
+            SET state = 'ready_for_release', pull_request_number = ?, pull_request_url = ?, updated_at = ?
+          WHERE job_id = ? AND state = 'publishing_pull_request' AND current_head_sha = ?`,
+      ).run(published.number, published.url, now, input.jobId, request.headSha);
+      return this.publishedPullRequest(this.pullRequestRow(input.jobId)!);
+    }).immediate();
+  }
+
+  public snapshot(jobId: string): NavigatorIntegrationSnapshot {
+    const integration = this.integrationRow(jobId);
+    if (!integration) throw new Error(`navigator integration ${jobId} was not found`);
+    const tickets = this.ticketRows(jobId);
+    const attempts = this.db.prepare(
+      "SELECT * FROM navigator_ticket_worker_attempts WHERE job_id = ? ORDER BY created_at, id",
+    ).all(jobId) as AttemptRow[];
+    const outcomes = this.db.prepare(
+      `SELECT outcome.* FROM navigator_ticket_worker_outcomes AS outcome
+        JOIN navigator_ticket_worker_attempts AS attempt ON attempt.id = outcome.attempt_id
+       WHERE attempt.job_id = ? ORDER BY outcome.recorded_at, outcome.attempt_id`,
+    ).all(jobId) as OutcomeRow[];
+    const activeSlice = integration.active_slice_id === null ? null : this.requireSlice(integration.active_slice_id);
+    return {
+      integration: {
+        jobId: integration.job_id,
+        specification: {
+          artifactId: integration.specification_artifact_id,
+          snapshotId: integration.specification_snapshot_id,
+          snapshotDigest: integration.specification_snapshot_digest,
+        },
+        baseBranch: integration.base_branch,
+        integrationBranch: integration.integration_branch,
+        worktreeId: integration.worktree_id,
+        baseHeadSha: integration.base_head_sha,
+        currentHeadSha: integration.current_head_sha,
+        state: integration.state,
+        activeSliceId: integration.active_slice_id,
+        pullRequestNumber: integration.pull_request_number,
+        pullRequestUrl: integration.pull_request_url,
+        evidenceRefs: JSON.parse(integration.evidence_refs_json) as readonly string[],
+      },
+      tickets: tickets.map((ticket) => ({
+        artifactId: ticket.artifact_id,
+        snapshotId: ticket.snapshot_id,
+        snapshotDigest: ticket.snapshot_digest,
+        order: ticket.ticket_order,
+        state: ticket.state,
+        acceptedHeadSha: ticket.accepted_head_sha,
+      })),
+      activeSlice: activeSlice === null ? null : this.sliceValue(activeSlice),
+      attempts: attempts.map(parseAttempt),
+      outcomes: outcomes.map(parseOutcome),
+    };
+  }
+
+  private boundCurrentArtifact(
+    bindings: readonly NavigatorArtifactBinding[],
+    artifactId: string,
+    kind: "specification" | "implementation_ticket",
+  ): NavigatorArtifactBinding {
+    const binding = bindings.find((candidate) => candidate.artifactId === artifactId);
+    const artifact = this.dependencies.store.getWorkArtifact(artifactId);
+    const snapshot = this.dependencies.store.getCurrentWorkArtifactSnapshot(artifactId);
+    if (
+      !binding || artifact?.kind !== kind || snapshot?.id !== binding.snapshotId ||
+      snapshot.snapshotDigest !== binding.snapshotDigest ||
+      !this.dependencies.store.isWorkArtifactSnapshotValid(binding.snapshotId)
+    ) throw new TypeError(`navigator integration ${kind} binding is stale or unavailable`);
+    return artifactBindingSchema.parse(binding);
+  }
+
+  private requireWritableIntegration(jobId: string): IntegrationRow {
+    const integration = this.integrationRow(jobId);
+    if (!integration || integration.state !== "implementing") {
+      throw new TypeError("navigator integration is not writable");
+    }
+    if (!this.bindingIsCurrent({
+      artifactId: integration.specification_artifact_id,
+      snapshotId: integration.specification_snapshot_id,
+      snapshotDigest: integration.specification_snapshot_digest,
+    })) {
+      this.invalidateIntegration(integration, "stale_specification", this.dependencies.clock.now());
+      throw new TypeError("navigator integration specification snapshot is stale");
+    }
+    return integration;
+  }
+
+  private ticketIsEligible(jobId: string, ticket: TicketRow): boolean {
+    const relationships = this.dependencies.store.listWorkArtifactRelationships(ticket.artifact_id);
+    const parent = this.integrationRow(jobId)?.specification_artifact_id;
+    if (!relationships.some((relationship) =>
+      relationship.kind === "parent" && relationship.targetArtifactId === parent)) return false;
+    return relationships.filter((relationship) => relationship.kind === "blocks").every((relationship) => {
+      const blocker = relationship.sourceArtifactId === null
+        ? null
+        : this.dependencies.store.getWorkArtifact(relationship.sourceArtifactId);
+      return blocker !== null && (blocker.status === "resolved" || blocker.status === "cancelled") &&
+        blocker.externalStatus !== "open";
+    });
+  }
+
+  private nextEligibleTicket(jobId: string): TicketRow | null {
+    return this.ticketRows(jobId).find((ticket) =>
+      ticket.state === "pending" && this.ticketIsEligible(jobId, ticket)) ?? null;
+  }
+
+  private assertClaim(claim: WorkArtifactClaim | null, jobId: string, ticket: TicketRow): void {
+    if (
+      !claim || claim.state !== "held" || claim.jobId !== jobId ||
+      claim.artifactId !== ticket.artifact_id || claim.snapshotId !== ticket.snapshot_id ||
+      !this.bindingIsCurrent({
+        artifactId: ticket.artifact_id,
+        snapshotId: ticket.snapshot_id,
+        snapshotDigest: ticket.snapshot_digest,
+      })
+    ) throw new TypeError("implementation ticket claim is stale or belongs to another lane");
+  }
+
+  private createAttempt(input: Readonly<{
+    integration: IntegrationRow;
+    sliceId: string;
+    ticket: TicketRow;
+    kind: "implementation" | "review";
+    ordinal: number;
+    taskEvidence: readonly string[];
+    evidenceRefs: readonly string[];
+    changedPaths: readonly string[];
+    baseHeadSha: string;
+    comparisonBaseHeadSha: string;
+    now: number;
+  }>): NavigatorTicketWorkerAttempt {
+    const workOrder = navigatorTicketWorkOrderSchema.parse({
+      kind: "navigator_ticket_work_order",
+      jobId: input.integration.job_id,
+      integrationBranch: input.integration.integration_branch,
+      baseBranch: input.integration.base_branch,
+      worktreeId: input.integration.worktree_id,
+      baseHeadSha: input.baseHeadSha,
+      comparisonBaseHeadSha: input.comparisonBaseHeadSha,
+      projectPolicyVersion: input.integration.project_policy_version,
+      projectPolicy: JSON.parse(input.integration.project_policy_json),
+      projectPolicyDigest: input.integration.project_policy_digest,
+      specification: {
+        artifactId: input.integration.specification_artifact_id,
+        snapshotId: input.integration.specification_snapshot_id,
+        snapshotDigest: input.integration.specification_snapshot_digest,
+      },
+      ticket: {
+        artifactId: input.ticket.artifact_id,
+        snapshotId: input.ticket.snapshot_id,
+        snapshotDigest: input.ticket.snapshot_digest,
+      },
+      taskEvidence: input.taskEvidence,
+      evidenceRefs: input.evidenceRefs,
+      changedPaths: input.changedPaths,
+    });
+    const profile = navigatorTicketWorkerProfile({
+      kind: input.kind,
+      taskEvidence: input.taskEvidence,
+      changedPaths: input.changedPaths,
+    });
+    const stepContract = NAVIGATOR_TICKET_STEP_CONTRACTS[input.kind];
+    const route = parseNavigatorTicketModelRoute(this.dependencies.modelRoute(input.kind), input.kind);
+    const attemptId = stableId("navworker", input.sliceId, input.kind, String(input.ordinal));
+    const effectKey = `${input.integration.job_id}:navigator-ticket:${attemptId}`;
+    this.db.prepare(
+      `INSERT INTO effects (
+         idempotency_key, job_id, kind, payload_json, status, attempts,
+         next_attempt_at, created_at, updated_at
+       ) VALUES (?, ?, 'run_navigator_ticket_worker', ?, 'pending', 0, ?, ?, ?)`,
+    ).run(
+      effectKey,
+      input.integration.job_id,
+      JSON.stringify({ attemptId, sliceId: input.sliceId }),
+      input.now,
+      input.now,
+      input.now,
+    );
+    this.db.prepare(
+      `INSERT INTO navigator_ticket_worker_attempts (
+         id, job_id, slice_id, kind, ordinal, effect_idempotency_key,
+         work_order_json, work_order_digest, step_contract_id, step_contract_revision,
+         step_contract_digest, profile_json, profile_digest, model_route_json,
+         resource_kind, resource_id, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)`,
+    ).run(
+      attemptId,
+      input.integration.job_id,
+      input.sliceId,
+      input.kind,
+      input.ordinal,
+      effectKey,
+      JSON.stringify(workOrder),
+      navigatorJsonDigest(workOrder),
+      stepContract.id,
+      stepContract.revision,
+      stepContract.digest,
+      JSON.stringify(profile),
+      profile.digest,
+      JSON.stringify(route),
+      input.now,
+      input.now,
+    );
+    return this.getAttempt(attemptId)!;
+  }
+
+  private leaseEffect(fence: EffectFence, now: number): StoredEffect | null {
+    const leaseMs = this.dependencies.leaseMs ?? 30_000;
+    return this.db.transaction(() => {
+      if (!this.dependencies.store.isExecutorLeaseCurrent(fence.ownerId, fence.generation, now)) return null;
+      const row = this.db.prepare(
+        `SELECT effect.* FROM effects AS effect
+          JOIN navigator_ticket_worker_attempts AS attempt
+            ON attempt.effect_idempotency_key = effect.idempotency_key
+          JOIN navigator_integrations AS integration ON integration.job_id = attempt.job_id
+         WHERE effect.kind = 'run_navigator_ticket_worker'
+           AND integration.state = 'implementing'
+           AND NOT EXISTS (
+             SELECT 1 FROM navigator_ticket_worker_outcomes AS outcome WHERE outcome.attempt_id = attempt.id
+           )
+           AND ((effect.status IN ('pending', 'failed') AND effect.next_attempt_at <= ?)
+             OR (effect.status = 'leased' AND effect.lease_expires_at <= ?))
+         ORDER BY effect.created_at, effect.idempotency_key LIMIT 1`,
+      ).get(now, now) as Parameters<typeof this.parseEffect>[0] | undefined;
+      if (!row) return null;
+      const changed = this.db.prepare(
+        `UPDATE effects SET status = 'leased', lease_owner = ?, lease_generation = ?,
+             lease_expires_at = ?, attempts = attempts + 1, updated_at = ?
+          WHERE idempotency_key = ? AND (
+            (status IN ('pending', 'failed') AND next_attempt_at <= ?)
+            OR (status = 'leased' AND lease_expires_at <= ?)
+          )`,
+      ).run(fence.ownerId, fence.generation, now + leaseMs, now, row.idempotency_key, now, now);
+      return changed.changes === 1
+        ? this.parseEffect(this.db.prepare("SELECT * FROM effects WHERE idempotency_key = ?").get(row.idempotency_key) as Parameters<typeof this.parseEffect>[0])
+        : null;
+    }).immediate();
+  }
+
+  private parseEffect(row: Readonly<{
+    idempotency_key: string;
+    job_id: string;
+    kind: StoredEffect["kind"];
+    payload_json: string;
+    status: StoredEffect["status"];
+    attempts: number;
+    lease_owner: string | null;
+    lease_generation: number | null;
+    lease_expires_at: number | null;
+    next_attempt_at: number;
+    last_error: string | null;
+    created_at: number;
+    updated_at: number;
+  }>): StoredEffect {
+    return {
+      idempotencyKey: row.idempotency_key,
+      jobId: row.job_id,
+      kind: row.kind,
+      payload: JSON.parse(row.payload_json) as Record<string, unknown>,
+      status: row.status,
+      attempts: row.attempts,
+      leaseOwner: row.lease_owner,
+      leaseGeneration: row.lease_generation,
+      leaseExpiresAt: row.lease_expires_at,
+      nextAttemptAt: row.next_attempt_at,
+      lastError: row.last_error,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private bindResource(
+    attemptId: string,
+    effectKey: string,
+    resource: { kind: "bb_thread"; id: string },
+    fence: EffectFence,
+    now: number,
+  ): boolean {
+    assertIdentifier(resource.id, "worker resource id");
+    return this.db.transaction(() => {
+      if (!this.effectLeaseCurrent(effectKey, fence, now)) return false;
+      const attempt = this.getAttempt(attemptId);
+      if (!attempt || attempt.effectIdempotencyKey !== effectKey) return false;
+      if (attempt.resource !== null) return attempt.resource.id === resource.id;
+      const bound = this.db.prepare(
+        `UPDATE navigator_ticket_worker_attempts
+            SET resource_kind = 'bb_thread', resource_id = ?, updated_at = ?
+          WHERE id = ? AND resource_id IS NULL`,
+      ).run(resource.id, now, attemptId).changes === 1;
+      if (!bound) return false;
+      this.db.prepare(
+        "UPDATE navigator_ticket_slices SET state = ?, updated_at = ? WHERE id = ?",
+      ).run(attempt.kind === "implementation" ? "implementation_running" : "review_running", now, attempt.sliceId);
+      return true;
+    }).immediate();
+  }
+
+  private settleAttempt(
+    attemptId: string,
+    effectKey: string,
+    rawResult: unknown,
+    fence: EffectFence,
+    now: number,
+  ): NavigatorTicketWorkerOutcome | null {
+    return this.db.transaction(() => {
+      if (!this.effectLeaseCurrent(effectKey, fence, now)) return null;
+      const attempt = this.getAttempt(attemptId);
+      if (!attempt || attempt.effectIdempotencyKey !== effectKey || attempt.resource === null) return null;
+      const existing = this.getOutcome(attemptId);
+      if (existing) return existing;
+      const rawResultJson = JSON.stringify(rawResult);
+      const resultTooLarge = rawResultJson !== undefined &&
+        Buffer.byteLength(rawResultJson, "utf8") > attempt.stepContract.maximumResultBytes;
+      const parsed = navigatorTicketWorkerResultSchema.safeParse(resultTooLarge ? undefined : rawResult);
+      const integration = this.integrationRow(attempt.jobId)!;
+      let outcome: NavigatorTicketWorkerOutcome["outcome"] = "succeeded";
+      let reasonCode = "accepted";
+      let result: unknown = parsed.success ? parsed.data : { kind: "policy_failure", reasonCode: "malformed_result" };
+      if (resultTooLarge) {
+        outcome = "policy_failure";
+        reasonCode = "result_too_large";
+        result = { kind: "policy_failure", reasonCode };
+      } else if (!parsed.success || parsed.data.kind !== (attempt.kind === "implementation" ? "implementation_result" : "code_review_result")) {
+        outcome = "policy_failure";
+        reasonCode = "malformed_result";
+      } else if (!this.bindingIsCurrent(attempt.workOrder.specification)) {
+        outcome = "policy_failure";
+        reasonCode = "stale_specification";
+      } else if (!this.bindingIsCurrent(attempt.workOrder.ticket)) {
+        outcome = "policy_failure";
+        reasonCode = "stale_ticket";
+      } else if (!resultCapabilitiesAreAccepted(parsed.data, attempt.profile)) {
+        outcome = "policy_failure";
+        reasonCode = "capability_outcome_missing";
+      } else if (parsed.data.kind === "implementation_result") {
+        if (
+          parsed.data.baseHeadSha !== attempt.workOrder.baseHeadSha ||
+          integration.current_head_sha !== attempt.workOrder.baseHeadSha ||
+          parsed.data.focusedVerification.some((receipt) => receipt.outcome !== "passed") ||
+          parsed.data.fullVerification.some((receipt) => receipt.outcome !== "passed")
+        ) {
+          outcome = "policy_failure";
+          reasonCode = integration.current_head_sha !== attempt.workOrder.baseHeadSha
+            ? "integration_head_drift"
+            : "implementation_evidence_rejected";
+        }
+      } else if (parsed.data.reviewedHeadSha !== attempt.workOrder.baseHeadSha) {
+        outcome = "policy_failure";
+        reasonCode = "review_head_mismatch";
+      } else if (parsed.data.outcome === "findings") {
+        outcome = "findings";
+        reasonCode = "review_findings";
+      }
+      const exactHeadSha = parsed.success && parsed.data.kind === "implementation_result"
+        ? parsed.data.headSha
+        : attempt.workOrder.baseHeadSha;
+      const resultDigest = navigatorJsonDigest(result);
+      this.db.prepare(
+        `INSERT INTO navigator_ticket_worker_outcomes (
+           attempt_id, slice_id, outcome, reason_code, exact_head_sha,
+           result_json, result_digest, recorded_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        attempt.id,
+        attempt.sliceId,
+        outcome,
+        reasonCode,
+        exactHeadSha,
+        JSON.stringify(result),
+        resultDigest,
+        now,
+      );
+      if (outcome === "policy_failure") {
+        this.invalidateIntegration(integration, reasonCode, now);
+      } else if (attempt.kind === "implementation") {
+        const implementationResult = navigatorImplementationResultSchema.parse(result);
+        this.acceptImplementation(attempt, implementationResult.headSha, implementationResult.changedPaths, now);
+      } else if (outcome === "findings") {
+        this.db.prepare(
+          "UPDATE navigator_ticket_slices SET state = 'repair_pending', updated_at = ? WHERE id = ?",
+        ).run(now, attempt.sliceId);
+      } else {
+        navigatorCodeReviewResultSchema.parse(result);
+        this.db.prepare(
+          "UPDATE navigator_ticket_slices SET state = 'accepted', accepted_head_sha = ?, updated_at = ? WHERE id = ?",
+        ).run(exactHeadSha, now, attempt.sliceId);
+        this.db.prepare(
+          `UPDATE navigator_integration_tickets
+              SET state = 'accepted', accepted_head_sha = ?
+            WHERE job_id = ? AND artifact_id = ?`,
+        ).run(exactHeadSha, attempt.jobId, attempt.workOrder.ticket.artifactId);
+      }
+      this.finishEffectByKey(effectKey, fence, now, "done", null);
+      return this.getOutcome(attempt.id);
+    }).immediate();
+  }
+
+  private acceptImplementation(
+    attempt: NavigatorTicketWorkerAttempt,
+    headSha: string,
+    changedPaths: readonly string[],
+    now: number,
+  ): void {
+    const integration = this.integrationRow(attempt.jobId)!;
+    this.db.prepare(
+      "UPDATE navigator_integrations SET current_head_sha = ?, updated_at = ? WHERE job_id = ?",
+    ).run(headSha, now, attempt.jobId);
+    this.db.prepare(
+      "UPDATE navigator_ticket_slices SET state = 'review_pending', updated_at = ? WHERE id = ?",
+    ).run(now, attempt.sliceId);
+    const ticket = this.requireTicket(attempt.jobId, attempt.workOrder.ticket.artifactId);
+    const nextIntegration = this.integrationRow(attempt.jobId)!;
+    this.createAttempt({
+      integration: nextIntegration,
+      sliceId: attempt.sliceId,
+      ticket,
+      kind: "review",
+      ordinal: this.nextAttemptOrdinal(attempt.sliceId, "review"),
+      taskEvidence: attempt.workOrder.taskEvidence,
+      evidenceRefs: mergeEvidenceRefs(attempt.workOrder.evidenceRefs, [`navigator-result:${attempt.id}`]),
+      changedPaths,
+      baseHeadSha: headSha,
+      comparisonBaseHeadSha: this.requireSlice(attempt.sliceId).integration_base_head_sha,
+      now,
+    });
+  }
+
+  private replaceUnavailableAttempt(
+    attempt: NavigatorTicketWorkerAttempt,
+    effectKey: string,
+    reason: "missing" | "stale",
+    fence: EffectFence,
+    now: number,
+  ): void {
+    this.db.transaction(() => {
+      if (!this.effectLeaseCurrent(effectKey, fence, now) || this.getOutcome(attempt.id) !== null) return;
+      const integration = this.integrationRow(attempt.jobId);
+      if (!integration || integration.state !== "implementing") return;
+      const staleReason = !this.bindingIsCurrent(attempt.workOrder.specification)
+        ? "stale_specification"
+        : !this.bindingIsCurrent(attempt.workOrder.ticket)
+          ? "stale_ticket"
+          : null;
+      if (staleReason !== null) {
+        const staleResult = { kind: "policy_failure", reasonCode: staleReason } as const;
+        this.db.prepare(
+          `INSERT INTO navigator_ticket_worker_outcomes (
+             attempt_id, slice_id, outcome, reason_code, exact_head_sha,
+             result_json, result_digest, recorded_at
+           ) VALUES (?, ?, 'policy_failure', ?, ?, ?, ?, ?)`,
+        ).run(
+          attempt.id,
+          attempt.sliceId,
+          staleReason,
+          attempt.workOrder.baseHeadSha,
+          JSON.stringify(staleResult),
+          navigatorJsonDigest(staleResult),
+          now,
+        );
+        this.invalidateIntegration(integration, staleReason, now);
+        this.finishEffectByKey(effectKey, fence, now, "done", null);
+        return;
+      }
+      const result = { kind: "worker_unavailable", reason } as const;
+      this.db.prepare(
+        `INSERT INTO navigator_ticket_worker_outcomes (
+           attempt_id, slice_id, outcome, reason_code, exact_head_sha,
+           result_json, result_digest, recorded_at
+         ) VALUES (?, ?, 'worker_unavailable', ?, ?, ?, ?, ?)`,
+      ).run(
+        attempt.id,
+        attempt.sliceId,
+        `worker_${reason}`,
+        attempt.workOrder.baseHeadSha,
+        JSON.stringify(result),
+        navigatorJsonDigest(result),
+        now,
+      );
+      this.finishEffectByKey(effectKey, fence, now, "done", null);
+      this.createAttempt({
+        integration,
+        sliceId: attempt.sliceId,
+        ticket: this.requireTicket(attempt.jobId, attempt.workOrder.ticket.artifactId),
+        kind: attempt.kind,
+        ordinal: this.nextAttemptOrdinal(attempt.sliceId, attempt.kind),
+        taskEvidence: attempt.workOrder.taskEvidence,
+        evidenceRefs: mergeEvidenceRefs(attempt.workOrder.evidenceRefs, [`navigator-result:${attempt.id}`]),
+        changedPaths: attempt.workOrder.changedPaths,
+        baseHeadSha: attempt.workOrder.baseHeadSha,
+        comparisonBaseHeadSha: attempt.workOrder.comparisonBaseHeadSha,
+        now,
+      });
+      this.db.prepare(
+        "UPDATE navigator_ticket_slices SET state = ?, updated_at = ? WHERE id = ?",
+      ).run(attempt.kind === "implementation" ? "implementation_pending" : "review_pending", now, attempt.sliceId);
+    }).immediate();
+  }
+
+  private preparePullRequest(input: Readonly<{ jobId: string; title: string; body: string }>): NavigatorPullRequestRequest {
+    return this.db.transaction(() => {
+      let integration = this.integrationRow(input.jobId);
+      if (!integration || !["ready_for_pull_request", "publishing_pull_request", "ready_for_release"].includes(integration.state)) {
+        throw new TypeError("navigator integration is not ready for one final pull request");
+      }
+      if (!this.bindingIsCurrent({
+        artifactId: integration.specification_artifact_id,
+        snapshotId: integration.specification_snapshot_id,
+        snapshotDigest: integration.specification_snapshot_digest,
+      })) {
+        this.invalidateIntegration(integration, "stale_specification", this.dependencies.clock.now());
+        throw new TypeError("navigator integration specification changed before pull request publication");
+      }
+      const existing = this.pullRequestRow(input.jobId);
+      if (existing) return navigatorPullRequestRequestSchema.parse(JSON.parse(existing.request_json));
+      const outcomeRefs = this.db.prepare(
+        `SELECT 'navigator-result:' || outcome.attempt_id AS evidence_ref
+           FROM navigator_ticket_worker_outcomes AS outcome
+           JOIN navigator_ticket_worker_attempts AS attempt ON attempt.id = outcome.attempt_id
+          WHERE attempt.job_id = ? AND outcome.outcome = 'succeeded'
+          ORDER BY outcome.recorded_at, outcome.attempt_id`,
+      ).all(input.jobId) as Array<{ evidence_ref: string }>;
+      const request = navigatorPullRequestRequestSchema.parse({
+        operationId: stableId("navigator-pr", input.jobId, integration.current_head_sha),
+        jobId: input.jobId,
+        baseBranch: integration.base_branch,
+        integrationBranch: integration.integration_branch,
+        headSha: integration.current_head_sha,
+        title: input.title,
+        body: input.body,
+        evidenceRefs: outcomeRefs.map((row) => row.evidence_ref),
+      });
+      const now = this.dependencies.clock.now();
+      this.db.prepare(
+        `INSERT INTO navigator_pull_requests (
+           job_id, operation_id, request_json, request_digest, status,
+           number, url, head_sha, created_at, settled_at
+         ) VALUES (?, ?, ?, ?, 'pending', NULL, NULL, ?, ?, NULL)`,
+      ).run(
+        input.jobId,
+        request.operationId,
+        JSON.stringify(request),
+        navigatorJsonDigest(request),
+        request.headSha,
+        now,
+      );
+      this.db.prepare(
+        "UPDATE navigator_integrations SET state = 'publishing_pull_request', updated_at = ? WHERE job_id = ?",
+      ).run(now, input.jobId);
+      integration = this.integrationRow(input.jobId)!;
+      return request;
+    }).immediate();
+  }
+
+  private publishedPullRequest(row: Readonly<{
+    operation_id: string;
+    job_id: string;
+    number: number | null;
+    url: string | null;
+    head_sha: string;
+  }>): NavigatorPullRequestRecord {
+    if (row.number === null || row.url === null) throw new Error("published pull request is incomplete");
+    return {
+      operationId: row.operation_id,
+      jobId: row.job_id,
+      number: row.number,
+      url: row.url,
+      headSha: row.head_sha,
+    };
+  }
+
+  private pullRequestRow(jobId: string) {
+    return this.db.prepare("SELECT * FROM navigator_pull_requests WHERE job_id = ?").get(jobId) as Readonly<{
+      job_id: string;
+      operation_id: string;
+      request_json: string;
+      request_digest: string;
+      status: "pending" | "published";
+      number: number | null;
+      url: string | null;
+      head_sha: string;
+    }> | undefined;
+  }
+
+  private invalidateIntegration(integration: IntegrationRow, reasonCode: string, now: number): void {
+    this.db.prepare(
+      `UPDATE navigator_integrations SET state = 'invalidated', updated_at = ? WHERE job_id = ?`,
+    ).run(now, integration.job_id);
+    if (integration.active_slice_id !== null) {
+      this.db.prepare(
+        "UPDATE navigator_ticket_slices SET state = 'invalidated', updated_at = ? WHERE id = ?",
+      ).run(now, integration.active_slice_id);
+      this.db.prepare(
+        `UPDATE navigator_integration_tickets SET state = 'invalidated'
+          WHERE job_id = ? AND artifact_id = (
+            SELECT ticket_artifact_id FROM navigator_ticket_slices WHERE id = ?
+          )`,
+      ).run(integration.job_id, integration.active_slice_id);
+    }
+    this.db.prepare(
+      `UPDATE jobs SET last_error = ?, updated_at = ? WHERE id = ?`,
+    ).run(`Navigator implementation invalidated: ${reasonCode}`, now, integration.job_id);
+  }
+
+  private bindingIsCurrent(binding: NavigatorArtifactBinding): boolean {
+    const snapshot = this.dependencies.store.getCurrentWorkArtifactSnapshot(binding.artifactId);
+    return snapshot?.id === binding.snapshotId && snapshot.snapshotDigest === binding.snapshotDigest &&
+      this.dependencies.store.isWorkArtifactSnapshotValid(binding.snapshotId);
+  }
+
+  private integrationRow(jobId: string): IntegrationRow | null {
+    return this.db.prepare("SELECT * FROM navigator_integrations WHERE job_id = ?").get(jobId) as IntegrationRow | undefined ?? null;
+  }
+
+  private ticketRows(jobId: string): TicketRow[] {
+    return this.db.prepare(
+      "SELECT * FROM navigator_integration_tickets WHERE job_id = ? ORDER BY ticket_order",
+    ).all(jobId) as TicketRow[];
+  }
+
+  private requireTicket(jobId: string, artifactId: string): TicketRow {
+    const ticket = this.ticketRows(jobId).find((candidate) => candidate.artifact_id === artifactId);
+    if (!ticket) throw new Error(`navigator integration ticket ${artifactId} was not found`);
+    return ticket;
+  }
+
+  private sliceForTicket(jobId: string, ticketArtifactId: string): SliceRow | null {
+    return this.db.prepare(
+      "SELECT * FROM navigator_ticket_slices WHERE job_id = ? AND ticket_artifact_id = ?",
+    ).get(jobId, ticketArtifactId) as SliceRow | undefined ?? null;
+  }
+
+  private requireSliceForTicket(jobId: string, ticketArtifactId: string): SliceRow {
+    const slice = this.sliceForTicket(jobId, ticketArtifactId);
+    if (!slice) throw new Error(`navigator ticket slice ${ticketArtifactId} was not found`);
+    return slice;
+  }
+
+  private requireSlice(sliceId: string): SliceRow {
+    const slice = this.db.prepare("SELECT * FROM navigator_ticket_slices WHERE id = ?").get(sliceId) as SliceRow | undefined;
+    if (!slice) throw new Error(`navigator ticket slice ${sliceId} was not found`);
+    return slice;
+  }
+
+  private sliceValue(slice: SliceRow) {
+    return {
+      id: slice.id,
+      ticketArtifactId: slice.ticket_artifact_id,
+      claimId: slice.claim_id,
+      state: slice.state,
+      acceptedHeadSha: slice.accepted_head_sha,
+    } as const;
+  }
+
+  private getAttempt(attemptId: string): NavigatorTicketWorkerAttempt | null {
+    const row = this.db.prepare("SELECT * FROM navigator_ticket_worker_attempts WHERE id = ?").get(attemptId) as AttemptRow | undefined;
+    return row ? parseAttempt(row) : null;
+  }
+
+  private latestAttempt(sliceId: string, kind: "implementation" | "review"): NavigatorTicketWorkerAttempt {
+    const row = this.db.prepare(
+      `SELECT * FROM navigator_ticket_worker_attempts
+        WHERE slice_id = ? AND kind = ? ORDER BY ordinal DESC LIMIT 1`,
+    ).get(sliceId, kind) as AttemptRow | undefined;
+    if (!row) throw new Error(`navigator ${kind} attempt was not found`);
+    return parseAttempt(row);
+  }
+
+  private nextAttemptOrdinal(sliceId: string, kind: "implementation" | "review"): number {
+    const row = this.db.prepare(
+      "SELECT COALESCE(MAX(ordinal), 0) AS ordinal FROM navigator_ticket_worker_attempts WHERE slice_id = ? AND kind = ?",
+    ).get(sliceId, kind) as { ordinal: number };
+    return row.ordinal + 1;
+  }
+
+  private getOutcome(attemptId: string): NavigatorTicketWorkerOutcome | null {
+    const row = this.db.prepare(
+      "SELECT * FROM navigator_ticket_worker_outcomes WHERE attempt_id = ?",
+    ).get(attemptId) as OutcomeRow | undefined;
+    return row ? parseOutcome(row) : null;
+  }
+
+  private effectLeaseCurrent(effectKey: string, fence: EffectFence, now: number): boolean {
+    return this.dependencies.store.isExecutorLeaseCurrent(fence.ownerId, fence.generation, now) &&
+      this.db.prepare(
+        `SELECT 1 FROM effects WHERE idempotency_key = ? AND status = 'leased'
+          AND lease_owner = ? AND lease_generation = ? AND lease_expires_at > ?`,
+      ).get(effectKey, fence.ownerId, fence.generation, now) !== undefined;
+  }
+
+  private finishEffect(
+    effect: StoredEffect,
+    fence: EffectFence,
+    now: number,
+    status: "done" | "failed" | "dead",
+    error: string | null,
+  ): void {
+    this.finishEffectByKey(effect.idempotencyKey, fence, now, status, error);
+  }
+
+  private finishEffectByKey(
+    effectKey: string,
+    fence: EffectFence,
+    now: number,
+    status: "done" | "failed" | "dead",
+    error: string | null,
+  ): void {
+    const changed = this.db.prepare(
+      `UPDATE effects SET status = ?, lease_owner = NULL, lease_generation = NULL,
+           lease_expires_at = NULL, next_attempt_at = ?, last_error = ?, updated_at = ?
+        WHERE idempotency_key = ? AND status = 'leased' AND lease_owner = ?
+          AND lease_generation = ? AND lease_expires_at > ?`,
+    ).run(status, now, error, now, effectKey, fence.ownerId, fence.generation, now);
+    if (changed.changes !== 1) throw new Error("navigator ticket effect lease changed before settlement");
+  }
+}

--- a/src/services/effect-runner.ts
+++ b/src/services/effect-runner.ts
@@ -224,6 +224,7 @@ function expectedStates(kind: JobEffect["kind"]): readonly string[] {
     case "stop_thread": return [];
     case "steer_implementation": return ["implementing", "remediating"];
     case "run_navigator_skill": return [];
+    case "run_navigator_ticket_worker": return [];
     case "reconcile_job": return [];
     default: {
       const unreachable: never = kind;
@@ -255,6 +256,7 @@ const KNOWN_EFFECT_KINDS = new Set<string>([
   "stop_thread",
   "steer_implementation",
   "run_navigator_skill",
+  "run_navigator_ticket_worker",
   "reconcile_job",
 ]);
 
@@ -2485,6 +2487,8 @@ export class EffectRunner {
       }
       case "run_navigator_skill":
         throw new PermanentEffectError("navigator skill effects require the navigator executor");
+      case "run_navigator_ticket_worker":
+        throw new PermanentEffectError("navigator ticket effects require the navigator implementation executor");
       case "reconcile_job":
         await this.reconcile(effect, job);
         return;

--- a/src/services/job-executor-service.ts
+++ b/src/services/job-executor-service.ts
@@ -70,6 +70,10 @@ export type JobExecutorDependencies = {
   navigator?: {
     processOne(fence: EffectFence, signal: AbortSignal): Promise<boolean>;
   };
+  /** Deterministic navigator-v1 ticket integration work. */
+  navigatorImplementation?: {
+    processOne(fence: EffectFence, signal: AbortSignal): Promise<boolean>;
+  };
   monitors?: {
     processDue(): Promise<boolean>;
     processDueDelegations(): Promise<boolean>;
@@ -930,6 +934,9 @@ export async function runJobExecutorService(deps: JobExecutorDependencies, signa
         }
         if (deps.navigator) {
           didWork = await deps.navigator.processOne(effectFence, workAbort.signal) || didWork;
+        }
+        if (deps.navigatorImplementation) {
+          didWork = await deps.navigatorImplementation.processOne(effectFence, workAbort.signal) || didWork;
         }
         if (deps.monitors) {
           didWork = await deps.monitors.processDue() || didWork;

--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -3108,7 +3108,6 @@ CREATE TABLE navigator_ticket_worker_attempts (
   step_contract_id TEXT NOT NULL,
   step_contract_revision INTEGER NOT NULL CHECK (step_contract_revision >= 1),
   step_contract_digest TEXT NOT NULL,
-  step_contract_json TEXT NOT NULL,
   profile_json TEXT NOT NULL,
   profile_digest TEXT NOT NULL,
   model_route_json TEXT NOT NULL,
@@ -3133,7 +3132,6 @@ WHEN NEW.id <> OLD.id
   OR NEW.step_contract_id <> OLD.step_contract_id
   OR NEW.step_contract_revision <> OLD.step_contract_revision
   OR NEW.step_contract_digest <> OLD.step_contract_digest
-  OR NEW.step_contract_json <> OLD.step_contract_json
   OR NEW.profile_json <> OLD.profile_json
   OR NEW.profile_digest <> OLD.profile_digest
   OR NEW.model_route_json <> OLD.model_route_json
@@ -3150,6 +3148,97 @@ BEGIN SELECT RAISE(ABORT, 'navigator ticket worker attempts cannot be deleted');
 CREATE TABLE navigator_ticket_worker_outcomes (
   attempt_id TEXT PRIMARY KEY REFERENCES navigator_ticket_worker_attempts(id),
   slice_id TEXT NOT NULL REFERENCES navigator_ticket_slices(id),
+  outcome TEXT NOT NULL CHECK (outcome IN ('succeeded', 'findings', 'worker_unavailable', 'policy_failure')),
+  reason_code TEXT NOT NULL,
+  exact_head_sha TEXT NOT NULL,
+  result_json TEXT NOT NULL,
+  result_digest TEXT NOT NULL,
+  recorded_at INTEGER NOT NULL
+);
+
+CREATE TRIGGER navigator_ticket_worker_outcomes_append_only_update
+BEFORE UPDATE ON navigator_ticket_worker_outcomes
+BEGIN SELECT RAISE(ABORT, 'navigator ticket worker outcomes are append-only'); END;
+CREATE TRIGGER navigator_ticket_worker_outcomes_append_only_delete
+BEFORE DELETE ON navigator_ticket_worker_outcomes
+BEGIN SELECT RAISE(ABORT, 'navigator ticket worker outcomes are append-only'); END;
+
+CREATE TABLE navigator_pull_requests (
+  job_id TEXT PRIMARY KEY REFERENCES navigator_integrations(job_id),
+  operation_id TEXT NOT NULL UNIQUE,
+  request_json TEXT NOT NULL,
+  request_digest TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'published')),
+  number INTEGER,
+  url TEXT,
+  head_sha TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  settled_at INTEGER,
+  CHECK ((status = 'published') = (number IS NOT NULL AND url IS NOT NULL AND settled_at IS NOT NULL))
+);
+
+CREATE TRIGGER navigator_pull_requests_immutable_request
+BEFORE UPDATE ON navigator_pull_requests
+WHEN NEW.job_id <> OLD.job_id
+  OR NEW.operation_id <> OLD.operation_id
+  OR NEW.request_json <> OLD.request_json
+  OR NEW.request_digest <> OLD.request_digest
+  OR NEW.head_sha <> OLD.head_sha
+  OR NEW.created_at <> OLD.created_at
+  OR OLD.status = 'published'
+BEGIN SELECT RAISE(ABORT, 'navigator pull request identity is immutable'); END;
+CREATE TRIGGER navigator_pull_requests_no_delete
+BEFORE DELETE ON navigator_pull_requests
+BEGIN SELECT RAISE(ABORT, 'navigator pull requests cannot be deleted'); END;
+`] as const;
+
+export const NAVIGATOR_IMPLEMENTATION_UPGRADE_MIGRATIONS = [String.raw`
+ALTER TABLE navigator_ticket_worker_attempts
+  ADD COLUMN step_contract_json TEXT NOT NULL DEFAULT '';
+
+UPDATE navigator_ticket_worker_attempts
+   SET step_contract_json = CASE
+     WHEN step_contract_id = 'navigator-ticket-implementation' AND step_contract_revision = 1 THEN
+       '{"id":"navigator-ticket-implementation","revision":1,"skillId":"implement","freshContext":true,"codeWriting":true,"resourceClass":"managed_integration_worktree","resultSchema":"navigator-implementation-result-v1","mandatoryEvidence":["ticket_snapshot","specification_snapshot","focused_verification","full_verification"],"modelPools":["standard","strong"],"timeoutMs":14400000,"maximumResultBytes":256000,"digest":"c3d183d0b7c961ad1cbc223aa38a025f6ec8b52496e40137ce5e7bd6ae77f851"}'
+     WHEN step_contract_id = 'navigator-ticket-code-review' AND step_contract_revision = 1 THEN
+       '{"id":"navigator-ticket-code-review","revision":1,"skillId":"code-review","freshContext":true,"codeWriting":false,"resourceClass":"managed_integration_worktree","resultSchema":"navigator-code-review-result-v1","mandatoryEvidence":["ticket_snapshot","specification_snapshot","exact_head_review"],"modelPools":["strong"],"timeoutMs":3600000,"maximumResultBytes":256000,"digest":"cd460fc7ac1f32321ff9a9072332fbadec39b235e02f5a4e0894367b74199329"}'
+     WHEN step_contract_id = 'navigator-ticket-implementation' AND step_contract_revision = 2 THEN
+       '{"id":"navigator-ticket-implementation","revision":2,"skillId":"implement","freshContext":true,"codeWriting":true,"resourceClass":"managed_integration_worktree","resultSchema":"navigator-implementation-result-v1","mandatoryEvidence":["ticket_snapshot","specification_snapshot","focused_verification","full_verification"],"modelPools":["standard","strong"],"timeoutMs":14400000,"maximumResultBytes":256000,"retryClass":"bounded_exponential","maximumAttempts":5,"backoffBaseMs":500,"backoffMaximumMs":30000,"digest":"265975681ea5dbd57a9bf428532400ea72fd9f5a96110cf47fcb4da2de19987b"}'
+     WHEN step_contract_id = 'navigator-ticket-code-review' AND step_contract_revision = 2 THEN
+       '{"id":"navigator-ticket-code-review","revision":2,"skillId":"code-review","freshContext":true,"codeWriting":false,"resourceClass":"managed_integration_worktree","resultSchema":"navigator-code-review-result-v1","mandatoryEvidence":["ticket_snapshot","specification_snapshot","exact_head_review"],"modelPools":["strong"],"timeoutMs":3600000,"maximumResultBytes":256000,"retryClass":"bounded_exponential","maximumAttempts":5,"backoffBaseMs":500,"backoffMaximumMs":30000,"digest":"b32624e6c687619ad840747a023b9f918108b8a409308f935723eb99de5f2f3c"}'
+     ELSE NULL
+   END;
+
+DROP TRIGGER navigator_ticket_worker_attempts_immutable_identity;
+CREATE TRIGGER navigator_ticket_worker_attempts_immutable_identity
+BEFORE UPDATE ON navigator_ticket_worker_attempts
+WHEN NEW.id <> OLD.id
+  OR NEW.job_id <> OLD.job_id
+  OR NEW.slice_id <> OLD.slice_id
+  OR NEW.kind <> OLD.kind
+  OR NEW.ordinal <> OLD.ordinal
+  OR NEW.effect_idempotency_key <> OLD.effect_idempotency_key
+  OR NEW.work_order_json <> OLD.work_order_json
+  OR NEW.work_order_digest <> OLD.work_order_digest
+  OR NEW.step_contract_id <> OLD.step_contract_id
+  OR NEW.step_contract_revision <> OLD.step_contract_revision
+  OR NEW.step_contract_digest <> OLD.step_contract_digest
+  OR NEW.step_contract_json <> OLD.step_contract_json
+  OR NEW.profile_json <> OLD.profile_json
+  OR NEW.profile_digest <> OLD.profile_digest
+  OR NEW.model_route_json <> OLD.model_route_json
+  OR NEW.created_at <> OLD.created_at
+  OR (OLD.resource_kind IS NOT NULL AND (
+    NEW.resource_kind IS NOT OLD.resource_kind OR NEW.resource_id IS NOT OLD.resource_id
+  ))
+BEGIN SELECT RAISE(ABORT, 'navigator ticket worker attempt identity is immutable'); END;
+
+DROP TRIGGER navigator_ticket_worker_outcomes_append_only_update;
+DROP TRIGGER navigator_ticket_worker_outcomes_append_only_delete;
+ALTER TABLE navigator_ticket_worker_outcomes RENAME TO navigator_ticket_worker_outcomes_before_upgrade;
+CREATE TABLE navigator_ticket_worker_outcomes (
+  attempt_id TEXT PRIMARY KEY REFERENCES navigator_ticket_worker_attempts(id),
+  slice_id TEXT NOT NULL REFERENCES navigator_ticket_slices(id),
   outcome TEXT NOT NULL CHECK (outcome IN ('succeeded', 'findings', 'worker_unavailable', 'policy_failure', 'dead_letter')),
   reason_code TEXT NOT NULL,
   exact_head_sha TEXT NOT NULL,
@@ -3160,6 +3249,14 @@ CREATE TABLE navigator_ticket_worker_outcomes (
   recorded_at INTEGER NOT NULL,
   CHECK ((git_observation_json IS NULL) = (git_observation_digest IS NULL))
 );
+INSERT INTO navigator_ticket_worker_outcomes (
+  attempt_id, slice_id, outcome, reason_code, exact_head_sha,
+  result_json, result_digest, git_observation_json, git_observation_digest, recorded_at
+)
+SELECT attempt_id, slice_id, outcome, reason_code, exact_head_sha,
+       result_json, result_digest, NULL, NULL, recorded_at
+  FROM navigator_ticket_worker_outcomes_before_upgrade;
+DROP TABLE navigator_ticket_worker_outcomes_before_upgrade;
 
 CREATE TRIGGER navigator_ticket_worker_outcomes_append_only_update
 BEFORE UPDATE ON navigator_ticket_worker_outcomes
@@ -3214,34 +3311,6 @@ BEGIN SELECT RAISE(ABORT, 'navigator ticket repair dispatches are append-only');
 CREATE TRIGGER navigator_ticket_repair_dispatches_append_only_delete
 BEFORE DELETE ON navigator_ticket_repair_dispatches
 BEGIN SELECT RAISE(ABORT, 'navigator ticket repair dispatches are append-only'); END;
-
-CREATE TABLE navigator_pull_requests (
-  job_id TEXT PRIMARY KEY REFERENCES navigator_integrations(job_id),
-  operation_id TEXT NOT NULL UNIQUE,
-  request_json TEXT NOT NULL,
-  request_digest TEXT NOT NULL,
-  status TEXT NOT NULL CHECK (status IN ('pending', 'published')),
-  number INTEGER,
-  url TEXT,
-  head_sha TEXT NOT NULL,
-  created_at INTEGER NOT NULL,
-  settled_at INTEGER,
-  CHECK ((status = 'published') = (number IS NOT NULL AND url IS NOT NULL AND settled_at IS NOT NULL))
-);
-
-CREATE TRIGGER navigator_pull_requests_immutable_request
-BEFORE UPDATE ON navigator_pull_requests
-WHEN NEW.job_id <> OLD.job_id
-  OR NEW.operation_id <> OLD.operation_id
-  OR NEW.request_json <> OLD.request_json
-  OR NEW.request_digest <> OLD.request_digest
-  OR NEW.head_sha <> OLD.head_sha
-  OR NEW.created_at <> OLD.created_at
-  OR OLD.status = 'published'
-BEGIN SELECT RAISE(ABORT, 'navigator pull request identity is immutable'); END;
-CREATE TRIGGER navigator_pull_requests_no_delete
-BEFORE DELETE ON navigator_pull_requests
-BEGIN SELECT RAISE(ABORT, 'navigator pull requests cannot be deleted'); END;
 `] as const;
 
 export const ALL_MIGRATIONS = [
@@ -3324,4 +3393,5 @@ export const ALL_MIGRATIONS = [
   ...NAVIGATOR_WORKFLOW_MIGRATIONS,
   ...NAVIGATOR_PLANNING_MIGRATIONS,
   ...NAVIGATOR_IMPLEMENTATION_MIGRATIONS,
+  ...NAVIGATOR_IMPLEMENTATION_UPGRADE_MIGRATIONS,
 ] as const;

--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -3108,6 +3108,7 @@ CREATE TABLE navigator_ticket_worker_attempts (
   step_contract_id TEXT NOT NULL,
   step_contract_revision INTEGER NOT NULL CHECK (step_contract_revision >= 1),
   step_contract_digest TEXT NOT NULL,
+  step_contract_json TEXT NOT NULL,
   profile_json TEXT NOT NULL,
   profile_digest TEXT NOT NULL,
   model_route_json TEXT NOT NULL,
@@ -3132,6 +3133,7 @@ WHEN NEW.id <> OLD.id
   OR NEW.step_contract_id <> OLD.step_contract_id
   OR NEW.step_contract_revision <> OLD.step_contract_revision
   OR NEW.step_contract_digest <> OLD.step_contract_digest
+  OR NEW.step_contract_json <> OLD.step_contract_json
   OR NEW.profile_json <> OLD.profile_json
   OR NEW.profile_digest <> OLD.profile_digest
   OR NEW.model_route_json <> OLD.model_route_json
@@ -3148,12 +3150,15 @@ BEGIN SELECT RAISE(ABORT, 'navigator ticket worker attempts cannot be deleted');
 CREATE TABLE navigator_ticket_worker_outcomes (
   attempt_id TEXT PRIMARY KEY REFERENCES navigator_ticket_worker_attempts(id),
   slice_id TEXT NOT NULL REFERENCES navigator_ticket_slices(id),
-  outcome TEXT NOT NULL CHECK (outcome IN ('succeeded', 'findings', 'worker_unavailable', 'policy_failure')),
+  outcome TEXT NOT NULL CHECK (outcome IN ('succeeded', 'findings', 'worker_unavailable', 'policy_failure', 'dead_letter')),
   reason_code TEXT NOT NULL,
   exact_head_sha TEXT NOT NULL,
   result_json TEXT NOT NULL,
   result_digest TEXT NOT NULL,
-  recorded_at INTEGER NOT NULL
+  git_observation_json TEXT,
+  git_observation_digest TEXT,
+  recorded_at INTEGER NOT NULL,
+  CHECK ((git_observation_json IS NULL) = (git_observation_digest IS NULL))
 );
 
 CREATE TRIGGER navigator_ticket_worker_outcomes_append_only_update
@@ -3162,6 +3167,53 @@ BEGIN SELECT RAISE(ABORT, 'navigator ticket worker outcomes are append-only'); E
 CREATE TRIGGER navigator_ticket_worker_outcomes_append_only_delete
 BEFORE DELETE ON navigator_ticket_worker_outcomes
 BEGIN SELECT RAISE(ABORT, 'navigator ticket worker outcomes are append-only'); END;
+
+CREATE TABLE navigator_ticket_repair_snapshots (
+  id TEXT PRIMARY KEY,
+  job_id TEXT NOT NULL REFERENCES navigator_integrations(job_id),
+  slice_id TEXT NOT NULL REFERENCES navigator_ticket_slices(id),
+  review_attempt_id TEXT NOT NULL UNIQUE REFERENCES navigator_ticket_worker_attempts(id),
+  snapshot_json TEXT NOT NULL,
+  snapshot_digest TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE TRIGGER navigator_ticket_repair_snapshots_append_only_update
+BEFORE UPDATE ON navigator_ticket_repair_snapshots
+BEGIN SELECT RAISE(ABORT, 'navigator ticket repair snapshots are append-only'); END;
+CREATE TRIGGER navigator_ticket_repair_snapshots_append_only_delete
+BEFORE DELETE ON navigator_ticket_repair_snapshots
+BEGIN SELECT RAISE(ABORT, 'navigator ticket repair snapshots are append-only'); END;
+
+CREATE TABLE navigator_ticket_repair_proposals (
+  id TEXT PRIMARY KEY,
+  snapshot_id TEXT NOT NULL REFERENCES navigator_ticket_repair_snapshots(id),
+  route TEXT NOT NULL CHECK (route IN ('implementation', 'diagnosis', 'research', 'owner_boundary')),
+  proposal_json TEXT NOT NULL,
+  proposal_digest TEXT NOT NULL,
+  decision TEXT NOT NULL CHECK (decision = 'accepted'),
+  accepted_at INTEGER NOT NULL
+);
+
+CREATE TRIGGER navigator_ticket_repair_proposals_append_only_update
+BEFORE UPDATE ON navigator_ticket_repair_proposals
+BEGIN SELECT RAISE(ABORT, 'navigator ticket repair proposals are append-only'); END;
+CREATE TRIGGER navigator_ticket_repair_proposals_append_only_delete
+BEFORE DELETE ON navigator_ticket_repair_proposals
+BEGIN SELECT RAISE(ABORT, 'navigator ticket repair proposals are append-only'); END;
+
+CREATE TABLE navigator_ticket_repair_dispatches (
+  proposal_id TEXT PRIMARY KEY REFERENCES navigator_ticket_repair_proposals(id),
+  attempt_id TEXT NOT NULL UNIQUE REFERENCES navigator_ticket_worker_attempts(id),
+  dispatched_at INTEGER NOT NULL
+);
+
+CREATE TRIGGER navigator_ticket_repair_dispatches_append_only_update
+BEFORE UPDATE ON navigator_ticket_repair_dispatches
+BEGIN SELECT RAISE(ABORT, 'navigator ticket repair dispatches are append-only'); END;
+CREATE TRIGGER navigator_ticket_repair_dispatches_append_only_delete
+BEFORE DELETE ON navigator_ticket_repair_dispatches
+BEGIN SELECT RAISE(ABORT, 'navigator ticket repair dispatches are append-only'); END;
 
 CREATE TABLE navigator_pull_requests (
   job_id TEXT PRIMARY KEY REFERENCES navigator_integrations(job_id),

--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -3034,6 +3034,164 @@ BEFORE DELETE ON navigator_routing_blocks
 BEGIN SELECT RAISE(ABORT, 'navigator routing blocks are append-only'); END;
 `] as const;
 
+export const NAVIGATOR_IMPLEMENTATION_MIGRATIONS = [String.raw`
+CREATE TABLE navigator_integrations (
+  job_id TEXT PRIMARY KEY REFERENCES jobs(id),
+  specification_artifact_id TEXT NOT NULL REFERENCES work_artifacts(id),
+  specification_snapshot_id TEXT NOT NULL REFERENCES work_artifact_snapshots(id),
+  specification_snapshot_digest TEXT NOT NULL,
+  base_branch TEXT NOT NULL,
+  integration_branch TEXT NOT NULL UNIQUE,
+  worktree_id TEXT NOT NULL UNIQUE,
+  project_policy_version INTEGER NOT NULL CHECK (project_policy_version >= 1),
+  project_policy_json TEXT NOT NULL,
+  project_policy_digest TEXT NOT NULL,
+  base_head_sha TEXT NOT NULL,
+  current_head_sha TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN (
+    'implementing', 'invalidated', 'ready_for_pull_request', 'publishing_pull_request', 'ready_for_release'
+  )),
+  active_slice_id TEXT,
+  pull_request_number INTEGER,
+  pull_request_url TEXT,
+  evidence_refs_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  CHECK ((pull_request_number IS NULL) = (pull_request_url IS NULL))
+);
+
+CREATE TABLE navigator_integration_tickets (
+  job_id TEXT NOT NULL REFERENCES navigator_integrations(job_id),
+  artifact_id TEXT NOT NULL REFERENCES work_artifacts(id),
+  snapshot_id TEXT NOT NULL REFERENCES work_artifact_snapshots(id),
+  snapshot_digest TEXT NOT NULL,
+  ticket_order INTEGER NOT NULL CHECK (ticket_order >= 0),
+  state TEXT NOT NULL CHECK (state IN ('pending', 'active', 'accepted', 'resolved', 'invalidated')),
+  accepted_head_sha TEXT,
+  resolved_at INTEGER,
+  PRIMARY KEY(job_id, artifact_id),
+  UNIQUE(job_id, ticket_order),
+  CHECK ((state = 'resolved') = (resolved_at IS NOT NULL))
+);
+
+CREATE TABLE navigator_ticket_slices (
+  id TEXT PRIMARY KEY,
+  job_id TEXT NOT NULL REFERENCES navigator_integrations(job_id),
+  ticket_artifact_id TEXT NOT NULL REFERENCES work_artifacts(id),
+  ticket_snapshot_id TEXT NOT NULL REFERENCES work_artifact_snapshots(id),
+  ticket_snapshot_digest TEXT NOT NULL,
+  claim_id INTEGER NOT NULL REFERENCES work_artifact_claims(id),
+  integration_base_head_sha TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN (
+    'implementation_pending', 'implementation_running', 'review_pending', 'review_running',
+    'repair_pending', 'accepted', 'resolved', 'invalidated'
+  )),
+  accepted_head_sha TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE(job_id, ticket_artifact_id)
+);
+
+CREATE UNIQUE INDEX navigator_ticket_slices_one_active_writer
+  ON navigator_ticket_slices(job_id)
+  WHERE state IN ('implementation_pending', 'implementation_running', 'review_pending', 'review_running', 'repair_pending');
+
+CREATE TABLE navigator_ticket_worker_attempts (
+  id TEXT PRIMARY KEY,
+  job_id TEXT NOT NULL REFERENCES navigator_integrations(job_id),
+  slice_id TEXT NOT NULL REFERENCES navigator_ticket_slices(id),
+  kind TEXT NOT NULL CHECK (kind IN ('implementation', 'review')),
+  ordinal INTEGER NOT NULL CHECK (ordinal >= 1),
+  effect_idempotency_key TEXT NOT NULL UNIQUE REFERENCES effects(idempotency_key),
+  work_order_json TEXT NOT NULL,
+  work_order_digest TEXT NOT NULL,
+  step_contract_id TEXT NOT NULL,
+  step_contract_revision INTEGER NOT NULL CHECK (step_contract_revision >= 1),
+  step_contract_digest TEXT NOT NULL,
+  profile_json TEXT NOT NULL,
+  profile_digest TEXT NOT NULL,
+  model_route_json TEXT NOT NULL,
+  resource_kind TEXT CHECK (resource_kind IS NULL OR resource_kind = 'bb_thread'),
+  resource_id TEXT UNIQUE,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE(slice_id, kind, ordinal),
+  CHECK ((resource_kind IS NULL) = (resource_id IS NULL))
+);
+
+CREATE TRIGGER navigator_ticket_worker_attempts_immutable_identity
+BEFORE UPDATE ON navigator_ticket_worker_attempts
+WHEN NEW.id <> OLD.id
+  OR NEW.job_id <> OLD.job_id
+  OR NEW.slice_id <> OLD.slice_id
+  OR NEW.kind <> OLD.kind
+  OR NEW.ordinal <> OLD.ordinal
+  OR NEW.effect_idempotency_key <> OLD.effect_idempotency_key
+  OR NEW.work_order_json <> OLD.work_order_json
+  OR NEW.work_order_digest <> OLD.work_order_digest
+  OR NEW.step_contract_id <> OLD.step_contract_id
+  OR NEW.step_contract_revision <> OLD.step_contract_revision
+  OR NEW.step_contract_digest <> OLD.step_contract_digest
+  OR NEW.profile_json <> OLD.profile_json
+  OR NEW.profile_digest <> OLD.profile_digest
+  OR NEW.model_route_json <> OLD.model_route_json
+  OR NEW.created_at <> OLD.created_at
+  OR (OLD.resource_kind IS NOT NULL AND (
+    NEW.resource_kind IS NOT OLD.resource_kind OR NEW.resource_id IS NOT OLD.resource_id
+  ))
+BEGIN SELECT RAISE(ABORT, 'navigator ticket worker attempt identity is immutable'); END;
+
+CREATE TRIGGER navigator_ticket_worker_attempts_no_delete
+BEFORE DELETE ON navigator_ticket_worker_attempts
+BEGIN SELECT RAISE(ABORT, 'navigator ticket worker attempts cannot be deleted'); END;
+
+CREATE TABLE navigator_ticket_worker_outcomes (
+  attempt_id TEXT PRIMARY KEY REFERENCES navigator_ticket_worker_attempts(id),
+  slice_id TEXT NOT NULL REFERENCES navigator_ticket_slices(id),
+  outcome TEXT NOT NULL CHECK (outcome IN ('succeeded', 'findings', 'worker_unavailable', 'policy_failure')),
+  reason_code TEXT NOT NULL,
+  exact_head_sha TEXT NOT NULL,
+  result_json TEXT NOT NULL,
+  result_digest TEXT NOT NULL,
+  recorded_at INTEGER NOT NULL
+);
+
+CREATE TRIGGER navigator_ticket_worker_outcomes_append_only_update
+BEFORE UPDATE ON navigator_ticket_worker_outcomes
+BEGIN SELECT RAISE(ABORT, 'navigator ticket worker outcomes are append-only'); END;
+CREATE TRIGGER navigator_ticket_worker_outcomes_append_only_delete
+BEFORE DELETE ON navigator_ticket_worker_outcomes
+BEGIN SELECT RAISE(ABORT, 'navigator ticket worker outcomes are append-only'); END;
+
+CREATE TABLE navigator_pull_requests (
+  job_id TEXT PRIMARY KEY REFERENCES navigator_integrations(job_id),
+  operation_id TEXT NOT NULL UNIQUE,
+  request_json TEXT NOT NULL,
+  request_digest TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'published')),
+  number INTEGER,
+  url TEXT,
+  head_sha TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  settled_at INTEGER,
+  CHECK ((status = 'published') = (number IS NOT NULL AND url IS NOT NULL AND settled_at IS NOT NULL))
+);
+
+CREATE TRIGGER navigator_pull_requests_immutable_request
+BEFORE UPDATE ON navigator_pull_requests
+WHEN NEW.job_id <> OLD.job_id
+  OR NEW.operation_id <> OLD.operation_id
+  OR NEW.request_json <> OLD.request_json
+  OR NEW.request_digest <> OLD.request_digest
+  OR NEW.head_sha <> OLD.head_sha
+  OR NEW.created_at <> OLD.created_at
+  OR OLD.status = 'published'
+BEGIN SELECT RAISE(ABORT, 'navigator pull request identity is immutable'); END;
+CREATE TRIGGER navigator_pull_requests_no_delete
+BEFORE DELETE ON navigator_pull_requests
+BEGIN SELECT RAISE(ABORT, 'navigator pull requests cannot be deleted'); END;
+`] as const;
+
 export const ALL_MIGRATIONS = [
   ...INITIAL_MIGRATIONS,
   ...UPDATE_CLAIM_MIGRATIONS,
@@ -3113,4 +3271,5 @@ export const ALL_MIGRATIONS = [
   ...WORK_ARTIFACT_RELATIONSHIP_CANONICAL_MIGRATIONS,
   ...NAVIGATOR_WORKFLOW_MIGRATIONS,
   ...NAVIGATOR_PLANNING_MIGRATIONS,
+  ...NAVIGATOR_IMPLEMENTATION_MIGRATIONS,
 ] as const;

--- a/src/work-artifacts/coordinator.ts
+++ b/src/work-artifacts/coordinator.ts
@@ -578,13 +578,17 @@ export class WorkArtifactCoordinator {
     const settlement = this.commitExecutorMutation(input, (boundaryNow) => {
       const adoptNow = Math.max(input.now, boundaryNow);
       const adoptedCapture = this.captureObservation(artifact, external, adoptNow);
-      const adopted = this.store.adoptWorkArtifactClaim({
+      const currentClaim = this.store.getHeldWorkArtifactClaim(artifact.id);
+      const adopted = currentClaim !== null && this.store.adoptWorkArtifactClaim({
         artifactId: artifact.id,
         workflowStepId: input.workflowStepId,
         jobId: input.jobId,
         externalAssignee: input.assignee,
         ownerId: input.ownerId,
         generation: input.generation,
+        expectedOwnerId: currentClaim.ownerId,
+        expectedGeneration: currentClaim.generation,
+        expectedLeaseExpiresAt: currentClaim.leaseExpiresAt,
         now: adoptNow,
         leaseMs: input.leaseMs,
       });

--- a/src/work-artifacts/coordinator.ts
+++ b/src/work-artifacts/coordinator.ts
@@ -693,6 +693,7 @@ export class WorkArtifactCoordinator {
     }
     if (claim.state !== "held") return false;
     if (!this.store.isExecutorLeaseCurrent(input.ownerId, input.generation, input.now)) return false;
+    if (claim.leaseExpiresAt <= input.now) return false;
     const artifact = this.requireArtifact(claim.artifactId);
     let observed = await this.readBoundTrackerArtifact(artifact);
     const releaseEvidence = await this.tracker.operationStatus({

--- a/src/work-artifacts/repository.ts
+++ b/src/work-artifacts/repository.ts
@@ -1343,12 +1343,21 @@ export class WorkArtifactRepository {
           claim.releaseReason === reason;
       }
       if (claim.state !== "held") return false;
+      if (claim.leaseExpiresAt <= input.now) return false;
       if (!currentExecutorLease(this.db, input.ownerId, input.generation, input.now)) return false;
       const updated = this.db.prepare(
         `UPDATE work_artifact_claims
             SET state = 'released', released_at = ?, release_reason = ?
-          WHERE id = ? AND state = 'held' AND owner_id = ? AND generation = ?`,
-      ).run(input.now, reason, input.claimId, input.ownerId, input.generation);
+          WHERE id = ? AND state = 'held' AND owner_id = ? AND generation = ?
+            AND lease_expires_at > ?`,
+      ).run(
+        input.now,
+        reason,
+        input.claimId,
+        input.ownerId,
+        input.generation,
+        input.now,
+      );
       if (updated.changes !== 1) return false;
       this.db.prepare(
         `UPDATE work_artifacts SET status = 'ready', updated_at = ?

--- a/src/work-artifacts/repository.ts
+++ b/src/work-artifacts/repository.ts
@@ -153,6 +153,9 @@ export type AdoptWorkArtifactClaimInput = Readonly<{
   externalAssignee: string;
   ownerId: string;
   generation: number;
+  expectedOwnerId: string;
+  expectedGeneration: number;
+  expectedLeaseExpiresAt: number;
   now: number;
   leaseMs: number;
 }>;
@@ -1255,7 +1258,7 @@ export class WorkArtifactRepository {
   }
 
   public adoptArtifactClaim(input: AdoptWorkArtifactClaimInput): boolean {
-    this.validateClaimFence(input);
+    this.validateAdoptionFence(input);
     return this.db.transaction((): boolean => {
       if (!currentExecutorLease(this.db, input.ownerId, input.generation, input.now)) return false;
       const artifact = this.requireArtifact(input.artifactId);
@@ -1269,16 +1272,29 @@ export class WorkArtifactRepository {
         artifact.assignees.length !== 1 || artifact.assignees[0] !== input.externalAssignee ||
         !this.isSnapshotValid(claim.snapshotId)
       ) return false;
+      if (
+        claim.ownerId !== input.expectedOwnerId ||
+        claim.generation !== input.expectedGeneration ||
+        claim.leaseExpiresAt !== input.expectedLeaseExpiresAt
+      ) return false;
+      if (
+        (claim.ownerId !== input.ownerId || claim.generation !== input.generation) &&
+        claim.leaseExpiresAt > input.now
+      ) return false;
       return this.db.prepare(
         `UPDATE work_artifact_claims
             SET owner_id = ?, generation = ?, lease_expires_at = ?, renewed_at = ?
-          WHERE id = ? AND state = 'held'`,
+          WHERE id = ? AND state = 'held' AND owner_id = ? AND generation = ?
+            AND lease_expires_at = ?`,
       ).run(
         input.ownerId,
         input.generation,
         input.now + input.leaseMs,
         input.now,
         claim.id,
+        input.expectedOwnerId,
+        input.expectedGeneration,
+        input.expectedLeaseExpiresAt,
       ).changes === 1;
     }).immediate();
   }
@@ -1889,6 +1905,13 @@ export class WorkArtifactRepository {
     assertPositiveInteger(input.generation, "generation");
     assertNonNegativeInteger(input.now, "now");
     assertPositiveInteger(input.leaseMs, "leaseMs");
+  }
+
+  private validateAdoptionFence(input: AdoptWorkArtifactClaimInput): void {
+    this.validateClaimFence(input);
+    assertBoundedString(input.expectedOwnerId, "expectedOwnerId");
+    assertPositiveInteger(input.expectedGeneration, "expectedGeneration");
+    assertNonNegativeInteger(input.expectedLeaseExpiresAt, "expectedLeaseExpiresAt");
   }
 
   private validateClaimLeaseInput(input: RenewWorkArtifactClaimInput): void {

--- a/src/work-artifacts/repository.ts
+++ b/src/work-artifacts/repository.ts
@@ -1770,7 +1770,7 @@ export class WorkArtifactRepository {
   }
 
   private navigatorResultAuthorizesResolution(attemptId: string, artifact: WorkArtifact): boolean {
-    return this.db.prepare(
+    const planningResult = this.db.prepare(
       `SELECT 1
          FROM navigator_planning_results AS result
          JOIN navigator_skill_attempts AS attempt ON attempt.id = result.attempt_id
@@ -1780,6 +1780,18 @@ export class WorkArtifactRepository {
           AND job.project_id = ?
           AND json_extract(binding.value, '$.artifactId') = ?
           AND json_extract(binding.value, '$.snapshotId') = ?`,
+    ).get(attemptId, artifact.projectId, artifact.id, artifact.currentSnapshotId);
+    if (planningResult !== undefined) return true;
+    return this.db.prepare(
+      `SELECT 1
+         FROM navigator_ticket_worker_outcomes AS outcome
+         JOIN navigator_ticket_worker_attempts AS attempt ON attempt.id = outcome.attempt_id
+         JOIN navigator_ticket_slices AS slice ON slice.id = attempt.slice_id
+         JOIN jobs AS job ON job.id = attempt.job_id
+        WHERE outcome.attempt_id = ? AND outcome.outcome = 'succeeded'
+          AND attempt.kind = 'review' AND slice.state = 'accepted'
+          AND job.project_id = ? AND slice.ticket_artifact_id = ?
+          AND slice.ticket_snapshot_id = ?`,
     ).get(attemptId, artifact.projectId, artifact.id, artifact.currentSnapshotId) !== undefined;
   }
 

--- a/tests/autonomy-migration.test.ts
+++ b/tests/autonomy-migration.test.ts
@@ -105,7 +105,7 @@ function insertRelationshipUpgradeArtifact(
 }
 
 it("keeps the autonomy migration after the frozen legacy positions and appends later migrations", () => {
-  expect(ALL_MIGRATIONS).toHaveLength(LEGACY_MIGRATION_COUNT + 63);
+  expect(ALL_MIGRATIONS).toHaveLength(LEGACY_MIGRATION_COUNT + 64);
   for (const [index, marker] of LEGACY_MIGRATION_MARKERS) {
     expect(ALL_MIGRATIONS[index]).toContain(marker);
   }
@@ -182,7 +182,7 @@ it("keeps the autonomy migration after the frozen legacy positions and appends l
 it("strengthens relationship triggers after the original artifact migration was applied", () => {
   const { bb } = createFakePluginHost({ pluginId: "work-artifact-relationship-trigger-upgrade" });
   const db = bb.storage.database();
-  bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, -4));
+  bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, -5));
   expect(db.prepare(
     "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'work_artifact_relationships'",
   ).get()).toEqual({ name: "work_artifact_relationships" });
@@ -244,7 +244,7 @@ it("SPEC-39-002: backfills preexisting snapshot dependencies for recursive inval
   const { bb } = createFakePluginHost({ pluginId: "navigator-dependency-backfill-upgrade" });
   const db = bb.storage.database();
   registerWorkArtifactRelationshipValidation(db);
-  bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, -2));
+  bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, -3));
   const insertArtifact = db.prepare(
     `INSERT INTO work_artifacts (
        id, project_id, effort_id, operation_id, kind, initial_status, status,
@@ -395,7 +395,7 @@ it.each([
     pluginId: `work-artifact-invalid-relationship-upgrade-${String(relationship[1])}`,
   });
   const db = bb.storage.database();
-  const migrationsBeforeUpgrade = ALL_MIGRATIONS.length - 5;
+  const migrationsBeforeUpgrade = ALL_MIGRATIONS.length - 6;
   bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, migrationsBeforeUpgrade));
   const insertArtifact = db.prepare(
     `INSERT INTO work_artifacts (
@@ -538,7 +538,7 @@ it.each([
     pluginId: `work-artifact-canonical-relationship-${String(_scenario).replaceAll(" ", "-")}`,
   });
   const db = bb.storage.database();
-  const migrationsBeforeUpgrade = ALL_MIGRATIONS.length - 4;
+  const migrationsBeforeUpgrade = ALL_MIGRATIONS.length - 5;
   bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, migrationsBeforeUpgrade));
   arrange(db);
   const ledgerBefore = db.prepare("SELECT * FROM _bb_migrations ORDER BY id").all();

--- a/tests/autonomy-migration.test.ts
+++ b/tests/autonomy-migration.test.ts
@@ -105,7 +105,7 @@ function insertRelationshipUpgradeArtifact(
 }
 
 it("keeps the autonomy migration after the frozen legacy positions and appends later migrations", () => {
-  expect(ALL_MIGRATIONS).toHaveLength(LEGACY_MIGRATION_COUNT + 62);
+  expect(ALL_MIGRATIONS).toHaveLength(LEGACY_MIGRATION_COUNT + 63);
   for (const [index, marker] of LEGACY_MIGRATION_MARKERS) {
     expect(ALL_MIGRATIONS[index]).toContain(marker);
   }
@@ -171,12 +171,18 @@ it("keeps the autonomy migration after the frozen legacy positions and appends l
     .toContain("CREATE TABLE navigator_snapshots");
   expect(ALL_MIGRATIONS[LEGACY_MIGRATION_COUNT + 61])
     .toContain("CREATE TABLE navigator_planning_results");
+  expect(ALL_MIGRATIONS[LEGACY_MIGRATION_COUNT + 62])
+    .toContain("CREATE TABLE navigator_integrations");
+  expect(ALL_MIGRATIONS[LEGACY_MIGRATION_COUNT + 62])
+    .toContain("CREATE TABLE navigator_ticket_worker_outcomes");
+  expect(ALL_MIGRATIONS[LEGACY_MIGRATION_COUNT + 62])
+    .toContain("CREATE TABLE navigator_pull_requests");
 });
 
 it("strengthens relationship triggers after the original artifact migration was applied", () => {
   const { bb } = createFakePluginHost({ pluginId: "work-artifact-relationship-trigger-upgrade" });
   const db = bb.storage.database();
-  bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, -3));
+  bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, -4));
   expect(db.prepare(
     "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'work_artifact_relationships'",
   ).get()).toEqual({ name: "work_artifact_relationships" });
@@ -238,7 +244,7 @@ it("SPEC-39-002: backfills preexisting snapshot dependencies for recursive inval
   const { bb } = createFakePluginHost({ pluginId: "navigator-dependency-backfill-upgrade" });
   const db = bb.storage.database();
   registerWorkArtifactRelationshipValidation(db);
-  bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, -1));
+  bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, -2));
   const insertArtifact = db.prepare(
     `INSERT INTO work_artifacts (
        id, project_id, effort_id, operation_id, kind, initial_status, status,
@@ -389,7 +395,7 @@ it.each([
     pluginId: `work-artifact-invalid-relationship-upgrade-${String(relationship[1])}`,
   });
   const db = bb.storage.database();
-  const migrationsBeforeUpgrade = ALL_MIGRATIONS.length - 4;
+  const migrationsBeforeUpgrade = ALL_MIGRATIONS.length - 5;
   bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, migrationsBeforeUpgrade));
   const insertArtifact = db.prepare(
     `INSERT INTO work_artifacts (
@@ -532,7 +538,7 @@ it.each([
     pluginId: `work-artifact-canonical-relationship-${String(_scenario).replaceAll(" ", "-")}`,
   });
   const db = bb.storage.database();
-  const migrationsBeforeUpgrade = ALL_MIGRATIONS.length - 3;
+  const migrationsBeforeUpgrade = ALL_MIGRATIONS.length - 4;
   bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(0, migrationsBeforeUpgrade));
   arrange(db);
   const ledgerBefore = db.prepare("SELECT * FROM _bb_migrations ORDER BY id").all();

--- a/tests/controller-interaction-repository.test.ts
+++ b/tests/controller-interaction-repository.test.ts
@@ -489,7 +489,7 @@ async function runInteractionRace(
 }
 
 it("pins the shipped migration bytes and appends the runtime repair migrations", () => {
-  expect(ALL_MIGRATIONS).toHaveLength(79);
+  expect(ALL_MIGRATIONS).toHaveLength(80);
   expect(createHash("sha256").update([...ALL_MIGRATIONS].slice(0, 28).join("\u0000")).digest("hex")).toBe(
     "505dfd4781117dfb2c817d31640e833370189e6b3ef2c7c24e646fb1838eed56",
   );
@@ -514,6 +514,7 @@ it("pins the shipped migration bytes and appends the runtime repair migrations",
   expect(ALL_MIGRATIONS[69]).toContain("CREATE TABLE controller_voice_inbox");
   expect(ALL_MIGRATIONS[70]).toContain("attempts_before_consensus_lens");
   expect(ALL_MIGRATIONS[78]).toContain("CREATE TABLE navigator_integrations");
+  expect(ALL_MIGRATIONS[79]).toContain("step_contract_json");
   expect(ALL_MIGRATIONS[71]).toContain("CREATE TABLE audit_intake_findings");
   expect(ALL_MIGRATIONS[72]).toContain("merge_pre_approved_at");
   expect(ALL_MIGRATIONS[73]).toContain("CREATE TABLE work_artifacts");

--- a/tests/controller-interaction-repository.test.ts
+++ b/tests/controller-interaction-repository.test.ts
@@ -489,7 +489,7 @@ async function runInteractionRace(
 }
 
 it("pins the shipped migration bytes and appends the runtime repair migrations", () => {
-  expect(ALL_MIGRATIONS).toHaveLength(78);
+  expect(ALL_MIGRATIONS).toHaveLength(79);
   expect(createHash("sha256").update([...ALL_MIGRATIONS].slice(0, 28).join("\u0000")).digest("hex")).toBe(
     "505dfd4781117dfb2c817d31640e833370189e6b3ef2c7c24e646fb1838eed56",
   );
@@ -513,6 +513,7 @@ it("pins the shipped migration bytes and appends the runtime repair migrations",
   expect(ALL_MIGRATIONS[68]).toContain("CREATE TABLE project_admission_pause_clear_history");
   expect(ALL_MIGRATIONS[69]).toContain("CREATE TABLE controller_voice_inbox");
   expect(ALL_MIGRATIONS[70]).toContain("attempts_before_consensus_lens");
+  expect(ALL_MIGRATIONS[78]).toContain("CREATE TABLE navigator_integrations");
   expect(ALL_MIGRATIONS[71]).toContain("CREATE TABLE audit_intake_findings");
   expect(ALL_MIGRATIONS[72]).toContain("merge_pre_approved_at");
   expect(ALL_MIGRATIONS[73]).toContain("CREATE TABLE work_artifacts");

--- a/tests/controller-store.test.ts
+++ b/tests/controller-store.test.ts
@@ -200,7 +200,7 @@ function expectDuplicateGenerationRepair(
 // Applied migrations are immutable history: each release appends, so these are
 // indexed from the start and a new migration only ever extends the tail.
 it("keeps every shipped migration at its original position and appends new ones", () => {
-  expect(ALL_MIGRATIONS).toHaveLength(79);
+  expect(ALL_MIGRATIONS).toHaveLength(80);
   expect(ALL_MIGRATIONS[70]).toContain("attempts_before_consensus_lens");
   expect(ALL_MIGRATIONS[71]).toContain("CREATE TABLE audit_intake_findings");
   expect(ALL_MIGRATIONS[72]).toContain("merge_pre_approved_at");
@@ -211,6 +211,7 @@ it("keeps every shipped migration at its original position and appends new ones"
   expect(ALL_MIGRATIONS[76]).toContain("CREATE TABLE navigator_snapshots");
   expect(ALL_MIGRATIONS[77]).toContain("CREATE TABLE navigator_planning_results");
   expect(ALL_MIGRATIONS[78]).toContain("CREATE TABLE navigator_integrations");
+  expect(ALL_MIGRATIONS[79]).toContain("step_contract_json");
   expect(ALL_MIGRATIONS[65]).toContain("CREATE TABLE reference_documents");
   expect(ALL_MIGRATIONS[66]).toContain("thread_interactions ADD COLUMN controller_key");
   expect(ALL_MIGRATIONS[67]).toContain("CREATE TABLE reference_section_digests");

--- a/tests/controller-store.test.ts
+++ b/tests/controller-store.test.ts
@@ -200,7 +200,7 @@ function expectDuplicateGenerationRepair(
 // Applied migrations are immutable history: each release appends, so these are
 // indexed from the start and a new migration only ever extends the tail.
 it("keeps every shipped migration at its original position and appends new ones", () => {
-  expect(ALL_MIGRATIONS).toHaveLength(78);
+  expect(ALL_MIGRATIONS).toHaveLength(79);
   expect(ALL_MIGRATIONS[70]).toContain("attempts_before_consensus_lens");
   expect(ALL_MIGRATIONS[71]).toContain("CREATE TABLE audit_intake_findings");
   expect(ALL_MIGRATIONS[72]).toContain("merge_pre_approved_at");
@@ -210,6 +210,7 @@ it("keeps every shipped migration at its original position and appends new ones"
   expect(ALL_MIGRATIONS[75]).toContain("work_artifact_relationships_canonical_insert");
   expect(ALL_MIGRATIONS[76]).toContain("CREATE TABLE navigator_snapshots");
   expect(ALL_MIGRATIONS[77]).toContain("CREATE TABLE navigator_planning_results");
+  expect(ALL_MIGRATIONS[78]).toContain("CREATE TABLE navigator_integrations");
   expect(ALL_MIGRATIONS[65]).toContain("CREATE TABLE reference_documents");
   expect(ALL_MIGRATIONS[66]).toContain("thread_interactions ADD COLUMN controller_key");
   expect(ALL_MIGRATIONS[67]).toContain("CREATE TABLE reference_section_digests");

--- a/tests/navigator-implementation.test.ts
+++ b/tests/navigator-implementation.test.ts
@@ -2,7 +2,10 @@ import { createFakePluginHost } from "@bb/plugin-sdk/testing";
 import type Database from "better-sqlite3";
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_MODEL_POOL_REGISTRY } from "../src/capabilities/models";
-import { navigatorJsonDigest } from "../src/navigator/implementation-contracts";
+import {
+  navigatorJsonDigest,
+  navigatorPersistedTicketStepContractSchema,
+} from "../src/navigator/implementation-contracts";
 import {
   NavigatorImplementationExecutor,
   NavigatorTicketWorkerRetryableError,
@@ -12,7 +15,9 @@ import {
   type NavigatorTicketWorkerRunner,
 } from "../src/navigator/implementation-executor";
 import { openStore, type TelegramAgentStore } from "../src/storage/store";
+import { ALL_MIGRATIONS } from "../src/storage/migrations";
 import {
+  registerWorkArtifactRelationshipValidation,
   stableWorkArtifactId,
   type CaptureWorkArtifactInput,
 } from "../src/work-artifacts/repository";
@@ -70,9 +75,17 @@ function artifactInput(input: Readonly<{
   };
 }
 
-function fixture(): Fixture {
+function fixture(
+  migrationCount: number = ALL_MIGRATIONS.length,
+  beforeOpen?: (database: Database.Database) => void,
+): Fixture {
   fixtureSequence += 1;
   const { bb } = createFakePluginHost({ pluginId: `navigator-implementation-${fixtureSequence}` });
+  if (migrationCount !== ALL_MIGRATIONS.length) {
+    registerWorkArtifactRelationshipValidation(bb.storage.database());
+    bb.storage.migrate(bb.storage.database(), [...ALL_MIGRATIONS].slice(0, migrationCount));
+  }
+  beforeOpen?.(bb.storage.database());
   const store = openStore(bb.storage, bb.storage.kv, () => 1_000);
   let currentTime = 1_100;
   const now = () => currentTime++;
@@ -293,6 +306,78 @@ function validGitObserver(): NavigatorGitObserver {
 }
 
 describe("navigator ticket integration executor", () => {
+  it("appends the navigator persistence upgrade after the shipped implementation migration", () => {
+    expect(ALL_MIGRATIONS).toHaveLength(80);
+    expect(ALL_MIGRATIONS[78]).not.toContain("step_contract_json");
+    expect(ALL_MIGRATIONS[78]).not.toContain("navigator_ticket_repair_snapshots");
+    expect(ALL_MIGRATIONS[78]).not.toContain("git_observation_json");
+    expect(ALL_MIGRATIONS[79]).toContain("step_contract_json");
+    expect(ALL_MIGRATIONS[79]).toContain("navigator_ticket_repair_snapshots");
+    expect(ALL_MIGRATIONS[79]).toContain("git_observation_json");
+  });
+
+  it("backfills an existing v1 navigator attempt before enabling repair and Git evidence", () => {
+    const legacyEffect = "legacy-navigator-effect";
+    const legacyAttempt = "legacy-navigator-attempt";
+    const value = fixture(ALL_MIGRATIONS.length - 1, (database) => {
+      database.pragma("foreign_keys = OFF");
+      database.prepare(
+        `INSERT INTO effects (
+           idempotency_key, job_id, kind, payload_json, status, attempts,
+           next_attempt_at, created_at, updated_at
+         ) VALUES (?, 'legacy-job', 'run_navigator_ticket_worker', ?, 'done', 1, 1000, 1000, 1000)`,
+      ).run(legacyEffect, JSON.stringify({ attemptId: legacyAttempt }));
+      database.prepare(
+        `INSERT INTO navigator_ticket_slices (
+           id, job_id, ticket_artifact_id, ticket_snapshot_id, ticket_snapshot_digest,
+           claim_id, integration_base_head_sha, state, accepted_head_sha, created_at, updated_at
+         ) VALUES ('legacy-slice', 'legacy-job', 'legacy-ticket', 'legacy-snapshot', ?, 1, ?, 'invalidated', NULL, 1000, 1000)`,
+      ).run("a".repeat(64), SHA.base);
+      database.prepare(
+        `INSERT INTO navigator_ticket_worker_attempts (
+           id, job_id, slice_id, kind, ordinal, effect_idempotency_key,
+           work_order_json, work_order_digest, step_contract_id, step_contract_revision,
+           step_contract_digest, profile_json, profile_digest, model_route_json,
+           resource_kind, resource_id, created_at, updated_at
+         ) VALUES (?, 'legacy-job', 'legacy-slice', 'implementation', 1, ?, '{}', ?,
+           'navigator-ticket-implementation', 1,
+           'c3d183d0b7c961ad1cbc223aa38a025f6ec8b52496e40137ce5e7bd6ae77f851',
+           '{}', ?, '{}', NULL, NULL, 1000, 1000)`,
+      ).run(legacyAttempt, legacyEffect, navigatorJsonDigest({}), navigatorJsonDigest({}));
+      database.prepare(
+        `INSERT INTO navigator_ticket_worker_outcomes (
+           attempt_id, slice_id, outcome, reason_code, exact_head_sha,
+           result_json, result_digest, recorded_at
+         ) VALUES (?, 'legacy-slice', 'worker_unavailable', 'worker_missing', ?, '{}', ?, 1000)`,
+      ).run(legacyAttempt, SHA.base, navigatorJsonDigest({}));
+      database.pragma("foreign_keys = ON");
+    });
+
+    const attempt = value.database.prepare(
+      "SELECT step_contract_json FROM navigator_ticket_worker_attempts WHERE id = ?",
+    ).get(legacyAttempt) as { step_contract_json: string };
+    const contract = navigatorPersistedTicketStepContractSchema.parse(JSON.parse(attempt.step_contract_json));
+    expect(contract).toMatchObject({
+      id: "navigator-ticket-implementation",
+      revision: 1,
+      maximumResultBytes: 256_000,
+    });
+    expect(value.database.prepare(
+      "SELECT outcome, git_observation_json, git_observation_digest FROM navigator_ticket_worker_outcomes WHERE attempt_id = ?",
+    ).get(legacyAttempt)).toEqual({
+      outcome: "worker_unavailable",
+      git_observation_json: null,
+      git_observation_digest: null,
+    });
+    expect(value.database.prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?)",
+    ).all(
+      "navigator_ticket_repair_snapshots",
+      "navigator_ticket_repair_proposals",
+      "navigator_ticket_repair_dispatches",
+    )).toHaveLength(3);
+  });
+
   it("rejects worker-reported Git evidence that disagrees with the executor observation", async () => {
     const value = fixture();
     const workerRunner: NavigatorTicketWorkerRunner = {
@@ -474,23 +559,102 @@ describe("navigator ticket integration executor", () => {
       backoffBaseMs: 500,
       backoffMaximumMs: 30_000,
     });
-    for (let attempt = 2; attempt <= contract.maximumAttempts; attempt += 1) {
-      value.advance(Math.min(contract.backoffMaximumMs, contract.backoffBaseMs * 2 ** (attempt - 2)));
+    const maximumAttempts = "maximumAttempts" in contract ? contract.maximumAttempts : 0;
+    const backoffBaseMs = "backoffBaseMs" in contract ? contract.backoffBaseMs : 0;
+    const backoffMaximumMs = "backoffMaximumMs" in contract ? contract.backoffMaximumMs : 0;
+    for (let attempt = 2; attempt <= maximumAttempts; attempt += 1) {
+      value.advance(Math.min(backoffMaximumMs, backoffBaseMs * 2 ** (attempt - 2)));
       await executor.processOne(fence, new AbortController().signal);
     }
 
-    expect(workerRunner.run).toHaveBeenCalledTimes(contract.maximumAttempts);
-    expect(executor.snapshot(value.jobId)).toMatchObject({
-      integration: { state: "invalidated" },
-      outcomes: [expect.objectContaining({ outcome: "dead_letter", reasonCode: "retry_exhausted" })],
+    expect(workerRunner.run).toHaveBeenCalledTimes(maximumAttempts);
+    const exhausted = executor.snapshot(value.jobId);
+    expect(exhausted.integration.state).toBe("invalidated");
+    expect(exhausted.outcomes).toEqual(expect.arrayContaining([
+      expect.objectContaining({ outcome: "dead_letter", reasonCode: "retry_exhausted" }),
+    ]));
+  });
+
+  it("preserves retry attempts and backoff across repeated unavailable worker replacements", async () => {
+    const value = fixture();
+    const workerRunner: NavigatorTicketWorkerRunner = {
+      run: vi.fn(async (attempt, hooks) => {
+        await hooks.bindResource({ kind: "bb_thread", id: `thr_${attempt.id}` });
+        throw new NavigatorTicketWorkerUnavailableError("missing");
+      }),
+      reconcileUnavailableResource: vi.fn(async (resource) => ({
+        resource,
+        state: "missing" as const,
+        evidenceRef: `reconciled:${resource.id}`,
+        observedAt: value.now(),
+      })),
+    };
+    const executor = new NavigatorImplementationExecutor({
+      store: value.store,
+      database: value.database,
+      workerRunner,
+      gitObserver: validGitObserver(),
+      pullRequests: { createOrRefresh: vi.fn() },
+      modelRoute: () => ({ pool: "standard", ...DEFAULT_MODEL_POOL_REGISTRY.worker.standard }),
+      clock: { now: value.now },
     });
+    executor.startIntegration({
+      jobId: value.jobId,
+      specificationArtifactId: value.specificationId,
+      implementationTicketIds: value.ticketIds,
+      baseBranch: "main",
+      integrationBranch: "hanoon/job-40",
+      worktreeId: "env_job_40",
+      baseHeadSha: SHA.base,
+      evidenceRefs: ["ticket:40"],
+    });
+    executor.beginClaimedTicket({
+      jobId: value.jobId,
+      ticketArtifactId: value.ticketIds[0],
+      claimId: value.claim(value.ticketIds[0]),
+      taskEvidence: ["behavioral-change"],
+      evidenceRefs: ["ticket:40:claim"],
+      ownerId: "executor-40",
+      generation: 1,
+    });
+    const fence = { ownerId: "executor-40", generation: 1, signal: new AbortController().signal };
+    const contract = executor.snapshot(value.jobId).attempts[0]!.stepContract;
+    const maximumAttempts = "maximumAttempts" in contract ? contract.maximumAttempts : 0;
+    const backoffBaseMs = "backoffBaseMs" in contract ? contract.backoffBaseMs : 0;
+    const backoffMaximumMs = "backoffMaximumMs" in contract ? contract.backoffMaximumMs : 0;
+
+    for (let attemptNumber = 1; attemptNumber <= maximumAttempts; attemptNumber += 1) {
+      await executor.processOne(fence, new AbortController().signal);
+      const current = executor.snapshot(value.jobId);
+      if (attemptNumber < maximumAttempts) {
+        const replacement = current.attempts.at(-1)!;
+        expect(value.database.prepare(
+          "SELECT attempts, next_attempt_at FROM effects WHERE idempotency_key = ?",
+        ).get(replacement.effectIdempotencyKey)).toMatchObject({
+          attempts: attemptNumber,
+          next_attempt_at: expect.any(Number),
+        });
+        expect(await executor.processOne(fence, new AbortController().signal)).toBe(false);
+        value.advance(Math.min(
+          backoffMaximumMs,
+          backoffBaseMs * 2 ** (attemptNumber - 1),
+        ));
+      }
+    }
+
+    expect(workerRunner.run).toHaveBeenCalledTimes(maximumAttempts);
+    const exhausted = executor.snapshot(value.jobId);
+    expect(exhausted.integration.state).toBe("invalidated");
+    expect(exhausted.outcomes).toEqual(expect.arrayContaining([
+      expect.objectContaining({ outcome: "dead_letter", reasonCode: "retry_exhausted" }),
+    ]));
   });
 
   it("adopts the ticket claim and rejects settlement after its executor fence changes", async () => {
     const value = fixture();
     const claimId = value.claim(value.ticketIds[0]);
     value.database.prepare(
-      "UPDATE work_artifact_claims SET owner_id = 'retired-executor', generation = 99 WHERE id = ?",
+      "UPDATE work_artifact_claims SET owner_id = 'retired-executor', generation = 99, lease_expires_at = 0 WHERE id = ?",
     ).run(claimId);
     const workerRunner: NavigatorTicketWorkerRunner = {
       run: vi.fn(async (attempt, hooks) => {
@@ -549,7 +713,7 @@ describe("navigator ticket integration executor", () => {
   });
 
   it("sequentially integrates fresh ticket workers, repairs review findings, and publishes one pull request", async () => {
-    const value = fixture();
+    const value = fixture(ALL_MIGRATIONS.length - 1);
     let firstAttemptInterrupted = true;
     let secondAttemptMissing = true;
     const resourceEvents: string[] = [];
@@ -723,6 +887,7 @@ describe("navigator ticket integration executor", () => {
       generation: 1,
     });
     await executor.processOne(fence, new AbortController().signal);
+    value.advance(500);
     await executor.processOne(fence, new AbortController().signal);
     await executor.processOne(fence, new AbortController().signal);
     const secondAccepted = executor.snapshot(value.jobId);

--- a/tests/navigator-implementation.test.ts
+++ b/tests/navigator-implementation.test.ts
@@ -1,0 +1,505 @@
+import { createFakePluginHost } from "@bb/plugin-sdk/testing";
+import type Database from "better-sqlite3";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_MODEL_POOL_REGISTRY } from "../src/capabilities/models";
+import {
+  NavigatorImplementationExecutor,
+  NavigatorTicketWorkerUnavailableError,
+  type NavigatorTicketWorkerAttempt,
+  type NavigatorTicketWorkerRunner,
+} from "../src/navigator/implementation-executor";
+import { openStore, type TelegramAgentStore } from "../src/storage/store";
+import {
+  stableWorkArtifactId,
+  type CaptureWorkArtifactInput,
+} from "../src/work-artifacts/repository";
+import { policyFixture } from "./helpers";
+
+const SHA = {
+  base: "1".repeat(40),
+  ticketOne: "2".repeat(40),
+  repair: "3".repeat(40),
+  ticketTwo: "4".repeat(40),
+} as const;
+
+let fixtureSequence = 0;
+
+type Fixture = Readonly<{
+  store: TelegramAgentStore;
+  database: Database.Database;
+  jobId: string;
+  specificationId: string;
+  ticketIds: readonly [string, string];
+  now(): number;
+  claim(ticketId: string): number;
+  close(ticketId: string, reviewAttemptId: string): void;
+}>;
+
+function artifactInput(input: Readonly<{
+  id: string;
+  operationId: string;
+  kind: CaptureWorkArtifactInput["kind"];
+  title: string;
+  trackerOrder: number;
+  relationships?: CaptureWorkArtifactInput["relationships"];
+}>): CaptureWorkArtifactInput {
+  return {
+    artifactId: input.id,
+    projectId: "proj_40",
+    effortId: "job_40",
+    operationId: input.operationId,
+    kind: input.kind,
+    status: "ready",
+    trackerKind: "github",
+    trackerNamespace: "github:acme/widgets",
+    externalId: input.operationId,
+    externalUrl: `https://github.com/acme/widgets/issues/${input.operationId}`,
+    externalRevision: `${input.operationId}:1`,
+    externalStatus: "open",
+    assignees: [],
+    title: input.title,
+    trackerOrder: input.trackerOrder,
+    content: `# ${input.title}\n\nImmutable ticket 40 fixture.`,
+    acceptanceCriteria: [`${input.title} is accepted`],
+    relationships: input.relationships ?? [],
+    capturedAt: 1_000 + input.trackerOrder,
+  };
+}
+
+function fixture(): Fixture {
+  fixtureSequence += 1;
+  const { bb } = createFakePluginHost({ pluginId: `navigator-implementation-${fixtureSequence}` });
+  const store = openStore(bb.storage, bb.storage.kv, () => 1_000);
+  let currentTime = 1_100;
+  const now = () => currentTime++;
+  const specificationId = stableWorkArtifactId("proj_40", "specification-35");
+  const firstTicketId = stableWorkArtifactId("proj_40", "ticket-40-1");
+  const secondTicketId = stableWorkArtifactId("proj_40", "ticket-40-2");
+  const specification = store.captureWorkArtifact(artifactInput({
+    id: specificationId,
+    operationId: "35",
+    kind: "specification",
+    title: "Agent-owned engineering workflow",
+    trackerOrder: 0,
+  }));
+  const firstTicket = store.captureWorkArtifact(artifactInput({
+    id: firstTicketId,
+    operationId: "40-1",
+    kind: "implementation_ticket",
+    title: "Add the integration lane",
+    trackerOrder: 1,
+    relationships: [{
+      kind: "parent",
+      sourceArtifactId: firstTicketId,
+      sourceRef: `artifact:${firstTicketId}`,
+      targetArtifactId: specificationId,
+      targetRef: `artifact:${specificationId}`,
+    }],
+  }));
+  const secondTicket = store.captureWorkArtifact(artifactInput({
+    id: secondTicketId,
+    operationId: "40-2",
+    kind: "implementation_ticket",
+    title: "Prove restart behavior",
+    trackerOrder: 2,
+    relationships: [{
+      kind: "parent",
+      sourceArtifactId: secondTicketId,
+      sourceRef: `artifact:${secondTicketId}`,
+      targetArtifactId: specificationId,
+      targetRef: `artifact:${specificationId}`,
+    }, {
+      kind: "blocks",
+      sourceArtifactId: firstTicketId,
+      sourceRef: `artifact:${firstTicketId}`,
+      targetArtifactId: secondTicketId,
+      targetRef: `artifact:${secondTicketId}`,
+    }],
+  }));
+  const draft = store.createJob({
+    id: "job_40",
+    sourceUpdateId: 40,
+    requestText: "Implement the specification tickets in one integration lane.",
+    workflow: { engine: "navigator-v1", mode: "deterministic" },
+    now: now(),
+  });
+  const selected = store.applyJobEvent(draft.id, draft.version, {
+    type: "PROJECT_SELECTED",
+    projectId: "proj_40",
+    policyVersion: 1,
+    policy: policyFixture({ projectId: "proj_40" }),
+  }, now());
+  store.bindNavigatorJobArtifacts({
+    jobId: selected.id,
+    expectedVersion: selected.version,
+    artifactBindings: [specification, firstTicket, secondTicket].map(({ artifact, snapshot }) => ({
+      artifactId: artifact.id,
+      snapshotId: snapshot.id,
+      snapshotDigest: snapshot.snapshotDigest,
+    })),
+    now: now(),
+  });
+  bb.storage.database().prepare("UPDATE jobs SET state = 'implementing' WHERE id = ?").run(draft.id);
+  const lease = store.acquireExecutorLease("executor-40", now(), 100_000);
+  if (!lease.acquired) throw new Error("executor fixture lease was unavailable");
+
+  const claim = (ticketId: string): number => {
+    const artifact = store.getWorkArtifact(ticketId)!;
+    const snapshot = store.getCurrentWorkArtifactSnapshot(ticketId)!;
+    store.observeWorkArtifact({
+      artifactId: ticketId,
+      expectedExternalRevision: artifact.externalRevision,
+      externalRevision: `${artifact.externalRevision}:claimed`,
+      externalStatus: "open",
+      assignees: ["owner"],
+      title: snapshot.title,
+      content: snapshot.content,
+      acceptanceCriteria: snapshot.acceptanceCriteria,
+      relationships: snapshot.relationships,
+      observedAt: now(),
+    });
+    const claimed = store.claimWorkArtifact({
+      artifactId: ticketId,
+      workflowStepId: `implement:${ticketId}`,
+      jobId: draft.id,
+      snapshotId: snapshot.id,
+      externalAssignee: "owner",
+      ownerId: "executor-40",
+      generation: lease.generation,
+      now: now(),
+      leaseMs: 100_000,
+    });
+    if (!claimed) throw new Error(`ticket ${ticketId} was not claimed`);
+    return claimed.id;
+  };
+
+  const close = (ticketId: string, reviewAttemptId: string): void => {
+    const claimRecord = store.getHeldWorkArtifactClaim(ticketId)!;
+    store.releaseWorkArtifactClaim({
+      claimId: claimRecord.id,
+      ownerId: "executor-40",
+      generation: lease.generation,
+      reason: "accepted",
+      now: now(),
+    });
+    const artifact = store.getWorkArtifact(ticketId)!;
+    const snapshot = store.getCurrentWorkArtifactSnapshot(ticketId)!;
+    const closed = store.observeWorkArtifact({
+      artifactId: ticketId,
+      expectedExternalRevision: artifact.externalRevision,
+      externalRevision: `${artifact.externalRevision}:closed`,
+      externalStatus: "closed",
+      assignees: [],
+      title: snapshot.title,
+      content: snapshot.content,
+      acceptanceCriteria: snapshot.acceptanceCriteria,
+      relationships: snapshot.relationships,
+      observedAt: now(),
+    });
+    const intent = store.authorizeWorkArtifactResolution({
+      artifactId: ticketId,
+      operationId: `resolve:${ticketId}`,
+      outcome: "resolved",
+      snapshotId: snapshot.id,
+      expectedExternalRevision: closed.artifact.externalRevision,
+      evidenceRefs: [`navigator-result:${reviewAttemptId}`],
+      now: now(),
+    });
+    if (!intent) throw new Error(`ticket ${ticketId} resolution was not authorized`);
+    const resolved = store.finalizeWorkArtifactResolution({
+      intentId: intent.id,
+      externalRevision: closed.artifact.externalRevision,
+      now: now(),
+    });
+    if (!resolved) throw new Error(`ticket ${ticketId} resolution was not finalized`);
+  };
+
+  return {
+    store,
+    database: bb.storage.database(),
+    jobId: draft.id,
+    specificationId,
+    ticketIds: [firstTicketId, secondTicketId],
+    now,
+    claim,
+    close,
+  };
+}
+
+function implementationResult(attempt: NavigatorTicketWorkerAttempt, headSha: string) {
+  return {
+    kind: "implementation_result" as const,
+    baseHeadSha: attempt.workOrder.baseHeadSha,
+    headSha,
+    summary: `Implemented ${attempt.workOrder.ticket.artifactId}.`,
+    changedPaths: ["src/navigator/implementation-executor.ts", "tests/navigator-implementation.test.ts"],
+    focusedVerification: [{ command: "npm test -- navigator-implementation", outcome: "passed" as const }],
+    fullVerification: [{ command: "npm run check", outcome: "passed" as const }],
+    capabilityOutcomes: attempt.profile.assignments.map(({ capabilityId }) => ({
+      capabilityId,
+      outcome: "passed" as const,
+      evidenceRefs: [`worker:${attempt.id}:${capabilityId}`],
+    })),
+  };
+}
+
+function reviewResult(
+  attempt: NavigatorTicketWorkerAttempt,
+  outcome: "passed" | "findings",
+) {
+  return {
+    kind: "code_review_result" as const,
+    reviewedHeadSha: attempt.workOrder.baseHeadSha,
+    outcome,
+    summary: outcome === "passed" ? "The exact head passes review." : "One exact-head finding needs repair.",
+    findings: outcome === "findings" ? [{
+      ruleId: "SPEC-40-RESTART",
+      severity: "high" as const,
+      summary: "The interrupted worker path is not yet durable.",
+      evidenceRefs: [`head:${attempt.workOrder.baseHeadSha}`],
+    }] : [],
+    capabilityOutcomes: attempt.profile.assignments.map(({ capabilityId }) => ({
+      capabilityId,
+      outcome: outcome === "findings" ? "findings" as const : "passed" as const,
+      evidenceRefs: [`worker:${attempt.id}:${capabilityId}`],
+    })),
+  };
+}
+
+describe("navigator ticket integration executor", () => {
+  it("sequentially integrates fresh ticket workers, repairs review findings, and publishes one pull request", async () => {
+    const value = fixture();
+    let firstAttemptInterrupted = true;
+    let secondAttemptMissing = true;
+    const workerRunner: NavigatorTicketWorkerRunner = {
+      run: vi.fn(async (attempt, hooks) => {
+        const resource = attempt.resource ?? { kind: "bb_thread" as const, id: `thr_${attempt.id}` };
+        await hooks.bindResource(resource);
+        if (attempt.kind === "implementation" && firstAttemptInterrupted) {
+          firstAttemptInterrupted = false;
+          throw new Error("worker stopped after durable thread binding");
+        }
+        if (
+          attempt.kind === "implementation" && attempt.workOrder.ticket.artifactId === value.ticketIds[1] &&
+          secondAttemptMissing
+        ) {
+          secondAttemptMissing = false;
+          throw new NavigatorTicketWorkerUnavailableError("missing");
+        }
+        if (attempt.kind === "implementation") {
+          const head = attempt.ordinal === 1 && attempt.workOrder.ticket.artifactId === value.ticketIds[0]
+            ? SHA.ticketOne
+            : attempt.workOrder.ticket.artifactId === value.ticketIds[0]
+              ? SHA.repair
+              : SHA.ticketTwo;
+          return { resource, result: implementationResult(attempt, head) };
+        }
+        const needsRepair = attempt.workOrder.ticket.artifactId === value.ticketIds[0] && attempt.ordinal === 1;
+        return { resource, result: reviewResult(attempt, needsRepair ? "findings" : "passed") };
+      }),
+    };
+    let pullRequestCreated = false;
+    const pullRequests = {
+      createOrRefresh: vi.fn(async (request: Readonly<{ headSha: string; operationId: string }>) => {
+        if (!pullRequestCreated) {
+          pullRequestCreated = true;
+          throw new Error("publisher stopped after the idempotent pull request write");
+        }
+        return {
+          jobId: value.jobId,
+          number: 40,
+          url: "https://github.com/acme/widgets/pull/40",
+          headSha: request.headSha,
+          operationId: request.operationId,
+        };
+      }),
+    };
+    const newExecutor = () => new NavigatorImplementationExecutor({
+      store: value.store,
+      database: value.database,
+      workerRunner,
+      pullRequests,
+      modelRoute: (kind) => ({
+        pool: kind === "review" ? "strong" : "standard",
+        ...DEFAULT_MODEL_POOL_REGISTRY.worker[kind === "review" ? "strong" : "standard"],
+      }),
+      clock: { now: value.now },
+    });
+    let executor = newExecutor();
+    executor.startIntegration({
+      jobId: value.jobId,
+      specificationArtifactId: value.specificationId,
+      implementationTicketIds: value.ticketIds,
+      baseBranch: "main",
+      integrationBranch: "hanoon/job-40",
+      worktreeId: "env_job_40",
+      baseHeadSha: SHA.base,
+      evidenceRefs: ["specification:35", "ticket:40"],
+    });
+
+    const firstClaimId = value.claim(value.ticketIds[0]);
+    const firstSlice = executor.beginClaimedTicket({
+      jobId: value.jobId,
+      ticketArtifactId: value.ticketIds[0],
+      claimId: firstClaimId,
+      taskEvidence: ["reproducible-bug", "behavioral-change", "interface-design", "merge-conflict", "agent-instructions"],
+      evidenceRefs: ["ticket:40:claim"],
+    });
+    expect(firstSlice.state).toBe("implementation_pending");
+    const fence = { ownerId: "executor-40", generation: 1, signal: new AbortController().signal };
+    await executor.processOne(fence, new AbortController().signal);
+    const interrupted = executor.snapshot(value.jobId).attempts[0]!;
+    expect(interrupted.resource?.id).toBe(`thr_${interrupted.id}`);
+    expect(interrupted.stepContract).toMatchObject({
+      skillId: "implement",
+      freshContext: true,
+      codeWriting: true,
+    });
+    expect(interrupted.workOrder).toMatchObject({
+      projectPolicyVersion: 1,
+      projectPolicyDigest: expect.stringMatching(/^[0-9a-f]{64}$/u),
+    });
+    expect(interrupted.profile.assignments.map(({ capabilityId }) => capabilityId)).toEqual([
+      "codebase-design",
+      "diagnosing-bugs",
+      "implement",
+      "resolving-merge-conflicts",
+      "tdd",
+      "writing-for-agents",
+    ]);
+
+    executor = newExecutor();
+    await executor.processOne(fence, new AbortController().signal);
+    await executor.processOne(fence, new AbortController().signal);
+    expect(executor.snapshot(value.jobId).activeSlice?.state).toBe("repair_pending");
+    const repair = executor.scheduleRepair({
+      jobId: value.jobId,
+      ticketArtifactId: value.ticketIds[0],
+      taskEvidence: ["behavioral-change"],
+      evidenceRefs: ["review-finding:SPEC-40-RESTART"],
+    });
+    expect(repair.kind).toBe("implementation");
+    await executor.processOne(fence, new AbortController().signal);
+    await executor.processOne(fence, new AbortController().signal);
+    const firstAccepted = executor.snapshot(value.jobId);
+    expect(firstAccepted.activeSlice?.state).toBe("accepted");
+    const firstReview = [...firstAccepted.attempts].reverse().find((attempt) => attempt.kind === "review")!;
+    expect(firstReview.stepContract).toMatchObject({
+      skillId: "code-review",
+      freshContext: true,
+      codeWriting: false,
+    });
+    expect(firstReview.profile.assignments.map(({ capabilityId }) => capabilityId)).toEqual([
+      "clean-code-guard",
+      "code-review",
+      "test-guard",
+    ]);
+    value.close(value.ticketIds[0], firstReview.id);
+    executor.markTicketResolved({ jobId: value.jobId, ticketArtifactId: value.ticketIds[0] });
+
+    const secondClaimId = value.claim(value.ticketIds[1]);
+    executor.beginClaimedTicket({
+      jobId: value.jobId,
+      ticketArtifactId: value.ticketIds[1],
+      claimId: secondClaimId,
+      taskEvidence: ["behavioral-change"],
+      evidenceRefs: ["ticket:40:second-claim"],
+    });
+    await executor.processOne(fence, new AbortController().signal);
+    await executor.processOne(fence, new AbortController().signal);
+    await executor.processOne(fence, new AbortController().signal);
+    const secondAccepted = executor.snapshot(value.jobId);
+    const secondReview = [...secondAccepted.attempts].reverse().find((attempt) =>
+      attempt.kind === "review" && attempt.workOrder.ticket.artifactId === value.ticketIds[1])!;
+    value.close(value.ticketIds[1], secondReview.id);
+    executor.markTicketResolved({ jobId: value.jobId, ticketArtifactId: value.ticketIds[1] });
+
+    const pullRequestInput = {
+      jobId: value.jobId,
+      title: "Run navigator tickets in one restart-safe integration lane",
+      body: "Implements both accepted tickets from specification #35 with exact-head verification and review evidence.",
+    } as const;
+    await expect(executor.publishPullRequest(pullRequestInput)).rejects.toThrow("publisher stopped");
+    executor = newExecutor();
+    const pullRequest = await executor.publishPullRequest(pullRequestInput);
+    expect(pullRequest).toMatchObject({ number: 40, headSha: SHA.ticketTwo });
+    expect(pullRequests.createOrRefresh).toHaveBeenCalledTimes(2);
+    expect(executor.snapshot(value.jobId)).toMatchObject({
+      integration: {
+        state: "ready_for_release",
+        currentHeadSha: SHA.ticketTwo,
+        pullRequestNumber: 40,
+      },
+      tickets: [
+        expect.objectContaining({ artifactId: value.ticketIds[0], state: "resolved" }),
+        expect.objectContaining({ artifactId: value.ticketIds[1], state: "resolved" }),
+      ],
+    });
+    const resources = executor.snapshot(value.jobId).attempts.map((attempt) => attempt.resource?.id);
+    expect(new Set(resources).size).toBe(resources.length);
+    expect(executor.snapshot(value.jobId).outcomes).toContainEqual(expect.objectContaining({
+      outcome: "worker_unavailable",
+      reasonCode: "worker_missing",
+    }));
+  });
+
+  it("invalidates a running ticket when its specification snapshot changes", async () => {
+    const value = fixture();
+    const workerRunner: NavigatorTicketWorkerRunner = {
+      run: vi.fn(async (attempt, hooks) => {
+        const resource = { kind: "bb_thread" as const, id: `thr_${attempt.id}` };
+        await hooks.bindResource(resource);
+        const specification = value.store.getWorkArtifact(value.specificationId)!;
+        const snapshot = value.store.getCurrentWorkArtifactSnapshot(value.specificationId)!;
+        value.store.observeWorkArtifact({
+          artifactId: value.specificationId,
+          expectedExternalRevision: specification.externalRevision,
+          externalRevision: "35:material-edit",
+          externalStatus: "open",
+          assignees: [],
+          title: snapshot.title,
+          content: `${snapshot.content}\n\nMaterially changed requirement.`,
+          acceptanceCriteria: snapshot.acceptanceCriteria,
+          relationships: snapshot.relationships,
+          observedAt: value.now(),
+        });
+        return { resource, result: implementationResult(attempt, SHA.ticketOne) };
+      }),
+    };
+    const executor = new NavigatorImplementationExecutor({
+      store: value.store,
+      database: value.database,
+      workerRunner,
+      pullRequests: { createOrRefresh: vi.fn() },
+      modelRoute: () => ({ pool: "standard", ...DEFAULT_MODEL_POOL_REGISTRY.worker.standard }),
+      clock: { now: value.now },
+    });
+    executor.startIntegration({
+      jobId: value.jobId,
+      specificationArtifactId: value.specificationId,
+      implementationTicketIds: value.ticketIds,
+      baseBranch: "main",
+      integrationBranch: "hanoon/job-40",
+      worktreeId: "env_job_40",
+      baseHeadSha: SHA.base,
+      evidenceRefs: ["ticket:40"],
+    });
+    executor.beginClaimedTicket({
+      jobId: value.jobId,
+      ticketArtifactId: value.ticketIds[0],
+      claimId: value.claim(value.ticketIds[0]),
+      taskEvidence: ["behavioral-change"],
+      evidenceRefs: ["ticket:40:claim"],
+    });
+    await executor.processOne(
+      { ownerId: "executor-40", generation: 1, signal: new AbortController().signal },
+      new AbortController().signal,
+    );
+
+    expect(executor.snapshot(value.jobId)).toMatchObject({
+      integration: { state: "invalidated", currentHeadSha: SHA.base },
+      activeSlice: { state: "invalidated" },
+      outcomes: [expect.objectContaining({ outcome: "policy_failure", reasonCode: "stale_specification" })],
+    });
+  });
+});

--- a/tests/navigator-implementation.test.ts
+++ b/tests/navigator-implementation.test.ts
@@ -2,10 +2,13 @@ import { createFakePluginHost } from "@bb/plugin-sdk/testing";
 import type Database from "better-sqlite3";
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_MODEL_POOL_REGISTRY } from "../src/capabilities/models";
+import { navigatorJsonDigest } from "../src/navigator/implementation-contracts";
 import {
   NavigatorImplementationExecutor,
+  NavigatorTicketWorkerRetryableError,
   NavigatorTicketWorkerUnavailableError,
   type NavigatorTicketWorkerAttempt,
+  type NavigatorGitObserver,
   type NavigatorTicketWorkerRunner,
 } from "../src/navigator/implementation-executor";
 import { openStore, type TelegramAgentStore } from "../src/storage/store";
@@ -31,6 +34,7 @@ type Fixture = Readonly<{
   specificationId: string;
   ticketIds: readonly [string, string];
   now(): number;
+  advance(milliseconds: number): void;
   claim(ticketId: string): number;
   close(ticketId: string, reviewAttemptId: string): void;
 }>;
@@ -221,6 +225,9 @@ function fixture(): Fixture {
     specificationId,
     ticketIds: [firstTicketId, secondTicketId],
     now,
+    advance: (milliseconds) => {
+      currentTime += milliseconds;
+    },
     claim,
     close,
   };
@@ -266,14 +273,290 @@ function reviewResult(
   };
 }
 
+function validGitObserver(): NavigatorGitObserver {
+  return {
+    observe: vi.fn(async (request) => ({
+      kind: "navigator_git_observation" as const,
+      worktreeId: request.worktreeId,
+      branch: request.integrationBranch,
+      headSha: request.expectedHeadSha,
+      baseHeadSha: request.baseHeadSha,
+      baseHeadIsAncestor: true,
+      comparisonBaseHeadSha: request.comparisonBaseHeadSha,
+      comparisonBaseHeadIsAncestor: true,
+      clean: true,
+      changedPaths: request.expectedChangedPaths,
+      evidenceRef: `git-observation:${request.expectedHeadSha}:${request.purpose}`,
+      observedAt: 2_000,
+    })),
+  };
+}
+
 describe("navigator ticket integration executor", () => {
+  it("rejects worker-reported Git evidence that disagrees with the executor observation", async () => {
+    const value = fixture();
+    const workerRunner: NavigatorTicketWorkerRunner = {
+      run: vi.fn(async (attempt, hooks) => {
+        const resource = { kind: "bb_thread" as const, id: `thr_${attempt.id}` };
+        await hooks.bindResource(resource);
+        return { resource, result: implementationResult(attempt, SHA.ticketOne) };
+      }),
+      reconcileUnavailableResource: vi.fn(),
+    };
+    const gitObserver = validGitObserver();
+    vi.mocked(gitObserver.observe).mockResolvedValueOnce({
+      kind: "navigator_git_observation",
+      worktreeId: "env_job_40",
+      branch: "hanoon/job-40",
+      headSha: SHA.repair,
+      baseHeadSha: SHA.base,
+      baseHeadIsAncestor: true,
+      comparisonBaseHeadSha: SHA.base,
+      comparisonBaseHeadIsAncestor: true,
+      clean: true,
+      changedPaths: ["src/navigator/implementation-executor.ts"],
+      evidenceRef: "git-observation:forged-worker-result",
+      observedAt: 2_000,
+    });
+    const executor = new NavigatorImplementationExecutor({
+      store: value.store,
+      database: value.database,
+      workerRunner,
+      gitObserver,
+      pullRequests: { createOrRefresh: vi.fn() },
+      modelRoute: () => ({ pool: "standard", ...DEFAULT_MODEL_POOL_REGISTRY.worker.standard }),
+      clock: { now: value.now },
+    });
+    executor.startIntegration({
+      jobId: value.jobId,
+      specificationArtifactId: value.specificationId,
+      implementationTicketIds: value.ticketIds,
+      baseBranch: "main",
+      integrationBranch: "hanoon/job-40",
+      worktreeId: "env_job_40",
+      baseHeadSha: SHA.base,
+      evidenceRefs: ["ticket:40"],
+    });
+    executor.beginClaimedTicket({
+      jobId: value.jobId,
+      ticketArtifactId: value.ticketIds[0],
+      claimId: value.claim(value.ticketIds[0]),
+      taskEvidence: ["behavioral-change"],
+      evidenceRefs: ["ticket:40:claim"],
+      ownerId: "executor-40",
+      generation: 1,
+    });
+    await executor.processOne(
+      { ownerId: "executor-40", generation: 1, signal: new AbortController().signal },
+      new AbortController().signal,
+    );
+
+    expect(executor.snapshot(value.jobId)).toMatchObject({
+      integration: { state: "invalidated", currentHeadSha: SHA.base },
+      outcomes: [expect.objectContaining({
+        outcome: "policy_failure",
+        reasonCode: "git_observation_rejected",
+      })],
+    });
+  });
+
+  it("reads a durable attempt from its immutable contract payload after the registry revision changes", () => {
+    const value = fixture();
+    const executor = new NavigatorImplementationExecutor({
+      store: value.store,
+      database: value.database,
+      workerRunner: { run: vi.fn(), reconcileUnavailableResource: vi.fn() },
+      gitObserver: validGitObserver(),
+      pullRequests: { createOrRefresh: vi.fn() },
+      modelRoute: () => ({ pool: "standard", ...DEFAULT_MODEL_POOL_REGISTRY.worker.standard }),
+      clock: { now: value.now },
+    });
+    executor.startIntegration({
+      jobId: value.jobId,
+      specificationArtifactId: value.specificationId,
+      implementationTicketIds: value.ticketIds,
+      baseBranch: "main",
+      integrationBranch: "hanoon/job-40",
+      worktreeId: "env_job_40",
+      baseHeadSha: SHA.base,
+      evidenceRefs: ["ticket:40"],
+    });
+    executor.beginClaimedTicket({
+      jobId: value.jobId,
+      ticketArtifactId: value.ticketIds[0],
+      claimId: value.claim(value.ticketIds[0]),
+      taskEvidence: ["behavioral-change"],
+      evidenceRefs: ["ticket:40:claim"],
+      ownerId: "executor-40",
+      generation: 1,
+    });
+    const current = executor.snapshot(value.jobId).attempts[0]!;
+    const unsignedHistorical = { ...current.stepContract, revision: 99, digest: undefined };
+    delete unsignedHistorical.digest;
+    const historical = { ...unsignedHistorical, digest: navigatorJsonDigest(unsignedHistorical) };
+    const historicalId = `${current.id}_historical`;
+    const historicalEffect = `${current.effectIdempotencyKey}:historical`;
+    value.database.prepare(
+      `INSERT INTO effects (
+         idempotency_key, job_id, kind, payload_json, status, attempts,
+         next_attempt_at, created_at, updated_at
+       ) VALUES (?, ?, 'run_navigator_ticket_worker', ?, 'done', 0, ?, ?, ?)`,
+    ).run(historicalEffect, value.jobId, JSON.stringify({ attemptId: historicalId }), value.now(), value.now(), value.now());
+    value.database.prepare(
+      `INSERT INTO navigator_ticket_worker_attempts (
+         id, job_id, slice_id, kind, ordinal, effect_idempotency_key,
+         work_order_json, work_order_digest, step_contract_id, step_contract_revision,
+         step_contract_digest, step_contract_json, profile_json, profile_digest,
+         model_route_json, resource_kind, resource_id, created_at, updated_at
+       ) SELECT ?, job_id, slice_id, kind, 99, ?, work_order_json, work_order_digest,
+                ?, ?, ?, ?, profile_json, profile_digest, model_route_json,
+                NULL, NULL, ?, ?
+           FROM navigator_ticket_worker_attempts WHERE id = ?`,
+    ).run(
+      historicalId,
+      historicalEffect,
+      historical.id,
+      historical.revision,
+      historical.digest,
+      JSON.stringify(historical),
+      value.now(),
+      value.now(),
+      current.id,
+    );
+
+    expect(executor.snapshot(value.jobId).attempts.at(-1)?.stepContract).toEqual(historical);
+  });
+
+  it("backs off retryable worker failures and dead-letters after the contract ceiling", async () => {
+    const value = fixture();
+    const workerRunner: NavigatorTicketWorkerRunner = {
+      run: vi.fn(async () => {
+        throw new NavigatorTicketWorkerRetryableError("BB provider unavailable");
+      }),
+      reconcileUnavailableResource: vi.fn(),
+    };
+    const executor = new NavigatorImplementationExecutor({
+      store: value.store,
+      database: value.database,
+      workerRunner,
+      gitObserver: validGitObserver(),
+      pullRequests: { createOrRefresh: vi.fn() },
+      modelRoute: () => ({ pool: "standard", ...DEFAULT_MODEL_POOL_REGISTRY.worker.standard }),
+      clock: { now: value.now },
+    });
+    executor.startIntegration({
+      jobId: value.jobId,
+      specificationArtifactId: value.specificationId,
+      implementationTicketIds: value.ticketIds,
+      baseBranch: "main",
+      integrationBranch: "hanoon/job-40",
+      worktreeId: "env_job_40",
+      baseHeadSha: SHA.base,
+      evidenceRefs: ["ticket:40"],
+    });
+    executor.beginClaimedTicket({
+      jobId: value.jobId,
+      ticketArtifactId: value.ticketIds[0],
+      claimId: value.claim(value.ticketIds[0]),
+      taskEvidence: ["behavioral-change"],
+      evidenceRefs: ["ticket:40:claim"],
+      ownerId: "executor-40",
+      generation: 1,
+    });
+    const fence = { ownerId: "executor-40", generation: 1, signal: new AbortController().signal };
+
+    await executor.processOne(fence, new AbortController().signal);
+    expect(await executor.processOne(fence, new AbortController().signal)).toBe(false);
+    const contract = executor.snapshot(value.jobId).attempts[0]!.stepContract;
+    expect(contract).toMatchObject({
+      retryClass: "bounded_exponential",
+      maximumAttempts: 5,
+      backoffBaseMs: 500,
+      backoffMaximumMs: 30_000,
+    });
+    for (let attempt = 2; attempt <= contract.maximumAttempts; attempt += 1) {
+      value.advance(Math.min(contract.backoffMaximumMs, contract.backoffBaseMs * 2 ** (attempt - 2)));
+      await executor.processOne(fence, new AbortController().signal);
+    }
+
+    expect(workerRunner.run).toHaveBeenCalledTimes(contract.maximumAttempts);
+    expect(executor.snapshot(value.jobId)).toMatchObject({
+      integration: { state: "invalidated" },
+      outcomes: [expect.objectContaining({ outcome: "dead_letter", reasonCode: "retry_exhausted" })],
+    });
+  });
+
+  it("adopts the ticket claim and rejects settlement after its executor fence changes", async () => {
+    const value = fixture();
+    const claimId = value.claim(value.ticketIds[0]);
+    value.database.prepare(
+      "UPDATE work_artifact_claims SET owner_id = 'retired-executor', generation = 99 WHERE id = ?",
+    ).run(claimId);
+    const workerRunner: NavigatorTicketWorkerRunner = {
+      run: vi.fn(async (attempt, hooks) => {
+        const resource = { kind: "bb_thread" as const, id: `thr_${attempt.id}` };
+        await hooks.bindResource(resource);
+        value.database.prepare(
+          "UPDATE work_artifact_claims SET owner_id = 'stolen-executor', generation = 100 WHERE id = ?",
+        ).run(claimId);
+        return { resource, result: implementationResult(attempt, SHA.ticketOne) };
+      }),
+      reconcileUnavailableResource: vi.fn(),
+    };
+    const executor = new NavigatorImplementationExecutor({
+      store: value.store,
+      database: value.database,
+      workerRunner,
+      gitObserver: validGitObserver(),
+      pullRequests: { createOrRefresh: vi.fn() },
+      modelRoute: () => ({ pool: "standard", ...DEFAULT_MODEL_POOL_REGISTRY.worker.standard }),
+      clock: { now: value.now },
+    });
+    executor.startIntegration({
+      jobId: value.jobId,
+      specificationArtifactId: value.specificationId,
+      implementationTicketIds: value.ticketIds,
+      baseBranch: "main",
+      integrationBranch: "hanoon/job-40",
+      worktreeId: "env_job_40",
+      baseHeadSha: SHA.base,
+      evidenceRefs: ["ticket:40"],
+    });
+    const claimInput = {
+      jobId: value.jobId,
+      ticketArtifactId: value.ticketIds[0],
+      claimId,
+      taskEvidence: ["behavioral-change"] as const,
+      evidenceRefs: ["ticket:40:claim"],
+      ownerId: "executor-40",
+      generation: 1,
+    };
+    executor.beginClaimedTicket(claimInput);
+
+    expect(value.store.getWorkArtifactClaim(claimId)).toMatchObject({
+      ownerId: "executor-40",
+      generation: 1,
+    });
+    await executor.processOne(
+      { ownerId: "executor-40", generation: 1, signal: new AbortController().signal },
+      new AbortController().signal,
+    );
+
+    expect(executor.snapshot(value.jobId)).toMatchObject({
+      integration: { state: "invalidated", currentHeadSha: SHA.base },
+      outcomes: [expect.objectContaining({ outcome: "policy_failure", reasonCode: "claim_fence_lost" })],
+    });
+  });
+
   it("sequentially integrates fresh ticket workers, repairs review findings, and publishes one pull request", async () => {
     const value = fixture();
     let firstAttemptInterrupted = true;
     let secondAttemptMissing = true;
+    const resourceEvents: string[] = [];
     const workerRunner: NavigatorTicketWorkerRunner = {
       run: vi.fn(async (attempt, hooks) => {
         const resource = attempt.resource ?? { kind: "bb_thread" as const, id: `thr_${attempt.id}` };
+        resourceEvents.push(`run:${resource.id}`);
         await hooks.bindResource(resource);
         if (attempt.kind === "implementation" && firstAttemptInterrupted) {
           firstAttemptInterrupted = false;
@@ -297,6 +580,15 @@ describe("navigator ticket integration executor", () => {
         const needsRepair = attempt.workOrder.ticket.artifactId === value.ticketIds[0] && attempt.ordinal === 1;
         return { resource, result: reviewResult(attempt, needsRepair ? "findings" : "passed") };
       }),
+      reconcileUnavailableResource: vi.fn(async (resource, reason) => {
+        resourceEvents.push(`reconcile:${resource.id}`);
+        return {
+          resource,
+          state: reason === "missing" ? "missing" as const : "terminal" as const,
+          evidenceRef: `bb-resource:${resource.id}:${reason}`,
+          observedAt: value.now(),
+        };
+      }),
     };
     let pullRequestCreated = false;
     const pullRequests = {
@@ -318,6 +610,7 @@ describe("navigator ticket integration executor", () => {
       store: value.store,
       database: value.database,
       workerRunner,
+      gitObserver: validGitObserver(),
       pullRequests,
       modelRoute: (kind) => ({
         pool: kind === "review" ? "strong" : "standard",
@@ -344,6 +637,8 @@ describe("navigator ticket integration executor", () => {
       claimId: firstClaimId,
       taskEvidence: ["reproducible-bug", "behavioral-change", "interface-design", "merge-conflict", "agent-instructions"],
       evidenceRefs: ["ticket:40:claim"],
+      ownerId: "executor-40",
+      generation: 1,
     });
     expect(firstSlice.state).toBe("implementation_pending");
     const fence = { ownerId: "executor-40", generation: 1, signal: new AbortController().signal };
@@ -369,14 +664,34 @@ describe("navigator ticket integration executor", () => {
     ]);
 
     executor = newExecutor();
+    value.advance(500);
     await executor.processOne(fence, new AbortController().signal);
     await executor.processOne(fence, new AbortController().signal);
     expect(executor.snapshot(value.jobId).activeSlice?.state).toBe("repair_pending");
+    const repairSnapshot = executor.prepareRepairNavigation({
+      jobId: value.jobId,
+      ticketArtifactId: value.ticketIds[0],
+      evidenceRefs: ["review-finding:SPEC-40-RESTART"],
+    });
+    expect(repairSnapshot).toMatchObject({
+      reviewedHeadSha: SHA.ticketOne,
+      findings: [expect.objectContaining({ ruleId: "SPEC-40-RESTART" })],
+    });
+    const repairDecision = executor.recordRepairProposal({
+      snapshotId: repairSnapshot.snapshotId,
+      rawProposal: {
+        kind: "implementation",
+        basedOn: { snapshotId: repairSnapshot.snapshotId, digest: repairSnapshot.digest },
+        objective: "Repair the exact-head restart finding.",
+        taskEvidence: ["behavioral-change"],
+        evidenceRefs: ["review-finding:SPEC-40-RESTART"],
+      },
+    });
+    expect(repairDecision).toMatchObject({ decision: "accepted", route: "implementation" });
     const repair = executor.scheduleRepair({
       jobId: value.jobId,
       ticketArtifactId: value.ticketIds[0],
-      taskEvidence: ["behavioral-change"],
-      evidenceRefs: ["review-finding:SPEC-40-RESTART"],
+      proposalId: repairDecision.proposalId,
     });
     expect(repair.kind).toBe("implementation");
     await executor.processOne(fence, new AbortController().signal);
@@ -404,6 +719,8 @@ describe("navigator ticket integration executor", () => {
       claimId: secondClaimId,
       taskEvidence: ["behavioral-change"],
       evidenceRefs: ["ticket:40:second-claim"],
+      ownerId: "executor-40",
+      generation: 1,
     });
     await executor.processOne(fence, new AbortController().signal);
     await executor.processOne(fence, new AbortController().signal);
@@ -424,6 +741,22 @@ describe("navigator ticket integration executor", () => {
     const pullRequest = await executor.publishPullRequest(pullRequestInput);
     expect(pullRequest).toMatchObject({ number: 40, headSha: SHA.ticketTwo });
     expect(pullRequests.createOrRefresh).toHaveBeenCalledTimes(2);
+    expect(pullRequests.createOrRefresh.mock.calls.at(-1)?.[0]).toMatchObject({
+      headSha: SHA.ticketTwo,
+      gitObservation: {
+        branch: "hanoon/job-40",
+        headSha: SHA.ticketTwo,
+        baseHeadIsAncestor: true,
+        clean: true,
+      },
+      gitObservationDigest: expect.stringMatching(/^[0-9a-f]{64}$/u),
+      evidenceRefs: expect.arrayContaining([
+        `git-observation:${SHA.ticketOne}:implementation`,
+        `git-observation:${SHA.repair}:review`,
+        `git-observation:${SHA.ticketTwo}:review`,
+        `git-observation:${SHA.ticketTwo}:pull_request`,
+      ]),
+    });
     expect(executor.snapshot(value.jobId)).toMatchObject({
       integration: {
         state: "ready_for_release",
@@ -441,6 +774,11 @@ describe("navigator ticket integration executor", () => {
       outcome: "worker_unavailable",
       reasonCode: "worker_missing",
     }));
+    const unavailableAttempts = executor.snapshot(value.jobId).attempts.filter((attempt) =>
+      attempt.workOrder.ticket.artifactId === value.ticketIds[1] && attempt.kind === "implementation");
+    expect(resourceEvents.indexOf(`reconcile:${unavailableAttempts[0]!.resource!.id}`)).toBeLessThan(
+      resourceEvents.indexOf(`run:${unavailableAttempts[1]!.resource!.id}`),
+    );
   });
 
   it("invalidates a running ticket when its specification snapshot changes", async () => {
@@ -465,11 +803,13 @@ describe("navigator ticket integration executor", () => {
         });
         return { resource, result: implementationResult(attempt, SHA.ticketOne) };
       }),
+      reconcileUnavailableResource: vi.fn(),
     };
     const executor = new NavigatorImplementationExecutor({
       store: value.store,
       database: value.database,
       workerRunner,
+      gitObserver: validGitObserver(),
       pullRequests: { createOrRefresh: vi.fn() },
       modelRoute: () => ({ pool: "standard", ...DEFAULT_MODEL_POOL_REGISTRY.worker.standard }),
       clock: { now: value.now },
@@ -490,6 +830,8 @@ describe("navigator ticket integration executor", () => {
       claimId: value.claim(value.ticketIds[0]),
       taskEvidence: ["behavioral-change"],
       evidenceRefs: ["ticket:40:claim"],
+      ownerId: "executor-40",
+      generation: 1,
     });
     await executor.processOne(
       { ownerId: "executor-40", generation: 1, signal: new AbortController().signal },

--- a/tests/work-artifact-coordinator.test.ts
+++ b/tests/work-artifact-coordinator.test.ts
@@ -1075,6 +1075,78 @@ describe("WorkArtifactCoordinator", () => {
       .toEqual(["hanoon-bot", "human-owner"]);
   });
 
+  it("STD-40-001: fails closed before releasing an expired artifact claim", async () => {
+    fixtureNumber += 1;
+    const directory = await mkdtemp(join(tmpdir(), "work-artifact-release-expiry-"));
+    temporaryDirectories.push(directory);
+    const { bb } = createFakePluginHost({ pluginId: `work-artifact-release-expiry-${fixtureNumber}` });
+    let clock = 4_700;
+    const store = openStore(bb.storage, bb.storage.kv, () => clock);
+    createClaimJob(store, bb.storage.database());
+    const baseTracker = createConfiguredWorkTracker({
+      kind: "local_markdown",
+      repositoryRoot: directory,
+      effortSlug: "release-expiry",
+    });
+    let releaseCalls = 0;
+    const tracker = new Proxy(baseTracker, {
+      get(target, property, receiver) {
+        if (property === "release") {
+          return async (input: Parameters<WorkTracker["release"]>[0]) => {
+            releaseCalls += 1;
+            return target.release(input);
+          };
+        }
+        const value: unknown = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as WorkTracker;
+    const lease = store.acquireExecutorLease("release-expiry-executor", clock, 1_000);
+    if (!lease.acquired) throw new Error("executor lease was not acquired");
+    const fence = { ownerId: "release-expiry-executor", generation: lease.generation };
+    const coordinator = new WorkArtifactCoordinator(store, tracker, () => clock);
+    const created = await coordinator.create({
+      projectId: "proj_1",
+      effortId: "effort_1",
+      operationId: "release-expiry-create",
+      kind: "implementation_ticket",
+      status: "ready",
+      title: "Expired release claim",
+      body: "# Goal\n\nKeep expired releases from changing tracker ownership.",
+      acceptanceCriteria: [],
+      relationships: [],
+      ...fence,
+      now: clock,
+    });
+    const claimed = await coordinator.claim({
+      artifactId: created.artifact.id,
+      workflowStepId: "workflow_release_expiry",
+      jobId: "job_work_artifact",
+      assignee: "hanoon-bot",
+      operationId: "release-expiry-claim",
+      leaseMs: 50,
+      ...fence,
+      now: 4_710,
+    });
+    if (!claimed) throw new Error("artifact was not claimed");
+
+    clock = 4_761;
+    expect(await coordinator.release({
+      claimId: claimed.claim.id,
+      operationId: "release-expiry-release",
+      reason: "expired claim",
+      ...fence,
+      now: clock,
+    })).toBe(false);
+    expect(releaseCalls).toBe(0);
+    expect(store.getWorkArtifactClaim(claimed.claim.id)).toMatchObject({
+      state: "held",
+      leaseExpiresAt: 4_760,
+    });
+    expect((await baseTracker.read(created.artifact.externalId)).assignees)
+      .toEqual(["hanoon-bot"]);
+  });
+
   it("settles an interrupted local release before observation can invalidate the claim", async () => {
     fixtureNumber += 1;
     const directory = await mkdtemp(join(tmpdir(), "work-artifact-release-restart-"));

--- a/tests/work-artifact-repository.test.ts
+++ b/tests/work-artifact-repository.test.ts
@@ -1088,6 +1088,27 @@ describe("WorkArtifactRepository", () => {
     })?.id).toBe(claim?.id);
 
     expect(store.releaseExecutorLease("executor-a", first.generation, 1_020)).toBe(true);
+    const liveTakeover = store.acquireExecutorLease("executor-b", 1_030, 100);
+    if (!liveTakeover.acquired) throw new Error("live takeover executor lease was not acquired");
+    expect(repository.adoptArtifactClaim({
+      artifactId: created.artifact.id,
+      workflowStepId: "workflow_1",
+      jobId: "job_1",
+      externalAssignee: "hanoon-bot",
+      ownerId: "executor-b",
+      generation: liveTakeover.generation,
+      expectedOwnerId: claim!.ownerId,
+      expectedGeneration: claim!.generation,
+      expectedLeaseExpiresAt: claim!.leaseExpiresAt,
+      now: 1_035,
+      leaseMs: 100,
+    })).toBe(false);
+    expect(repository.getHeldClaim(created.artifact.id)).toMatchObject({
+      ownerId: "executor-a",
+      generation: first.generation,
+      leaseExpiresAt: claim!.leaseExpiresAt,
+    });
+    expect(store.releaseExecutorLease("executor-b", liveTakeover.generation, 1_040)).toBe(true);
     const second = store.acquireExecutorLease("executor-b", 1_200, 100);
     if (!second.acquired) throw new Error("second executor lease was not acquired");
     expect(repository.adoptArtifactClaim({
@@ -1097,6 +1118,9 @@ describe("WorkArtifactRepository", () => {
       externalAssignee: "hanoon-bot",
       ownerId: "executor-b",
       generation: second.generation,
+      expectedOwnerId: claim!.ownerId,
+      expectedGeneration: claim!.generation,
+      expectedLeaseExpiresAt: claim!.leaseExpiresAt,
       now: 1_210,
       leaseMs: 100,
     })).toBe(false);
@@ -1107,6 +1131,9 @@ describe("WorkArtifactRepository", () => {
       externalAssignee: "hanoon-bot",
       ownerId: "executor-b",
       generation: second.generation,
+      expectedOwnerId: claim!.ownerId,
+      expectedGeneration: claim!.generation,
+      expectedLeaseExpiresAt: claim!.leaseExpiresAt,
       now: 1_210,
       leaseMs: 100,
     })).toBe(true);

--- a/tests/work-artifact-repository.test.ts
+++ b/tests/work-artifact-repository.test.ts
@@ -1181,6 +1181,39 @@ describe("WorkArtifactRepository", () => {
     expect(repository.getArtifact(created.artifact.id)?.status).toBe("ready");
   });
 
+  it("STD-40-001: transactional release refuses an expired claim", () => {
+    const { repository, store } = fixture();
+    const created = repository.captureArtifact(artifactInput("expired-release", "63", {
+      assignees: ["hanoon-bot"],
+    }));
+    const executor = store.acquireExecutorLease("expired-release-executor", 1_000, 1_000);
+    if (!executor.acquired) throw new Error("executor lease was not acquired");
+    const claim = repository.claimArtifact({
+      artifactId: created.artifact.id,
+      workflowStepId: "workflow_expired_release",
+      jobId: "job_1",
+      snapshotId: created.snapshot.id,
+      externalAssignee: "hanoon-bot",
+      ownerId: "expired-release-executor",
+      generation: executor.generation,
+      now: 1_010,
+      leaseMs: 50,
+    });
+    if (!claim) throw new Error("artifact was not claimed");
+
+    expect(repository.releaseArtifactClaim({
+      claimId: claim.id,
+      ownerId: "expired-release-executor",
+      generation: executor.generation,
+      now: 1_061,
+      reason: "expired claim",
+    })).toBe(false);
+    expect(repository.getClaim(claim.id)).toMatchObject({
+      state: "held",
+      leaseExpiresAt: 1_060,
+    });
+  });
+
   it("persists immutable tracker mutation identity and a stable indeterminate outcome", () => {
     const { store } = fixture();
     const first = store.acquireExecutorLease("mutation-a", 1_000, 100);


### PR DESCRIPTION
Hanoon now claims each eligible implementation ticket and runs implement, then code review, in fresh workers on one integration branch and managed worktree. Ticket work stays restart-safe and one-writer until a reviewer-facing pull request is ready.

Refs #40. This sits above #48 on `ticket/39-planning-frontier`.

The four commits vs that base:

**feat: add navigator ticket integration lane.** Adds the integration lane: work orders, worker profiles, step contracts, ticket and artifact claim fencing, durable implementation and review results, and the final PR request.

**fix: close ticket 40 executor findings.** Review findings return through a validated Navigator repair snapshot and proposal. Implementation, review, closure, and PR intent bind to executor-owned Git observations.

**fix: close ticket 40 upgrade and retry findings.** Appended migrations keep historical attempts, repair state, and Git evidence. Missing or stale workers are replaced only with terminal or missing resource evidence, while bounded retry and dead-letter state stay intact. Claim adoption is independently fenced on owner, generation, and lease expiry.

**fix: fence expired artifact claim releases.** Expired claim releases fail closed in the coordinator and in the repository CAS. After expiry there are no external tracker release calls.
