### PR TITLE
feat: ship navigator tasks through exact-head production

### DIFF
--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -162,7 +162,7 @@ export const projectPolicySchema = z
     // nobody is watching an unattended merge do it. A rollback command is the
     // one thing that turns that from an incident into a recovery, so it is
     // required before the owner's signature may be skipped.
-    if (policy.autonomy?.unattendedMerge && policy.production && !policy.production.rollbackCommand) {
+    if (policy.autonomy?.unattendedMerge && policy.production && !productionHasRollbackCommand(policy)) {
       context.addIssue({
         code: "custom",
         path: ["autonomy", "unattendedMerge"],
@@ -442,6 +442,10 @@ export function isResumablePermanentFailure(
  */
 export function mergesWithoutProduction(policy: ProjectPolicy | null | undefined): boolean {
   return policy?.production === undefined && policy?.autonomy?.mergeWithoutProduction === true;
+}
+
+export function productionHasRollbackCommand(policy: ProjectPolicy | null | undefined): boolean {
+  return policy?.production?.rollbackCommand !== undefined;
 }
 
 export function isReviewedPrCompletionBlock(

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -594,6 +594,7 @@ export interface JobEffect {
     | "steer_implementation"
     | "run_navigator_skill"
     | "run_navigator_ticket_worker"
+    | "run_navigator_release"
     | "reconcile_job";
   payload: Record<string, unknown>;
 }
@@ -626,6 +627,7 @@ export type JobEvent =
   | { type: "CRITIQUE_NEEDS_REVISION"; attemptId: string; summary: string }
   | { type: "IMPLEMENTATION_CREATED"; threadId: string; environmentId: string }
   | { type: "IMPLEMENTATION_IDLE" }
+  | { type: "RELEASE_STARTED"; number: number; url: string; environmentId: string }
   | { type: "PR_LOCATED"; number: number; url: string }
   | { type: "PR_HEAD_RESOLVED"; headSha: string }
   | { type: "REVIEW_STARTED"; laneCount?: number }
@@ -669,6 +671,7 @@ export type JobEvent =
   | { type: "DEPLOY_FAILED"; reason: string }
   | { type: "CANARY_SUCCEEDED"; summary: string }
   | { type: "CANARY_FAILED"; reason: string }
+  | { type: "PRODUCTION_INCIDENT_RECOVERED"; phase: "deploy" | "canary"; reason: string }
   | { type: "THREAD_FAILED"; workerKind?: WorkerKind; error?: string }
   | {
       type: "WORKER_RECOVERY_REQUESTED";

--- a/src/domain/state-machine.ts
+++ b/src/domain/state-machine.ts
@@ -122,6 +122,16 @@ function clearHeadAndReceipts(job: Job, effects: JobEffect[]): void {
   emitEffect(job, effects, "revoke_approvals");
 }
 
+function isNavigatorJob(job: Pick<Job, "workflowEngine">): boolean {
+  return job.workflowEngine === "navigator-v1";
+}
+
+function returnNavigatorToNavigation(job: Job, effects: JobEffect[]): void {
+  clearHeadAndReceipts(job, effects);
+  job.state = "implementing";
+  emitEffect(job, effects, "render_status");
+}
+
 function enterLocatingPr(job: Job, effects: JobEffect[]): void {
   clearHeadAndReceipts(job, effects);
   job.state = "locating_pr";
@@ -478,6 +488,18 @@ function transitionCreatingImplementation(job: Job, event: JobEvent, effects: Jo
 }
 
 function transitionImplementing(job: Job, event: JobEvent, effects: JobEffect[]): void {
+  if (isNavigatorJob(job)) {
+    if (event.type !== "RELEASE_STARTED") illegal(job, event);
+    if (!Number.isInteger(event.number) || event.number < 1) throw new TypeError("PR number must be positive");
+    assertNonEmpty(event.url, "url");
+    assertNonEmpty(event.environmentId, "environmentId");
+    job.prNumber = event.number;
+    job.prUrl = event.url;
+    job.environmentId = event.environmentId;
+    job.state = "resolving_pr_head";
+    emitEffect(job, effects, "resolve_pr_head", { number: event.number, url: event.url });
+    return;
+  }
   if (event.type !== "IMPLEMENTATION_IDLE") illegal(job, event);
   enterLocatingPr(job, effects);
 }
@@ -516,6 +538,19 @@ function transitionReviewPassed(job: Job, event: JobEvent, effects: JobEffect[])
   assertHeadSha(event.headSha);
   if (!headMatches(job, event.headSha)) {
     invalidateDriftedHead(job, effects);
+    return;
+  }
+  if (isNavigatorJob(job)) {
+    if (event.documentation?.required) {
+      returnNavigatorToNavigation(job, effects);
+      return;
+    }
+    if (job.policy?.production || mergesWithoutProduction(job.policy) || taskRequiresRelease(job)) {
+      job.state = "awaiting_merge_approval";
+      emitEffect(job, effects, "issue_approval", { headSha: event.headSha });
+      return;
+    }
+    completeReviewedWork(job, effects);
     return;
   }
   if (job.routingMode === "active") {
@@ -586,6 +621,10 @@ function transitionReviewChanges(job: Job, event: JobEvent, effects: JobEffect[]
     invalidateDriftedHead(job, effects);
     return;
   }
+  if (isNavigatorJob(job)) {
+    returnNavigatorToNavigation(job, effects);
+    return;
+  }
   enterPatch(job, effects, event.summary ?? "Review requested changes", {
     findings: event.findings,
     reasons: event.reasons,
@@ -642,6 +681,10 @@ function transitionValidationFailed(job: Job, event: JobEvent, effects: JobEffec
       invalidateDriftedHead(job, effects);
       return;
     }
+  }
+  if (isNavigatorJob(job)) {
+    returnNavigatorToNavigation(job, effects);
+    return;
   }
   enterPatch(job, effects, event.reason ?? "Validation failed");
 }
@@ -843,6 +886,12 @@ function enterProductionIncident(job: Job, effects: JobEffect[], reason: string)
 }
 
 function transitionDeploying(job: Job, event: JobEvent, effects: JobEffect[]): void {
+  if (event.type === "PRODUCTION_INCIDENT_RECOVERED") {
+    if (!isNavigatorJob(job) || event.phase !== "deploy") illegal(job, event);
+    assertSafeFailureSummary(event.reason);
+    returnNavigatorToNavigation(job, effects);
+    return;
+  }
   if (event.type === "DEPLOY_SUCCEEDED") {
     assertSummary(event.summary, "summary");
     assertNonEmpty(event.summary, "summary");
@@ -860,6 +909,12 @@ function transitionDeploying(job: Job, event: JobEvent, effects: JobEffect[]): v
 }
 
 function transitionVerifyingProduction(job: Job, event: JobEvent, effects: JobEffect[]): void {
+  if (event.type === "PRODUCTION_INCIDENT_RECOVERED") {
+    if (!isNavigatorJob(job) || event.phase !== "canary") illegal(job, event);
+    assertSafeFailureSummary(event.reason);
+    returnNavigatorToNavigation(job, effects);
+    return;
+  }
   if (event.type === "CANARY_SUCCEEDED") {
     assertSummary(event.summary, "summary");
     assertNonEmpty(event.summary, "summary");

--- a/src/navigator/release-contracts.ts
+++ b/src/navigator/release-contracts.ts
@@ -1,0 +1,32 @@
+export const NAVIGATOR_RELEASE_INCIDENT_BUDGET = 1;
+export const NAVIGATOR_RELEASE_STEP_SKILL_ID = "start_release";
+
+export const NAVIGATOR_RELEASE_STATES = [
+  "locating_pr",
+  "resolving_pr_head",
+  "validating",
+  "reviewing",
+  "remediating",
+  "documenting",
+  "resolving_docs_head",
+  "final_validating",
+  "final_reviewing",
+  "awaiting_merge_approval",
+  "merging",
+  "deploying",
+  "verifying_production",
+] as const;
+
+export type NavigatorReleaseIncidentPhase = "deploy" | "canary";
+export type NavigatorReleaseRollbackOutcome = "pass" | "fail" | "missing" | "indeterminate";
+
+export type NavigatorReleaseAttempt = Readonly<{
+  id: string;
+  jobId: string;
+  workflowStepId: string;
+  effectIdempotencyKey: string;
+  implementationTicketIds: readonly string[];
+  snapshotDigest: string;
+  jobVersion: number;
+  workflowRevision: number;
+}>;

--- a/src/navigator/release-executor.ts
+++ b/src/navigator/release-executor.ts
@@ -1,0 +1,95 @@
+import type { StoredEffect } from "../domain/models";
+import type { EffectFence } from "../services/effect-runner";
+import type { TelegramAgentStore } from "../storage/store";
+import type { NavigatorPullRequestRecord } from "./implementation-contracts";
+
+export type NavigatorReleaseExecutorDependencies = Readonly<{
+  store: TelegramAgentStore;
+  publishPullRequest(input: Readonly<{ jobId: string; title: string; body: string }>): Promise<NavigatorPullRequestRecord>;
+  integrationWorktreeId(jobId: string): string;
+  clock: { now(): number };
+  leaseMs?: number;
+}>;
+
+function payloadIdentifier(effect: StoredEffect, key: string): string {
+  const payloadValue = effect.payload[key];
+  if (typeof payloadValue !== "string" || payloadValue.length === 0 || payloadValue.length > 256) {
+    throw new TypeError(`navigator release effect ${key} is invalid`);
+  }
+  return payloadValue;
+}
+
+function releaseTitle(requestText: string): string {
+  const trimmed = requestText.trim();
+  if (trimmed.length === 0) return "Ship accepted navigator tickets";
+  return trimmed.length <= 72 ? trimmed : `${trimmed.slice(0, 69).trimEnd()}...`;
+}
+
+export class NavigatorReleaseExecutor {
+  public constructor(private readonly dependencies: NavigatorReleaseExecutorDependencies) {}
+
+  public async processOne(fence: EffectFence, _signal: AbortSignal): Promise<boolean> {
+    const now = this.dependencies.clock.now();
+    const effect = this.dependencies.store.leaseNavigatorReleaseEffect({
+      ownerId: fence.ownerId,
+      generation: fence.generation,
+      now,
+      leaseMs: this.dependencies.leaseMs ?? 30_000,
+    });
+    if (!effect) return false;
+    const attemptId = payloadIdentifier(effect, "attemptId");
+    const workflowStepId = payloadIdentifier(effect, "workflowStepId");
+    const attempt = this.dependencies.store.getNavigatorReleaseAttempt(attemptId);
+    if (!attempt || attempt.effectIdempotencyKey !== effect.idempotencyKey || attempt.workflowStepId !== workflowStepId) {
+      this.dependencies.store.deadLetterEffect(
+        effect.idempotencyKey,
+        fence.ownerId,
+        fence.generation,
+        "Navigator release attempt identity is unavailable",
+        this.dependencies.clock.now(),
+      );
+      return true;
+    }
+    if (!this.dependencies.store.taskAuthorityOperationIsCurrent(effect, "pull_request")) {
+      this.dependencies.store.deadLetterEffect(
+        effect.idempotencyKey,
+        fence.ownerId,
+        fence.generation,
+        "task authority effect admission is absent, stale, or denied",
+        this.dependencies.clock.now(),
+      );
+      return true;
+    }
+    const published = await this.dependencies.publishPullRequest({
+      jobId: effect.jobId,
+      title: releaseTitle(this.dependencies.store.getJob(effect.jobId)?.requestText ?? ""),
+      body: "Exact-head release of the accepted implementation tickets.",
+    });
+    const current = this.dependencies.store.getJob(effect.jobId);
+    if (current?.state === "implementing") {
+      const updated = this.dependencies.store.applyExecutorJobEvent({
+        jobId: current.id,
+        expectedVersion: current.version,
+        event: {
+          type: "RELEASE_STARTED",
+          number: published.number,
+          url: published.url,
+          environmentId: this.dependencies.integrationWorktreeId(current.id),
+        },
+        ownerId: fence.ownerId,
+        generation: fence.generation,
+        now: this.dependencies.clock.now(),
+      });
+      if (!updated) throw new Error("executor refused the RELEASE_STARTED job transition");
+    }
+    if (!this.dependencies.store.completeEffect(
+      effect.idempotencyKey,
+      fence.ownerId,
+      fence.generation,
+      this.dependencies.clock.now(),
+    )) {
+      throw new Error("navigator release effect lease changed before settlement");
+    }
+    return true;
+  }
+}

--- a/src/navigator/repository.ts
+++ b/src/navigator/repository.ts
@@ -49,6 +49,7 @@ import {
   type NavigatorWorkflowStep,
   type NavigatorWorkflowStepOutcome,
 } from "./models";
+import { NAVIGATOR_RELEASE_STEP_SKILL_ID, type NavigatorReleaseAttempt } from "./release-contracts";
 
 type SqliteDatabase = Database.Database;
 
@@ -367,6 +368,35 @@ function proposalReason(
       !NAVIGATOR_SKILL_CATALOG.some((entry) => entry.id === skillId && entry.admitted))) return "capability_denied";
     return null;
   }
+  if (proposal.kind === "start_release") {
+    if (job.taskOutcome !== "shipped_change" && job.taskOutcome !== "reviewed_change") {
+      return "release_outcome_not_permitted";
+    }
+    const ticketIds = proposal.implementationTicketIds;
+    if (new Set(ticketIds).size !== ticketIds.length) return "malformed_proposal";
+    const boundIds = new Set(job.artifactBindings.map((binding) => binding.artifactId));
+    for (const artifactId of ticketIds) {
+      if (!boundIds.has(artifactId)) return "unauthorized_subject";
+      if (artifacts.getArtifact(artifactId)?.kind !== "implementation_ticket") return "unauthorized_subject";
+    }
+    return null;
+  }
+  if (proposal.kind === "finish") {
+    const boundIds = new Set(job.artifactBindings.map((binding) => binding.artifactId));
+    if (proposal.artifactIds.some((artifactId) => !boundIds.has(artifactId))) return "unauthorized_subject";
+    if (job.taskOutcome === "artifact") {
+      return proposal.artifactIds.every((artifactId) => artifacts.getResolution(artifactId)?.outcome === "resolved")
+        ? null
+        : "completion_evidence_missing";
+    }
+    if (job.taskOutcome === "reviewed_change") {
+      return job.state === "complete" ? null : "completion_evidence_missing";
+    }
+    if (job.taskOutcome === "shipped_change") {
+      return job.state === "complete" || job.state === "merged" ? null : "completion_evidence_missing";
+    }
+    return "completion_evidence_missing";
+  }
   if (proposal.kind !== "invoke_skill") return "unsupported_deterministic_action";
   const catalog = NAVIGATOR_SKILL_CATALOG.find((entry) => entry.id === proposal.skillId);
   const contract = navigatorStepContract(proposal.skillId);
@@ -663,7 +693,82 @@ export class NavigatorRepository {
         this.insertDecision(proposalId, job.id, input.snapshotId, "accepted", "owner_boundary_recorded", input.now);
         return this.requireDecision(proposalId);
       }
-      if (proposal?.kind !== "invoke_skill" && proposal?.kind !== "unresolved_next_step") {
+      if (proposal.kind === "finish") {
+        this.insertDecision(proposalId, job.id, input.snapshotId, "accepted", "completion_recorded", input.now);
+        return this.requireDecision(proposalId);
+      }
+      if (proposal.kind === "start_release") {
+        if (this.releasePrerequisitesIncomplete(job, proposal.implementationTicketIds)) {
+          this.insertDecision(
+            proposalId,
+            job.id,
+            input.snapshotId,
+            "rejected",
+            "release_prerequisites_incomplete",
+            input.now,
+          );
+          return this.requireDecision(proposalId);
+        }
+        const stepId = digestId("wfstep", proposalId, digest);
+        const attemptId = digestId("navrelease", stepId, NAVIGATOR_RELEASE_STEP_SKILL_ID);
+        const effectKey = `${job.id}:navigator:${stepId}:run_release`;
+        this.db.prepare(
+          `INSERT INTO workflow_steps (
+             id, job_id, proposal_id, snapshot_id, skill_id, job_version, workflow_revision, accepted_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          stepId,
+          job.id,
+          proposalId,
+          input.snapshotId,
+          NAVIGATOR_RELEASE_STEP_SKILL_ID,
+          job.version,
+          job.workflowRevision,
+          input.now,
+        );
+        this.db.prepare(
+          `INSERT INTO effects (
+             idempotency_key, job_id, kind, payload_json, status, attempts,
+             next_attempt_at, created_at, updated_at
+           ) VALUES (?, ?, 'run_navigator_release', ?, 'pending', 0, ?, ?, ?)`,
+        ).run(
+          effectKey,
+          job.id,
+          serializeNavigatorJson({
+            workflowStepId: stepId,
+            attemptId,
+            snapshotId: input.snapshotId,
+          }, "navigator release effect"),
+          input.now,
+          input.now,
+          input.now,
+        );
+        this.db.prepare(
+          `INSERT INTO navigator_release_attempts (
+             id, job_id, workflow_step_id, effect_idempotency_key, implementation_ticket_ids_json,
+             snapshot_digest, job_version, workflow_revision, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          attemptId,
+          job.id,
+          stepId,
+          effectKey,
+          JSON.stringify(proposal.implementationTicketIds),
+          snapshot.identity.digest,
+          job.version,
+          job.workflowRevision,
+          input.now,
+          input.now,
+        );
+        const updated = this.db.prepare(
+          `UPDATE jobs SET current_workflow_step_id = ?, version = version + 1, updated_at = ?
+            WHERE id = ? AND version = ? AND current_workflow_step_id IS NULL`,
+        ).run(stepId, input.now, job.id, job.version);
+        if (updated.changes !== 1) throw new VersionConflictError(job.id, job.version);
+        this.insertDecision(proposalId, job.id, input.snapshotId, "accepted", "accepted", input.now);
+        return this.requireDecision(proposalId);
+      }
+      if (proposal.kind !== "invoke_skill" && proposal.kind !== "unresolved_next_step") {
         throw new Error("deterministic proposal validation was inconsistent");
       }
       const routingIdentity = proposal.kind === "unresolved_next_step"
@@ -1081,6 +1186,23 @@ export class NavigatorRepository {
     return row ? this.getRoutingDecision(row.decision_digest) : null;
   }
 
+  private releasePrerequisitesIncomplete(job: Job, implementationTicketIds: readonly string[]): boolean {
+    const integration = this.db.prepare(
+      "SELECT state FROM navigator_integrations WHERE job_id = ?",
+    ).get(job.id) as { state: string } | undefined;
+    if (
+      !integration ||
+      !["ready_for_pull_request", "publishing_pull_request", "ready_for_release"].includes(integration.state)
+    ) return true;
+    const tickets = this.db.prepare(
+      "SELECT artifact_id, state FROM navigator_integration_tickets WHERE job_id = ? ORDER BY ticket_order",
+    ).all(job.id) as Array<{ artifact_id: string; state: string }>;
+    if (tickets.length === 0 || tickets.some((ticket) => ticket.state !== "resolved")) return true;
+    const ticketIds = new Set(tickets.map((ticket) => ticket.artifact_id));
+    return ticketIds.size !== implementationTicketIds.length ||
+      implementationTicketIds.some((artifactId) => !ticketIds.has(artifactId));
+  }
+
   public leaseSkillEffect(input: Readonly<{
     ownerId: string;
     generation: number;
@@ -1150,6 +1272,98 @@ export class NavigatorRepository {
         .get(row.idempotency_key) as EffectRow;
       return parseStoredEffect(leased);
     }).immediate();
+  }
+
+  public leaseReleaseEffect(input: Readonly<{
+    ownerId: string;
+    generation: number;
+    now: number;
+    leaseMs: number;
+  }>): StoredEffect | null {
+    assertIdentifier(input.ownerId, "ownerId");
+    assertPositiveInteger(input.generation, "generation");
+    assertNonNegativeInteger(input.now, "now");
+    assertPositiveInteger(input.leaseMs, "leaseMs");
+    return this.db.transaction((): StoredEffect | null => {
+      if (!this.executorLeaseCurrent(input.ownerId, input.generation, input.now)) return null;
+      const row = this.db.prepare(
+        `SELECT effect.*
+           FROM effects AS effect
+           JOIN navigator_release_attempts AS attempt ON attempt.effect_idempotency_key = effect.idempotency_key
+           JOIN workflow_steps AS step ON step.id = attempt.workflow_step_id
+           JOIN navigator_snapshots AS snapshot ON snapshot.id = step.snapshot_id
+           JOIN jobs AS job ON job.id = effect.job_id
+          WHERE effect.kind = 'run_navigator_release'
+            AND job.workflow_engine = 'navigator-v1' AND job.workflow_mode = 'deterministic'
+            AND job.state NOT IN ('merged', 'cancelled', 'blocked', 'complete', 'production_failed')
+            AND job.cancel_requested_at IS NULL
+            AND effect.job_id = attempt.job_id AND attempt.job_id = step.job_id
+            AND step.job_id = snapshot.job_id
+            AND attempt.job_version = step.job_version AND step.job_version = snapshot.job_version
+            AND attempt.workflow_revision = step.workflow_revision
+            AND step.workflow_revision = snapshot.workflow_revision
+            AND attempt.snapshot_digest = snapshot.digest
+            AND job.workflow_revision = step.workflow_revision
+            AND job.current_workflow_step_id = attempt.workflow_step_id
+            AND NOT EXISTS (
+              SELECT 1 FROM navigator_release_outcomes AS outcome WHERE outcome.attempt_id = attempt.id
+            )
+            AND ((effect.status IN ('pending', 'failed') AND effect.next_attempt_at <= ?)
+              OR (effect.status = 'leased' AND effect.lease_expires_at <= ?))
+          ORDER BY effect.created_at, effect.idempotency_key
+          LIMIT 1`,
+      ).get(input.now, input.now) as EffectRow | undefined;
+      if (!row) return null;
+      if (!(["commit", "push", "pull_request"] as const).every((operation) => this.taskAuthorities.admitEffect(
+        row.job_id,
+        row.idempotency_key,
+        operation,
+        input.now,
+      ))) return null;
+      const updated = this.db.prepare(
+        `UPDATE effects SET status = 'leased', lease_owner = ?, lease_generation = ?,
+             lease_expires_at = ?, attempts = attempts + 1, updated_at = ?
+          WHERE idempotency_key = ? AND ((status IN ('pending', 'failed') AND next_attempt_at <= ?)
+            OR (status = 'leased' AND lease_expires_at <= ?))`,
+      ).run(
+        input.ownerId,
+        input.generation,
+        input.now + input.leaseMs,
+        input.now,
+        row.idempotency_key,
+        input.now,
+        input.now,
+      );
+      if (updated.changes !== 1) return null;
+      const leased = this.db.prepare("SELECT * FROM effects WHERE idempotency_key = ?")
+        .get(row.idempotency_key) as EffectRow;
+      return parseStoredEffect(leased);
+    }).immediate();
+  }
+
+  public getReleaseAttempt(id: string): NavigatorReleaseAttempt | null {
+    assertIdentifier(id, "attemptId");
+    const row = this.db.prepare("SELECT * FROM navigator_release_attempts WHERE id = ?").get(id) as {
+      id: string;
+      job_id: string;
+      workflow_step_id: string;
+      effect_idempotency_key: string;
+      implementation_ticket_ids_json: string;
+      snapshot_digest: string;
+      job_version: number;
+      workflow_revision: number;
+    } | undefined;
+    if (!row) return null;
+    return {
+      id: row.id,
+      jobId: row.job_id,
+      workflowStepId: row.workflow_step_id,
+      effectIdempotencyKey: row.effect_idempotency_key,
+      implementationTicketIds: JSON.parse(row.implementation_ticket_ids_json) as readonly string[],
+      snapshotDigest: row.snapshot_digest,
+      jobVersion: row.job_version,
+      workflowRevision: row.workflow_revision,
+    };
   }
 
   public bindAttemptResource(input: Readonly<{
@@ -1491,11 +1705,13 @@ export class NavigatorRepository {
 
   private decisionForProposal(proposalId: string): NavigatorProposalDecision | null {
     const row = this.db.prepare(
-      `SELECT decision.*, step.id AS workflow_step_id, attempt.id AS attempt_id,
-              attempt.effect_idempotency_key
+      `SELECT decision.*, step.id AS workflow_step_id,
+              COALESCE(attempt.id, release_attempt.id) AS attempt_id,
+              COALESCE(attempt.effect_idempotency_key, release_attempt.effect_idempotency_key) AS effect_idempotency_key
          FROM navigator_decisions AS decision
          LEFT JOIN workflow_steps AS step ON step.proposal_id = decision.proposal_id
          LEFT JOIN navigator_skill_attempts AS attempt ON attempt.workflow_step_id = step.id
+         LEFT JOIN navigator_release_attempts AS release_attempt ON release_attempt.workflow_step_id = step.id
         WHERE decision.proposal_id = ?`,
     ).get(proposalId) as {
       snapshot_id: string;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2014,7 +2014,7 @@ export async function createPlugin(bb: BbPluginApi, pluginRoot: string): Promise
     );
     if (assessment.outcome === "pending") return;
     if (assessment.outcome === "pass") {
-      if (latest.routingMode === "active") {
+      if (latest.routingMode === "active" || latest.workflowEngine === "navigator-v1") {
         if (!latest.environmentId || !latest.policy) {
           applyExecutorEvent(job.id, latest.version, { type: "REVIEW_BLOCKED", reason: "configuration" });
           return;

--- a/src/services/effect-runner.ts
+++ b/src/services/effect-runner.ts
@@ -24,7 +24,7 @@ import {
   type NativeAdapterTransition,
   type NativeAdapterTransitionEnvelope,
 } from "../capabilities/native-adapters";
-import { isSmallFixJob, type Job, type JobEffect, type JobEvent, type ProjectPolicy, type ReviewFinding, type StoredEffect, type WorkerLiveness } from "../domain/models";
+import { isSmallFixJob, productionHasRollbackCommand, type Job, type JobEffect, type JobEvent, type ProjectPolicy, type ReviewFinding, type StoredEffect, type WorkerLiveness } from "../domain/models";
 import { resolveConsensusExecution, type PipelineStage } from "../domain/stage-execution";
 import { assessConsensusReview, type ReviewLens } from "../domain/review-lenses";
 import { jobStageExecution } from "../domain/stage-routing";
@@ -1942,54 +1942,45 @@ export class EffectRunner {
       policy: job.policy,
       evidence: { ...evidence, taskAuthority },
     });
-    // A shipped task with no configured production path is not allowed to
-    // silently fall back to a one-use merge approval. That would turn the
-    // owner's exact task grant into a broader release decision.
-    if (
-      liveGrant?.source === "task" &&
-      taskAuthority?.outcome === "shipped_change" &&
-      !job.policy?.production &&
-      job.policy?.autonomy?.mergeWithoutProduction !== true
-    ) {
-      const current = this.dependencies.store.getJob(job.id);
-      if (!current || current.state !== "awaiting_merge_approval" || current.prHeadSha !== job.prHeadSha) return;
-      const boundaryNow = this.now();
-      const affectedEffectIdempotencyKey = `${current.id}:${current.version + 1}:merge_pr`;
-      if (!this.dependencies.store.recordExecutorPolicyBoundaryObservation({
-        jobId: current.id,
-        authorityRevision: taskAuthority.revision,
-        sourceEffectIdempotencyKey: effect.idempotencyKey,
-        affectedEffectIdempotencyKey,
-        ...this.executorFence(),
-      })) throw new Error("executor refused the policy boundary observation");
-      const boundary = this.dependencies.store.recordOwnerBoundary({
-        jobId: current.id,
-        authorityRevision: taskAuthority.revision,
-        code: "policy_change_required",
-        goal: "Complete the owner-requested shipped change",
-        blocker: "No production policy or merge-without-production permission is configured for this project",
-        priorChecks: [
-          "The pull-request head is the exact head that passed the review gate",
-          "The task authority is active for this job at its current revision",
-        ],
-        options: [
-          {
-            label: "Configure production",
-            consequence: "The task can continue through deploy and canary under project policy",
-          },
-          {
-            label: "Allow merge without production",
-            consequence: "The task can merge under its required checks and regression monitoring",
-          },
-        ],
-        recommendation: "Configure production because it preserves the requested shipped outcome",
-        pausedEffect: "The exact-head merge remains paused until this policy decision is recorded",
-        evidenceFacts: ["policy:change-required"],
-        affectedEffectIdempotencyKey,
-        now: boundaryNow,
-      });
-      if (boundary) this.enqueueStatus(current, { ownerBoundary: boundary.digest });
-      return;
+    // A shipped task with no configured production path, or with production and
+    // no rollback, is not allowed to silently fall back to a one-use merge
+    // approval. That would turn the owner's exact task grant into a broader
+    // release decision.
+    if (liveGrant?.source === "task" && taskAuthority?.outcome === "shipped_change") {
+      if (!job.policy?.production && job.policy?.autonomy?.mergeWithoutProduction !== true) {
+        this.pauseShippedTaskForPolicyChange(effect, job, taskAuthority, {
+          blocker: "No production policy or merge-without-production permission is configured for this project",
+          options: [
+            {
+              label: "Configure production",
+              consequence: "The task can continue through deploy and canary under project policy",
+            },
+            {
+              label: "Allow merge without production",
+              consequence: "The task can merge under its required checks and regression monitoring",
+            },
+          ],
+          recommendation: "Configure production because it preserves the requested shipped outcome",
+        });
+        return;
+      }
+      if (job.policy?.production && !productionHasRollbackCommand(job.policy)) {
+        this.pauseShippedTaskForPolicyChange(effect, job, taskAuthority, {
+          blocker: "This project deploys to production with no rollback command, so a failed unattended release cannot be restored",
+          options: [
+            {
+              label: "Configure rollback",
+              consequence: "A failed deploy or canary can restore the previous release under project policy",
+            },
+            {
+              label: "Remove production until rollback exists",
+              consequence: "The task stays paused rather than deploying with no way back",
+            },
+          ],
+          recommendation: "Configure a rollback command because unattended production requires a way back",
+        });
+        return;
+      }
     }
     // The owner already granted this merge in so many words, before the gate
     // was reached. Their word outranks the button: consuming it here is what
@@ -2069,6 +2060,47 @@ export class EffectRunner {
       mergeAuthorityGranted: liveGrant !== null,
       ...(decision.outcome === "ask_owner" ? { approvalReason: decision.reason } : {}),
     });
+  }
+
+  private pauseShippedTaskForPolicyChange(
+    effect: StoredEffect,
+    job: Job,
+    taskAuthority: { revision: number },
+    copy: {
+      blocker: string;
+      options: Array<{ label: string; consequence: string }>;
+      recommendation: string;
+    },
+  ): void {
+    const current = this.dependencies.store.getJob(job.id);
+    if (!current || current.state !== "awaiting_merge_approval" || current.prHeadSha !== job.prHeadSha) return;
+    const boundaryNow = this.now();
+    const affectedEffectIdempotencyKey = `${current.id}:${current.version + 1}:merge_pr`;
+    if (!this.dependencies.store.recordExecutorPolicyBoundaryObservation({
+      jobId: current.id,
+      authorityRevision: taskAuthority.revision,
+      sourceEffectIdempotencyKey: effect.idempotencyKey,
+      affectedEffectIdempotencyKey,
+      ...this.executorFence(),
+    })) throw new Error("executor refused the policy boundary observation");
+    const boundary = this.dependencies.store.recordOwnerBoundary({
+      jobId: current.id,
+      authorityRevision: taskAuthority.revision,
+      code: "policy_change_required",
+      goal: "Complete the owner-requested shipped change",
+      blocker: copy.blocker,
+      priorChecks: [
+        "The pull-request head is the exact head that passed the review gate",
+        "The task authority is active for this job at its current revision",
+      ],
+      options: copy.options,
+      recommendation: copy.recommendation,
+      pausedEffect: "The exact-head merge remains paused until this policy decision is recorded",
+      evidenceFacts: ["policy:change-required"],
+      affectedEffectIdempotencyKey,
+      now: boundaryNow,
+    });
+    if (boundary) this.enqueueStatus(current, { ownerBoundary: boundary.digest });
   }
 
   private acceptTaskMerge(job: Job): void {

--- a/src/services/effect-runner.ts
+++ b/src/services/effect-runner.ts
@@ -60,6 +60,10 @@ import {
   type ProductionPhase,
   type ProductionStageSnapshot,
 } from "./production-runner";
+import {
+  NAVIGATOR_RELEASE_INCIDENT_BUDGET,
+  type NavigatorReleaseRollbackOutcome,
+} from "../navigator/release-contracts";
 
 export class PermanentEffectError extends Error {
   public constructor(message: string) {
@@ -225,6 +229,7 @@ function expectedStates(kind: JobEffect["kind"]): readonly string[] {
     case "steer_implementation": return ["implementing", "remediating"];
     case "run_navigator_skill": return [];
     case "run_navigator_ticket_worker": return [];
+    case "run_navigator_release": return [];
     case "reconcile_job": return [];
     default: {
       const unreachable: never = kind;
@@ -257,6 +262,7 @@ const KNOWN_EFFECT_KINDS = new Set<string>([
   "steer_implementation",
   "run_navigator_skill",
   "run_navigator_ticket_worker",
+  "run_navigator_release",
   "reconcile_job",
 ]);
 
@@ -2122,7 +2128,113 @@ export class EffectRunner {
     return braked ? null : "The failure brake could not be recorded, so this project may still admit new work.";
   }
 
-  private applyProductionResult(job: Job, phase: ProductionPhase, result: ProductionStageSnapshot): void {
+  private classifyProductionRollback(result: ProductionStageSnapshot): NavigatorReleaseRollbackOutcome {
+    if (result.rollback === undefined || result.rollback === null) return "missing";
+    if (result.rollback.outcome === "pass") return "pass";
+    if (result.rollback.outcome === "fail") return "fail";
+    return "indeterminate";
+  }
+
+  private productionFailureSignature(result: ProductionStageSnapshot): string {
+    const signature = result.failedCommand ?? result.summary;
+    return signature.length <= 500 ? signature : signature.slice(0, 500);
+  }
+
+  private recordNavigatorProductionIncident(
+    job: Job,
+    phase: "deploy" | "canary",
+    failureSignature: string,
+    rollbackOutcome: NavigatorReleaseRollbackOutcome,
+  ): void {
+    this.dependencies.store.recordNavigatorReleaseIncident({
+      jobId: job.id,
+      workflowStepId: job.currentWorkflowStepId,
+      phase,
+      failureSignature,
+      rollbackOutcome,
+      now: this.now(),
+    });
+  }
+
+  private recordNavigatorProductionRecoveryBoundary(job: Job, effect: StoredEffect): void {
+    const authority = this.dependencies.store.getTaskAuthority(job.id);
+    const current = this.dependencies.store.getJob(job.id);
+    if (!authority || !current || current.state !== "production_failed") return;
+    const affectedEffectIdempotencyKey = effect.idempotencyKey;
+    if (!this.dependencies.store.recordExecutorProductionRecoveryObservation({
+      jobId: current.id,
+      authorityRevision: authority.revision,
+      sourceEffectIdempotencyKey: effect.idempotencyKey,
+      affectedEffectIdempotencyKey,
+      ...this.executorFence(),
+    })) throw new Error("executor refused the production recovery observation");
+    const boundary = this.dependencies.store.recordOwnerBoundary({
+      jobId: current.id,
+      authorityRevision: authority.revision,
+      code: "production_recovery_required",
+      goal: "Restore production after a failed release",
+      blocker: "Deploy or canary failed and rollback did not restore a known-good release",
+      priorChecks: [
+        "The production stage recorded a failure",
+        "Rollback was missing, failed, indeterminate, or already used for this failure",
+      ],
+      options: [
+        {
+          label: "Repair production",
+          consequence: "Unattended delivery can resume after production is known-good again",
+        },
+        {
+          label: "Pause this project",
+          consequence: "No further unattended work is admitted until you reopen it",
+        },
+      ],
+      recommendation: "Repair production before admitting more unattended work",
+      pausedEffect: "Unattended delivery stays braked until this recovery decision is recorded",
+      evidenceFacts: ["production:failed", "recovery:exhausted"],
+      affectedEffectIdempotencyKey,
+      now: this.now(),
+    });
+    if (boundary) this.enqueueStatus(current, { ownerBoundary: boundary.digest });
+  }
+
+  private failNavigatorProduction(
+    job: Job,
+    effect: StoredEffect,
+    phase: "deploy" | "canary",
+    reason: string,
+    failureSignature: string,
+    rollbackOutcome: NavigatorReleaseRollbackOutcome,
+  ): void {
+    this.recordNavigatorProductionIncident(job, phase, failureSignature, rollbackOutcome);
+    const brakeFailure = job.projectId === null
+      ? null
+      : this.withdrawUnattendedDelivery(
+        job.projectId,
+        rollbackOutcome === "pass"
+          ? `rollback budget exhausted after a bad ${phase}`
+          : rollbackOutcome === "fail"
+            ? `rollback failed after a bad ${phase}`
+            : rollbackOutcome === "indeterminate"
+              ? `production ${phase} outcome is unknown`
+              : `production ${phase} failed with no rollback configured`,
+      );
+    const reported = brakeFailure === null
+      ? reason
+      : `${brakeFailure} ${reason}`.slice(0, MAX_FAILURE_SUMMARY_LENGTH);
+    const current = this.dependencies.store.getJob(job.id);
+    if (!current || current.state !== (phase === "deploy" ? "deploying" : "verifying_production")) return;
+    this.applyEvent(job.id, current.version, phase === "deploy"
+      ? { type: "DEPLOY_FAILED", reason: reported }
+      : { type: "CANARY_FAILED", reason: reported });
+    this.recordNavigatorProductionRecoveryBoundary(current, effect);
+  }
+
+  private applyProductionResult(
+    job: Job,
+    phase: ProductionPhase,
+    result: ProductionStageSnapshot,
+    effect: StoredEffect,
+  ): void {
     const expectedState = phase === "deploy" ? "deploying" : "verifying_production";
     const current = this.dependencies.store.getJob(job.id);
     if (!current || current.state !== expectedState) return;
@@ -2130,6 +2242,34 @@ export class EffectRunner {
       this.applyEvent(job.id, current.version, phase === "deploy"
         ? { type: "DEPLOY_SUCCEEDED", summary: result.summary }
         : { type: "CANARY_SUCCEEDED", summary: result.summary });
+      return;
+    }
+    const rollbackOutcome = this.classifyProductionRollback(result);
+    const failureSignature = this.productionFailureSignature(result);
+    if (current.workflowEngine === "navigator-v1") {
+      const priorPassCount = this.dependencies.store.countNavigatorReleaseIncidents({
+        jobId: current.id,
+        phase,
+        failureSignature,
+        rollbackOutcome: "pass",
+      });
+      if (rollbackOutcome === "pass" && priorPassCount < NAVIGATOR_RELEASE_INCIDENT_BUDGET) {
+        this.recordNavigatorProductionIncident(current, phase, failureSignature, "pass");
+        this.applyEvent(job.id, current.version, {
+          type: "PRODUCTION_INCIDENT_RECOVERED",
+          phase,
+          reason: result.summary,
+        });
+        return;
+      }
+      this.failNavigatorProduction(
+        current,
+        effect,
+        phase,
+        result.summary,
+        failureSignature,
+        rollbackOutcome,
+      );
       return;
     }
     // A rollback that worked is a recovery: production is back, so unattended
@@ -2187,7 +2327,7 @@ export class EffectRunner {
       if (!productionReceiptCountIsValid(outcome, expectedReceiptCount)) {
         throw new PermanentEffectError("completed production stage receipt count is invalid");
       }
-      this.applyProductionResult(job, phase, outcome);
+      this.applyProductionResult(job, phase, outcome, effect);
       return;
     }
     if (effect.attempts > 1) {
@@ -2201,9 +2341,20 @@ export class EffectRunner {
       })) throw new Error("executor lease was lost before production failure persistence");
       const current = this.dependencies.store.getJob(job.id);
       if (current?.state === (phase === "deploy" ? "deploying" : "verifying_production")) {
-        this.applyEvent(job.id, current.version, phase === "deploy"
-          ? { type: "DEPLOY_FAILED", reason }
-          : { type: "CANARY_FAILED", reason });
+        if (current.workflowEngine === "navigator-v1") {
+          this.failNavigatorProduction(
+            current,
+            effect,
+            phase,
+            reason,
+            reason.slice(0, 500),
+            "indeterminate",
+          );
+        } else {
+          this.applyEvent(job.id, current.version, phase === "deploy"
+            ? { type: "DEPLOY_FAILED", reason }
+            : { type: "CANARY_FAILED", reason });
+        }
       }
       return;
     }
@@ -2280,7 +2431,7 @@ export class EffectRunner {
     });
     if (!completed) throw new Error("production stage completion lost its executor fence");
     this.assertFence();
-    this.applyProductionResult(job, phase, result);
+    this.applyProductionResult(job, phase, result, effect);
   }
 
   private async stopThread(effect: StoredEffect, job: Job): Promise<void> {
@@ -2575,6 +2726,8 @@ export class EffectRunner {
         throw new PermanentEffectError("navigator skill effects require the navigator executor");
       case "run_navigator_ticket_worker":
         throw new PermanentEffectError("navigator ticket effects require the navigator implementation executor");
+      case "run_navigator_release":
+        throw new PermanentEffectError("navigator release effects require the navigator release executor");
       case "reconcile_job":
         await this.reconcile(effect, job);
         return;

--- a/src/services/job-executor-service.ts
+++ b/src/services/job-executor-service.ts
@@ -74,6 +74,10 @@ export type JobExecutorDependencies = {
   navigatorImplementation?: {
     processOne(fence: EffectFence, signal: AbortSignal): Promise<boolean>;
   };
+  /** Deterministic navigator-v1 exact-head release work. */
+  navigatorRelease?: {
+    processOne(fence: EffectFence, signal: AbortSignal): Promise<boolean>;
+  };
   monitors?: {
     processDue(): Promise<boolean>;
     processDueDelegations(): Promise<boolean>;
@@ -937,6 +941,9 @@ export async function runJobExecutorService(deps: JobExecutorDependencies, signa
         }
         if (deps.navigatorImplementation) {
           didWork = await deps.navigatorImplementation.processOne(effectFence, workAbort.signal) || didWork;
+        }
+        if (deps.navigatorRelease) {
+          didWork = await deps.navigatorRelease.processOne(effectFence, workAbort.signal) || didWork;
         }
         if (deps.monitors) {
           didWork = await deps.monitors.processDue() || didWork;

--- a/src/services/merge-authority.ts
+++ b/src/services/merge-authority.ts
@@ -1,4 +1,4 @@
-import type { Job, ProjectPolicy } from "../domain/models";
+import { productionHasRollbackCommand, type Job, type ProjectPolicy } from "../domain/models";
 import { taskAuthorityAllowsEffect, type TaskConstraint, type TaskOutcome } from "../domain/task-authority";
 
 type TaskAuthorityEvidence = Readonly<{
@@ -183,6 +183,9 @@ export function decideAutoApproval(input: {
   // change, an unattended merge would be shipping into silence.
   if (!job.policy?.production && job.policy?.autonomy?.mergeWithoutProduction !== true) {
     return { outcome: "ask_owner", reason: "the project has no production configuration" };
+  }
+  if (job.policy?.production && !productionHasRollbackCommand(job.policy)) {
+    return { outcome: "ask_owner", reason: "the project has no production rollback command" };
   }
   if (job.reviewCycle >= REMEDIATION_ASK_THRESHOLD) {
     return decideRemediatedChange(job, input.consensus, live.source === "task");

--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -3954,6 +3954,156 @@ WHEN EXISTS (
 BEGIN SELECT RAISE(ABORT, 'policy observation lacks a live executor fence'); END;
 `] as const;
 
+export const NAVIGATOR_RELEASE_MIGRATIONS = [String.raw`
+CREATE TABLE navigator_release_attempts (
+  id TEXT PRIMARY KEY,
+  job_id TEXT NOT NULL REFERENCES jobs(id),
+  workflow_step_id TEXT NOT NULL UNIQUE REFERENCES workflow_steps(id),
+  effect_idempotency_key TEXT NOT NULL UNIQUE REFERENCES effects(idempotency_key),
+  implementation_ticket_ids_json TEXT NOT NULL CHECK (json_valid(implementation_ticket_ids_json)),
+  snapshot_digest TEXT NOT NULL CHECK (length(snapshot_digest) = 64),
+  job_version INTEGER NOT NULL CHECK (job_version >= 0),
+  workflow_revision INTEGER NOT NULL CHECK (workflow_revision >= 1),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE TRIGGER navigator_release_attempts_append_only_delete
+BEFORE DELETE ON navigator_release_attempts
+BEGIN SELECT RAISE(ABORT, 'navigator release attempts cannot be deleted'); END;
+
+CREATE TABLE navigator_release_outcomes (
+  attempt_id TEXT PRIMARY KEY REFERENCES navigator_release_attempts(id),
+  outcome TEXT NOT NULL CHECK (outcome IN ('entered_release', 'returned_to_navigation', 'completed', 'recovery_required')),
+  reason_code TEXT NOT NULL CHECK (length(reason_code) BETWEEN 1 AND 128),
+  recorded_at INTEGER NOT NULL
+);
+CREATE TRIGGER navigator_release_outcomes_append_only_update
+BEFORE UPDATE ON navigator_release_outcomes
+BEGIN SELECT RAISE(ABORT, 'navigator release outcomes are append-only'); END;
+CREATE TRIGGER navigator_release_outcomes_append_only_delete
+BEFORE DELETE ON navigator_release_outcomes
+BEGIN SELECT RAISE(ABORT, 'navigator release outcomes are append-only'); END;
+
+CREATE TABLE navigator_release_findings (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  job_id TEXT NOT NULL REFERENCES jobs(id),
+  workflow_step_id TEXT REFERENCES workflow_steps(id),
+  reason_code TEXT NOT NULL CHECK (length(reason_code) BETWEEN 1 AND 128),
+  previous_state TEXT NOT NULL CHECK (length(previous_state) BETWEEN 1 AND 64),
+  recorded_at INTEGER NOT NULL
+);
+CREATE TRIGGER navigator_release_findings_append_only_update
+BEFORE UPDATE ON navigator_release_findings
+BEGIN SELECT RAISE(ABORT, 'navigator release findings are append-only'); END;
+CREATE TRIGGER navigator_release_findings_append_only_delete
+BEFORE DELETE ON navigator_release_findings
+BEGIN SELECT RAISE(ABORT, 'navigator release findings are append-only'); END;
+
+CREATE TABLE navigator_release_incidents (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  job_id TEXT NOT NULL REFERENCES jobs(id),
+  workflow_step_id TEXT REFERENCES workflow_steps(id),
+  phase TEXT NOT NULL CHECK (phase IN ('deploy', 'canary')),
+  failure_signature TEXT NOT NULL CHECK (length(failure_signature) BETWEEN 1 AND 500),
+  rollback_outcome TEXT NOT NULL CHECK (rollback_outcome IN ('pass', 'fail', 'missing', 'indeterminate')),
+  recorded_at INTEGER NOT NULL
+);
+CREATE TRIGGER navigator_release_incidents_append_only_update
+BEFORE UPDATE ON navigator_release_incidents
+BEGIN SELECT RAISE(ABORT, 'navigator release incidents are append-only'); END;
+CREATE TRIGGER navigator_release_incidents_append_only_delete
+BEFORE DELETE ON navigator_release_incidents
+BEGIN SELECT RAISE(ABORT, 'navigator release incidents are append-only'); END;
+
+CREATE TABLE production_recovery_observations (
+  observation_id TEXT PRIMARY KEY,
+  job_id TEXT NOT NULL REFERENCES jobs(id),
+  authority_id TEXT NOT NULL,
+  authority_revision INTEGER NOT NULL CHECK (authority_revision >= 1),
+  artifact_graph_digest TEXT NOT NULL CHECK (length(artifact_graph_digest) = 64),
+  policy_digest TEXT NOT NULL CHECK (length(policy_digest) = 64),
+  source_effect_idempotency_key TEXT NOT NULL REFERENCES effects(idempotency_key),
+  affected_effect_idempotency_key TEXT NOT NULL,
+  observed_job_version INTEGER NOT NULL CHECK (observed_job_version >= 0),
+  observed_at INTEGER NOT NULL,
+  UNIQUE(job_id, authority_revision, affected_effect_idempotency_key),
+  FOREIGN KEY (authority_id, authority_revision)
+    REFERENCES task_authority_revisions(authority_id, revision)
+);
+CREATE TRIGGER production_recovery_observations_append_only_update
+BEFORE UPDATE ON production_recovery_observations
+BEGIN SELECT RAISE(ABORT, 'production recovery observations are append-only'); END;
+CREATE TRIGGER production_recovery_observations_append_only_delete
+BEFORE DELETE ON production_recovery_observations
+BEGIN SELECT RAISE(ABORT, 'production recovery observations are append-only'); END;
+
+DROP TRIGGER IF EXISTS owner_boundaries_require_authoritative_source;
+CREATE TRIGGER owner_boundaries_require_authoritative_source
+BEFORE INSERT ON owner_boundaries
+WHEN NOT (
+  (
+    NEW.code = 'policy_change_required' AND EXISTS (
+      SELECT 1
+        FROM policy_boundary_observations AS observation
+        JOIN task_authority_current AS current
+          ON current.job_id = observation.job_id
+         AND current.authority_id = observation.authority_id
+         AND current.revision = observation.authority_revision
+        JOIN task_authority_revisions AS revision
+          ON revision.authority_id = observation.authority_id
+         AND revision.revision = observation.authority_revision
+        JOIN jobs AS job ON job.id = observation.job_id
+        JOIN effects AS source_effect
+          ON source_effect.idempotency_key = observation.source_effect_idempotency_key
+         AND source_effect.job_id = observation.job_id
+       WHERE observation.job_id = NEW.job_id
+         AND observation.authority_id = NEW.authority_id
+         AND observation.authority_revision = NEW.authority_revision
+         AND observation.affected_effect_idempotency_key = NEW.affected_effect_idempotency_key
+         AND NEW.affected_artifact_id IS NULL
+         AND revision.status = 'active'
+         AND revision.task_outcome = 'shipped_change'
+         AND revision.artifact_graph_digest = observation.artifact_graph_digest
+         AND revision.policy_digest = observation.policy_digest
+         AND job.version = observation.observed_job_version
+         AND job.state = 'awaiting_merge_approval'
+         AND json_extract(job.policy_json, '$.production') IS NULL
+         AND COALESCE(json_extract(job.policy_json, '$.autonomy.mergeWithoutProduction'), 0) <> 1
+         AND source_effect.kind = 'issue_approval'
+    )
+  ) OR (
+    NEW.code = 'production_recovery_required' AND EXISTS (
+      SELECT 1
+        FROM production_recovery_observations AS observation
+        JOIN task_authority_current AS current
+          ON current.job_id = observation.job_id
+         AND current.authority_id = observation.authority_id
+         AND current.revision = observation.authority_revision
+        JOIN task_authority_revisions AS revision
+          ON revision.authority_id = observation.authority_id
+         AND revision.revision = observation.authority_revision
+        JOIN jobs AS job ON job.id = observation.job_id
+        JOIN effects AS source_effect
+          ON source_effect.idempotency_key = observation.source_effect_idempotency_key
+         AND source_effect.job_id = observation.job_id
+       WHERE observation.job_id = NEW.job_id
+         AND observation.authority_id = NEW.authority_id
+         AND observation.authority_revision = NEW.authority_revision
+         AND observation.affected_effect_idempotency_key = NEW.affected_effect_idempotency_key
+         AND NEW.affected_artifact_id IS NULL
+         AND revision.status = 'suspended'
+         AND revision.task_outcome = 'shipped_change'
+         AND revision.artifact_graph_digest = observation.artifact_graph_digest
+         AND revision.policy_digest = observation.policy_digest
+         AND job.version = observation.observed_job_version
+         AND job.state = 'production_failed'
+         AND source_effect.kind IN ('deploy_production', 'verify_production')
+    )
+  )
+)
+BEGIN SELECT RAISE(ABORT, 'owner boundary lacks an exact authoritative source'); END;
+`] as const;
+
 export const ALL_MIGRATIONS = [
   ...INITIAL_MIGRATIONS,
   ...UPDATE_CLAIM_MIGRATIONS,
@@ -4043,4 +4193,5 @@ export const ALL_MIGRATIONS = [
   ...TASK_AUTHORITY_PUBLISH_MIGRATIONS,
   ...OWNER_BOUNDARY_SOURCE_MIGRATIONS,
   ...POLICY_APPROVAL_INTENT_MIGRATIONS,
+  ...NAVIGATOR_RELEASE_MIGRATIONS,
 ] as const;

--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -4102,6 +4102,79 @@ WHEN NOT (
   )
 )
 BEGIN SELECT RAISE(ABORT, 'owner boundary lacks an exact authoritative source'); END;
+`, String.raw`
+DROP TRIGGER IF EXISTS owner_boundaries_require_authoritative_source;
+CREATE TRIGGER owner_boundaries_require_authoritative_source
+BEFORE INSERT ON owner_boundaries
+WHEN NOT (
+  (
+    NEW.code = 'policy_change_required' AND EXISTS (
+      SELECT 1
+        FROM policy_boundary_observations AS observation
+        JOIN task_authority_current AS current
+          ON current.job_id = observation.job_id
+         AND current.authority_id = observation.authority_id
+         AND current.revision = observation.authority_revision
+        JOIN task_authority_revisions AS revision
+          ON revision.authority_id = observation.authority_id
+         AND revision.revision = observation.authority_revision
+        JOIN jobs AS job ON job.id = observation.job_id
+        JOIN effects AS source_effect
+          ON source_effect.idempotency_key = observation.source_effect_idempotency_key
+         AND source_effect.job_id = observation.job_id
+       WHERE observation.job_id = NEW.job_id
+         AND observation.authority_id = NEW.authority_id
+         AND observation.authority_revision = NEW.authority_revision
+         AND observation.affected_effect_idempotency_key = NEW.affected_effect_idempotency_key
+         AND NEW.affected_artifact_id IS NULL
+         AND revision.status = 'active'
+         AND revision.task_outcome = 'shipped_change'
+         AND revision.artifact_graph_digest = observation.artifact_graph_digest
+         AND revision.policy_digest = observation.policy_digest
+         AND job.version = observation.observed_job_version
+         AND job.state = 'awaiting_merge_approval'
+         AND (
+           (
+             json_extract(job.policy_json, '$.production') IS NULL
+             AND COALESCE(json_extract(job.policy_json, '$.autonomy.mergeWithoutProduction'), 0) <> 1
+           ) OR (
+             json_extract(job.policy_json, '$.production') IS NOT NULL
+             AND json_extract(job.policy_json, '$.production.rollbackCommand') IS NULL
+           )
+         )
+         AND source_effect.kind = 'issue_approval'
+    )
+  ) OR (
+    NEW.code = 'production_recovery_required' AND EXISTS (
+      SELECT 1
+        FROM production_recovery_observations AS observation
+        JOIN task_authority_current AS current
+          ON current.job_id = observation.job_id
+         AND current.authority_id = observation.authority_id
+         AND current.revision = observation.authority_revision
+        JOIN task_authority_revisions AS revision
+          ON revision.authority_id = observation.authority_id
+         AND revision.revision = observation.authority_revision
+        JOIN jobs AS job ON job.id = observation.job_id
+        JOIN effects AS source_effect
+          ON source_effect.idempotency_key = observation.source_effect_idempotency_key
+         AND source_effect.job_id = observation.job_id
+       WHERE observation.job_id = NEW.job_id
+         AND observation.authority_id = NEW.authority_id
+         AND observation.authority_revision = NEW.authority_revision
+         AND observation.affected_effect_idempotency_key = NEW.affected_effect_idempotency_key
+         AND NEW.affected_artifact_id IS NULL
+         AND revision.status = 'suspended'
+         AND revision.task_outcome = 'shipped_change'
+         AND revision.artifact_graph_digest = observation.artifact_graph_digest
+         AND revision.policy_digest = observation.policy_digest
+         AND job.version = observation.observed_job_version
+         AND job.state = 'production_failed'
+         AND source_effect.kind IN ('deploy_production', 'verify_production')
+    )
+  )
+)
+BEGIN SELECT RAISE(ABORT, 'owner boundary lacks an exact authoritative source'); END;
 `] as const;
 
 export const ALL_MIGRATIONS = [

--- a/src/storage/owner-boundary-repository.ts
+++ b/src/storage/owner-boundary-repository.ts
@@ -290,6 +290,36 @@ function policySource(db: SqliteDatabase, input: CreateOwnerBoundaryInput): bool
   ).get(input.jobId, input.authorityId, input.authorityRevision, input.affectedEffectIdempotencyKey) !== undefined;
 }
 
+function productionRecoverySource(db: SqliteDatabase, input: CreateOwnerBoundaryInput): boolean {
+  if (!input.affectedEffectIdempotencyKey) return false;
+  return db.prepare(
+    `SELECT 1
+       FROM production_recovery_observations AS observation
+       JOIN task_authority_current AS current
+         ON current.job_id = observation.job_id
+        AND current.authority_id = observation.authority_id
+        AND current.revision = observation.authority_revision
+       JOIN task_authority_revisions AS revision
+         ON revision.authority_id = observation.authority_id
+        AND revision.revision = observation.authority_revision
+       JOIN jobs AS job ON job.id = observation.job_id
+       JOIN effects AS source_effect
+         ON source_effect.idempotency_key = observation.source_effect_idempotency_key
+        AND source_effect.job_id = observation.job_id
+      WHERE observation.job_id = ?
+        AND observation.authority_id = ?
+        AND observation.authority_revision = ?
+        AND observation.affected_effect_idempotency_key = ?
+        AND revision.status = 'suspended' AND revision.task_outcome = 'shipped_change'
+        AND revision.artifact_graph_digest = observation.artifact_graph_digest
+        AND revision.policy_digest = observation.policy_digest
+        AND job.version = observation.observed_job_version
+        AND job.state = 'production_failed'
+        AND source_effect.kind IN ('deploy_production', 'verify_production')
+     LIMIT 1`,
+  ).get(input.jobId, input.authorityId, input.authorityRevision, input.affectedEffectIdempotencyKey) !== undefined;
+}
+
 const unavailableSource: BoundarySourceValidator = () => false;
 
 const BOUNDARY_SOURCE_VALIDATORS = {
@@ -300,7 +330,7 @@ const BOUNDARY_SOURCE_VALIDATORS = {
   irreversible_effect_required: unavailableSource,
   policy_change_required: policySource,
   technical_tradeoff_required: unavailableSource,
-  production_recovery_required: unavailableSource,
+  production_recovery_required: productionRecoverySource,
 } satisfies Record<OwnerBoundaryCode, BoundarySourceValidator>;
 
 function durableBoundaryFacts(db: SqliteDatabase, input: CreateOwnerBoundaryInput): readonly string[] {

--- a/src/storage/owner-boundary-repository.ts
+++ b/src/storage/owner-boundary-repository.ts
@@ -283,8 +283,15 @@ function policySource(db: SqliteDatabase, input: CreateOwnerBoundaryInput): bool
         AND revision.policy_digest = observation.policy_digest
         AND job.version = observation.observed_job_version
         AND job.state = 'awaiting_merge_approval'
-        AND json_extract(job.policy_json, '$.production') IS NULL
-        AND COALESCE(json_extract(job.policy_json, '$.autonomy.mergeWithoutProduction'), 0) <> 1
+        AND (
+          (
+            json_extract(job.policy_json, '$.production') IS NULL
+            AND COALESCE(json_extract(job.policy_json, '$.autonomy.mergeWithoutProduction'), 0) <> 1
+          ) OR (
+            json_extract(job.policy_json, '$.production') IS NOT NULL
+            AND json_extract(job.policy_json, '$.production.rollbackCommand') IS NULL
+          )
+        )
         AND source_effect.kind = 'issue_approval'
      LIMIT 1`,
   ).get(input.jobId, input.authorityId, input.authorityRevision, input.affectedEffectIdempotencyKey) !== undefined;

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -307,6 +307,12 @@ import type {
   NavigatorWorkflowStepOutcome,
   WorkflowMode,
 } from "../navigator/models";
+import {
+  NAVIGATOR_RELEASE_STATES,
+  type NavigatorReleaseAttempt,
+  type NavigatorReleaseIncidentPhase,
+  type NavigatorReleaseRollbackOutcome,
+} from "../navigator/release-contracts";
 
 /**
  * A tapped controller button. `replayed` is a Telegram redelivery of a callback
@@ -1515,6 +1521,7 @@ const TASK_AUTHORITY_EFFECT_REQUIREMENTS: Readonly<Record<JobEffect["kind"], rea
   steer_implementation: ["worktree_write", "commit", "push", "pull_request"],
   run_navigator_skill: ["artifact_write"],
   run_navigator_ticket_worker: ["worktree_write", "commit", "push", "pull_request"],
+  run_navigator_release: ["commit", "push", "pull_request"],
   reconcile_job: ["read"],
 };
 
@@ -1566,6 +1573,7 @@ const FENCED_JOB_EVENT_TYPES: ReadonlySet<JobEvent["type"]> = new Set([
   "DEPLOY_FAILED",
   "CANARY_SUCCEEDED",
   "CANARY_FAILED",
+  "PRODUCTION_INCIDENT_RECOVERED",
   "WORKER_RECOVERY_REQUESTED",
   "WORKER_RECOVERY_REQUEUED",
 ]);
@@ -3926,6 +3934,28 @@ export interface TelegramAgentStore {
     now: number;
     leaseMs: number;
   }): StoredEffect | null;
+  leaseNavigatorReleaseEffect(input: {
+    ownerId: string;
+    generation: number;
+    now: number;
+    leaseMs: number;
+  }): StoredEffect | null;
+  getNavigatorReleaseAttempt(id: string): NavigatorReleaseAttempt | null;
+  recordNavigatorReleaseIncident(input: {
+    jobId: string;
+    workflowStepId: string | null;
+    phase: NavigatorReleaseIncidentPhase;
+    failureSignature: string;
+    rollbackOutcome: NavigatorReleaseRollbackOutcome;
+    now: number;
+  }): void;
+  countNavigatorReleaseIncidents(input: {
+    jobId: string;
+    phase: NavigatorReleaseIncidentPhase;
+    failureSignature: string;
+    rollbackOutcome?: NavigatorReleaseRollbackOutcome;
+  }): number;
+  recordExecutorProductionRecoveryObservation(input: PolicyBoundaryObservationInput): boolean;
   bindNavigatorSkillAttemptResource(input: {
     attemptId: string;
     effectIdempotencyKey: string;
@@ -12414,6 +12444,66 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
     return this.navigatorRepository.leaseSkillEffect(input);
   }
 
+  public leaseNavigatorReleaseEffect(input: {
+    ownerId: string;
+    generation: number;
+    now: number;
+    leaseMs: number;
+  }): StoredEffect | null {
+    return this.navigatorRepository.leaseReleaseEffect(input);
+  }
+
+  public getNavigatorReleaseAttempt(id: string): NavigatorReleaseAttempt | null {
+    return this.navigatorRepository.getReleaseAttempt(id);
+  }
+
+  public recordNavigatorReleaseIncident(input: {
+    jobId: string;
+    workflowStepId: string | null;
+    phase: NavigatorReleaseIncidentPhase;
+    failureSignature: string;
+    rollbackOutcome: NavigatorReleaseRollbackOutcome;
+    now: number;
+  }): void {
+    assertControllerIdentifier(input.jobId, "release incident job id");
+    if (input.workflowStepId !== null) assertControllerIdentifier(input.workflowStepId, "release incident step");
+    if (typeof input.failureSignature !== "string" || input.failureSignature.length === 0 || input.failureSignature.length > 500) {
+      throw new TypeError("release incident signature must be a bounded non-empty string");
+    }
+    assertNonNegativeInteger(input.now, "now");
+    this.db.prepare(
+      `INSERT INTO navigator_release_incidents (
+         job_id, workflow_step_id, phase, failure_signature, rollback_outcome, recorded_at
+       ) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      input.jobId,
+      input.workflowStepId,
+      input.phase,
+      input.failureSignature,
+      input.rollbackOutcome,
+      input.now,
+    );
+  }
+
+  public countNavigatorReleaseIncidents(input: {
+    jobId: string;
+    phase: NavigatorReleaseIncidentPhase;
+    failureSignature: string;
+    rollbackOutcome?: NavigatorReleaseRollbackOutcome;
+  }): number {
+    assertControllerIdentifier(input.jobId, "release incident job id");
+    const row = input.rollbackOutcome === undefined
+      ? this.db.prepare(
+        `SELECT COUNT(*) AS count FROM navigator_release_incidents
+          WHERE job_id = ? AND phase = ? AND failure_signature = ?`,
+      ).get(input.jobId, input.phase, input.failureSignature) as { count: number }
+      : this.db.prepare(
+        `SELECT COUNT(*) AS count FROM navigator_release_incidents
+          WHERE job_id = ? AND phase = ? AND failure_signature = ? AND rollback_outcome = ?`,
+      ).get(input.jobId, input.phase, input.failureSignature, input.rollbackOutcome) as { count: number };
+    return row.count;
+  }
+
   public bindNavigatorSkillAttemptResource(input: {
     attemptId: string;
     effectIdempotencyKey: string;
@@ -13094,6 +13184,63 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
     }).immediate();
   }
 
+  public recordExecutorProductionRecoveryObservation(input: PolicyBoundaryObservationInput): boolean {
+    this.assertExecutorFence(input);
+    assertControllerIdentifier(input.jobId, "production recovery job id");
+    assertControllerIdentifier(input.sourceEffectIdempotencyKey, "production recovery source effect");
+    assertControllerIdentifier(input.affectedEffectIdempotencyKey, "production recovery affected effect");
+    assertPositiveInteger(input.authorityRevision, "authorityRevision");
+    return this.db.transaction((): boolean => {
+      if (!this.executorLeaseIsCurrent(input.ownerId, input.generation, input.now)) return false;
+      const job = this.readJobById(input.jobId);
+      const authority = this.taskAuthorityRepository.get(input.jobId);
+      const sourceEffect = this.getEffect(input.jobId, input.sourceEffectIdempotencyKey);
+      if (
+        !job || !authority || !sourceEffect ||
+        authority.revision !== input.authorityRevision ||
+        authority.status !== "suspended" ||
+        authority.outcome !== "shipped_change" ||
+        job.state !== "production_failed" ||
+        (sourceEffect.kind !== "deploy_production" && sourceEffect.kind !== "verify_production") ||
+        sourceEffect.status !== "leased" ||
+        sourceEffect.leaseOwner !== input.ownerId ||
+        sourceEffect.leaseGeneration !== input.generation ||
+        sourceEffect.leaseExpiresAt === null ||
+        sourceEffect.leaseExpiresAt <= input.now ||
+        input.affectedEffectIdempotencyKey !== sourceEffect.idempotencyKey
+      ) return false;
+      const identity = [
+        job.id,
+        authority.authorityId,
+        String(authority.revision),
+        input.sourceEffectIdempotencyKey,
+        input.affectedEffectIdempotencyKey,
+      ].join("\u0000");
+      const observationId = `production_recovery_${createHash("sha256").update(identity, "utf8").digest("hex").slice(0, 32)}`;
+      this.db.prepare(
+        `INSERT OR IGNORE INTO production_recovery_observations (
+           observation_id, job_id, authority_id, authority_revision, artifact_graph_digest, policy_digest,
+           source_effect_idempotency_key, affected_effect_idempotency_key, observed_job_version, observed_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        observationId,
+        job.id,
+        authority.authorityId,
+        authority.revision,
+        authority.artifactGraphDigest,
+        authority.policyDigest,
+        input.sourceEffectIdempotencyKey,
+        input.affectedEffectIdempotencyKey,
+        job.version,
+        input.now,
+      );
+      return this.db.prepare(
+        `SELECT 1 FROM production_recovery_observations
+          WHERE observation_id = ? AND source_effect_idempotency_key = ?`,
+      ).get(observationId, input.sourceEffectIdempotencyKey) !== undefined;
+    }).immediate();
+  }
+
   public recordOwnerBoundary(
     input: OwnerBoundaryDraft & { jobId: string; authorityRevision: number; now: number },
   ): OwnerBoundaryRecord | null {
@@ -13259,6 +13406,7 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
       const transitioned = transition(current, event, now);
       persistJobTransition(this.db, jobId, expectedVersion, transitioned.job);
       persistPendingEffects(this.db, transitioned.effects, now);
+      this.settleNavigatorReleaseReturn(current, transitioned.job, event, now);
       if (current.prHeadSha !== transitioned.job.prHeadSha) {
         this.releaseAuthorityRepository.revokeForJob(jobId, "head_changed", now);
         this.ownerBoundaryRepository.revokeForJob(jobId, "head_changed", now);
@@ -13329,6 +13477,7 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
       if (terminalProductionState && productionClaimId === null) return null;
       persistJobTransition(this.db, input.jobId, input.expectedVersion, transitioned.job);
       persistPendingEffects(this.db, transitioned.effects, input.now);
+      this.settleNavigatorReleaseReturn(current, transitioned.job, input.event, input.now);
       if (current.prHeadSha !== transitioned.job.prHeadSha) {
         this.releaseAuthorityRepository.revokeForJob(input.jobId, "head_changed", input.now);
         this.ownerBoundaryRepository.revokeForJob(input.jobId, "head_changed", input.now);
@@ -14361,6 +14510,11 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
       for (const row of rows) {
         const effect = this.bindPolicyApprovalIntent(parseEffect(row), input.now);
         if (!effect) continue;
+        if (
+          effect.kind === "run_navigator_skill" ||
+          effect.kind === "run_navigator_ticket_worker" ||
+          effect.kind === "run_navigator_release"
+        ) continue;
         if (!admissionAllowsEffect(admission, effect, worker)) continue;
         const authorityEffects = taskAuthorityEffectsForJobEffect(effect);
         if (authorityEffects === null || authorityEffects.length === 0 || !authorityEffects.every((authorityEffect) => this.taskAuthorityRepository.admitEffect(
@@ -17126,6 +17280,54 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
   private markAdmissionDrainingForTerminal(job: Job, now: number): void {
     if (!isReleaseCandidate(job.state)) return;
     this.autonomyRepository.markDrainingInTransaction(job.id, now);
+  }
+
+  private settleNavigatorReleaseReturn(previous: Job, next: Job, event: JobEvent, now: number): void {
+    if (previous.workflowEngine !== "navigator-v1") return;
+    if (!(NAVIGATOR_RELEASE_STATES as readonly string[]).includes(previous.state)) return;
+    const returnedToNavigation = next.state === "implementing";
+    const releaseFinished = next.state === "complete" || next.state === "merged" || next.state === "production_failed";
+    if (!returnedToNavigation && !releaseFinished) return;
+    this.db.prepare(
+      `UPDATE jobs SET current_workflow_step_id = NULL, workflow_revision = workflow_revision + 1
+        WHERE id = ?`,
+    ).run(next.id);
+    next.currentWorkflowStepId = null;
+    next.workflowRevision += 1;
+    if (!returnedToNavigation) return;
+    const reasonCode = event.type === "VALIDATION_FAILED"
+      ? "validation_failed"
+      : event.type === "REVIEW_CHANGES_REQUESTED"
+        ? "review_changes_requested"
+        : event.type === "REVIEW_PASSED"
+          ? "documentation_required"
+          : event.type === "PRODUCTION_INCIDENT_RECOVERED"
+            ? "production_incident_recovered"
+            : "release_findings";
+    this.db.prepare(
+      `INSERT INTO navigator_release_findings (
+         job_id, workflow_step_id, reason_code, previous_state, recorded_at
+       ) VALUES (?, ?, ?, ?, ?)`,
+    ).run(next.id, previous.currentWorkflowStepId, reasonCode, previous.state, now);
+    if (event.type !== "PRODUCTION_INCIDENT_RECOVERED") return;
+    const owner = this.getOwner();
+    if (owner === null) return;
+    const phase = event.phase === "canary" ? "canary" : "deploy";
+    const text = phase === "canary"
+      ? "Production canary failed. The configured rollback restored the previous release. No action is required."
+      : "Production deploy failed. The configured rollback restored the previous release. No action is required.";
+    const item: OutboxInput = {
+      logicalKey: `job:${next.id}:production-incident`,
+      chatId: owner.chatId,
+      payload: { text, disable_web_page_preview: true },
+    };
+    const payloadJson = serializeOutbox(item, now);
+    this.db.prepare(
+      `INSERT OR IGNORE INTO outbox (
+         logical_key, chat_id, message_id, payload_json, status, attempts,
+         next_attempt_at, created_at, updated_at
+       ) VALUES (?, ?, NULL, ?, 'pending', 0, ?, ?, ?)`,
+    ).run(item.logicalKey, item.chatId, payloadJson, now, now, now);
   }
 
   private enqueueFinishNoteInTransaction(previous: Job, completed: Job, now: number): void {

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -6,6 +6,7 @@ import {
   isResumableConfigurationBlock,
   isReviewedPrCompletionBlock,
   PRODUCTION_NOT_CONFIGURED,
+  productionHasRollbackCommand,
   projectPolicySchema,
   type AutonomousJobOrigin,
   type Job,
@@ -5364,13 +5365,19 @@ function authoritySupportsPolicyBoundary(
     authority.outcome === "shipped_change";
 }
 
+function policyRequiresShippedTaskBoundary(policy: ProjectPolicy | null | undefined): boolean {
+  if (policy == null) return false;
+  if (policy.production === undefined) return policy.autonomy?.mergeWithoutProduction !== true;
+  return !productionHasRollbackCommand(policy);
+}
+
 function jobNeedsPolicyBoundary(
   job: Job,
   authority: TaskAuthority,
   affectedEffectIdempotencyKey: string,
 ): boolean {
   return job.state === "awaiting_merge_approval" && job.policy !== null &&
-    job.policy.production === undefined && job.policy.autonomy?.mergeWithoutProduction !== true &&
+    policyRequiresShippedTaskBoundary(job.policy) &&
     taskPolicyDigest(JSON.stringify(job.policy)) === authority.policyDigest &&
     affectedEffectIdempotencyKey === `${job.id}:${job.version + 1}:merge_pr`;
 }
@@ -12939,8 +12946,8 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
     if (effect.kind !== "issue_approval") return effect;
     const job = this.readJobById(effect.jobId);
     const authority = this.taskAuthorityRepository.get(effect.jobId);
-    if (!job || !authority || authority.outcome !== "shipped_change" || job.policy?.production ||
-      job.policy?.autonomy?.mergeWithoutProduction === true) return effect;
+    if (!job || !authority || authority.outcome !== "shipped_change" ||
+      !policyRequiresShippedTaskBoundary(job.policy)) return effect;
     const payload = policyApprovalIntentForLease(effect, job, authority);
     if (!payload) return null;
     if (policyApprovalIntentMatches(effect.payload, job, authority, `${job.id}:${job.version + 1}:merge_pr`)) {
@@ -17317,7 +17324,7 @@ class SqliteTelegramAgentStore implements TelegramAgentStore {
       ? "Production canary failed. The configured rollback restored the previous release. No action is required."
       : "Production deploy failed. The configured rollback restored the previous release. No action is required.";
     const item: OutboxInput = {
-      logicalKey: `job:${next.id}:production-incident`,
+      logicalKey: `job:${next.id}:production-incident:${phase}`,
       chatId: owner.chatId,
       payload: { text, disable_web_page_preview: true },
     };

--- a/tests/autonomy-migration.test.ts
+++ b/tests/autonomy-migration.test.ts
@@ -10,6 +10,7 @@ import {
   TASK_AUTHORITY_CLOSURE_MIGRATIONS,
   TASK_AUTHORITY_PUBLISH_MIGRATIONS,
   TASK_AUTHORITY_REVISION_MIGRATIONS,
+  NAVIGATOR_RELEASE_MIGRATIONS,
 } from "../src/storage/migrations";
 import {
   WorkArtifactRepository,
@@ -56,8 +57,9 @@ const TICKET_41_MIGRATION_COUNT = TASK_AUTHORITY_MIGRATIONS.length +
   TASK_AUTHORITY_REVISION_MIGRATIONS.length + TASK_AUTHORITY_CLOSURE_MIGRATIONS.length +
   TASK_AUTHORITY_PUBLISH_MIGRATIONS.length + OWNER_BOUNDARY_SOURCE_MIGRATIONS.length +
   POLICY_APPROVAL_INTENT_MIGRATIONS.length;
+const TICKET_42_MIGRATION_COUNT = NAVIGATOR_RELEASE_MIGRATIONS.length;
 
-const PRE_TICKET_41_MIGRATION_COUNT = ALL_MIGRATIONS.length - TICKET_41_MIGRATION_COUNT;
+const PRE_TICKET_41_MIGRATION_COUNT = ALL_MIGRATIONS.length - TICKET_41_MIGRATION_COUNT - TICKET_42_MIGRATION_COUNT;
 
 function legacyDatabase(pluginId: string) {
   const { bb } = createFakePluginHost({ pluginId });
@@ -111,7 +113,7 @@ function admissionUpgradeDatabase(pluginId: string, revisionJobId = "job_1") {
     0,
     -(
       TASK_AUTHORITY_PUBLISH_MIGRATIONS.length + OWNER_BOUNDARY_SOURCE_MIGRATIONS.length +
-      POLICY_APPROVAL_INTENT_MIGRATIONS.length
+      POLICY_APPROVAL_INTENT_MIGRATIONS.length + NAVIGATOR_RELEASE_MIGRATIONS.length
     ),
   ));
   db.prepare(
@@ -170,7 +172,7 @@ function insertRelationshipUpgradeArtifact(
 
 it("keeps the autonomy migration after the frozen legacy positions and appends later migrations", () => {
   expect(PRE_TICKET_41_MIGRATION_COUNT).toBe(LEGACY_MIGRATION_COUNT + 64);
-  expect(ALL_MIGRATIONS).toHaveLength(PRE_TICKET_41_MIGRATION_COUNT + TICKET_41_MIGRATION_COUNT);
+  expect(ALL_MIGRATIONS).toHaveLength(PRE_TICKET_41_MIGRATION_COUNT + TICKET_41_MIGRATION_COUNT + TICKET_42_MIGRATION_COUNT);
   for (const [index, marker] of LEGACY_MIGRATION_MARKERS) {
     expect(ALL_MIGRATIONS[index]).toContain(marker);
   }
@@ -277,7 +279,8 @@ it("rolls back the boundary-source upgrade when active legacy evidence cannot be
   const { bb, db } = admissionUpgradeDatabase("owner-boundary-source-upgrade");
   bb.storage.migrate(db, [...ALL_MIGRATIONS].slice(
     0,
-    -(OWNER_BOUNDARY_SOURCE_MIGRATIONS.length + POLICY_APPROVAL_INTENT_MIGRATIONS.length),
+    -(OWNER_BOUNDARY_SOURCE_MIGRATIONS.length + POLICY_APPROVAL_INTENT_MIGRATIONS.length +
+      NAVIGATOR_RELEASE_MIGRATIONS.length),
   ));
   db.prepare(
     `INSERT INTO task_authorities (
@@ -337,7 +340,7 @@ it("backfills the mutable ticket-41 authority row into immutable revision histor
     -(
       TASK_AUTHORITY_REVISION_MIGRATIONS.length + TASK_AUTHORITY_CLOSURE_MIGRATIONS.length +
       TASK_AUTHORITY_PUBLISH_MIGRATIONS.length + OWNER_BOUNDARY_SOURCE_MIGRATIONS.length +
-      POLICY_APPROVAL_INTENT_MIGRATIONS.length
+      POLICY_APPROVAL_INTENT_MIGRATIONS.length + NAVIGATOR_RELEASE_MIGRATIONS.length
     ),
   ));
   db.prepare(
@@ -390,7 +393,7 @@ it("fails the authority upgrade when an older bound revision cannot be reconstru
     -(
       TASK_AUTHORITY_REVISION_MIGRATIONS.length + TASK_AUTHORITY_CLOSURE_MIGRATIONS.length +
       TASK_AUTHORITY_PUBLISH_MIGRATIONS.length + OWNER_BOUNDARY_SOURCE_MIGRATIONS.length +
-      POLICY_APPROVAL_INTENT_MIGRATIONS.length
+      POLICY_APPROVAL_INTENT_MIGRATIONS.length + NAVIGATOR_RELEASE_MIGRATIONS.length
     ),
   ));
   db.prepare(
@@ -451,7 +454,7 @@ it("reconstructs an older shipped revision from its authoritative release bindin
     -(
       TASK_AUTHORITY_REVISION_MIGRATIONS.length + TASK_AUTHORITY_CLOSURE_MIGRATIONS.length +
       TASK_AUTHORITY_PUBLISH_MIGRATIONS.length + OWNER_BOUNDARY_SOURCE_MIGRATIONS.length +
-      POLICY_APPROVAL_INTENT_MIGRATIONS.length
+      POLICY_APPROVAL_INTENT_MIGRATIONS.length + NAVIGATOR_RELEASE_MIGRATIONS.length
     ),
   ));
   db.prepare(

--- a/tests/controller-interaction-repository.test.ts
+++ b/tests/controller-interaction-repository.test.ts
@@ -16,6 +16,7 @@ import {
   TASK_AUTHORITY_CLOSURE_MIGRATIONS,
   TASK_AUTHORITY_PUBLISH_MIGRATIONS,
   TASK_AUTHORITY_REVISION_MIGRATIONS,
+  NAVIGATOR_RELEASE_MIGRATIONS,
 } from "../src/storage/migrations";
 import {
   ControllerInteractionRepository,
@@ -504,7 +505,7 @@ async function runInteractionRace(
 }
 
 it("pins the shipped migration bytes and appends the runtime repair migrations", () => {
-  expect(ALL_MIGRATIONS).toHaveLength(80 + TICKET_41_MIGRATION_COUNT);
+  expect(ALL_MIGRATIONS).toHaveLength(80 + TICKET_41_MIGRATION_COUNT + NAVIGATOR_RELEASE_MIGRATIONS.length);
   expect(createHash("sha256").update([...ALL_MIGRATIONS].slice(0, 28).join("\u0000")).digest("hex")).toBe(
     "505dfd4781117dfb2c817d31640e833370189e6b3ef2c7c24e646fb1838eed56",
   );

--- a/tests/controller-store.test.ts
+++ b/tests/controller-store.test.ts
@@ -14,6 +14,7 @@ import {
   TASK_AUTHORITY_CLOSURE_MIGRATIONS,
   TASK_AUTHORITY_PUBLISH_MIGRATIONS,
   TASK_AUTHORITY_REVISION_MIGRATIONS,
+  NAVIGATOR_RELEASE_MIGRATIONS,
 } from "../src/storage/migrations";
 import { IdempotencyConflictError, openStore, type ControllerFailureCode } from "../src/storage/store";
 import { completeTurnThroughFinalization } from "./support/controller-trust-fixtures";
@@ -215,7 +216,7 @@ function expectDuplicateGenerationRepair(
 // Applied migrations are immutable history: each release appends, so these are
 // indexed from the start and a new migration only ever extends the tail.
 it("keeps every shipped migration at its original position and appends new ones", () => {
-  expect(ALL_MIGRATIONS).toHaveLength(80 + TICKET_41_MIGRATION_COUNT);
+  expect(ALL_MIGRATIONS).toHaveLength(80 + TICKET_41_MIGRATION_COUNT + NAVIGATOR_RELEASE_MIGRATIONS.length);
   expect(ALL_MIGRATIONS[70]).toContain("attempts_before_consensus_lens");
   expect(ALL_MIGRATIONS[71]).toContain("CREATE TABLE audit_intake_findings");
   expect(ALL_MIGRATIONS[72]).toContain("merge_pre_approved_at");

--- a/tests/end-to-end.test.ts
+++ b/tests/end-to-end.test.ts
@@ -575,7 +575,15 @@ describe("Task 12 complete mocked Telegram-to-merge workflow", () => {
       }),
     });
 
-    const policy = policyFixture({ projectId: "proj_1", alias: "cyndra", githubRepository: "acme/cyndra" });
+    const policy = policyFixture({
+      projectId: "proj_1",
+      alias: "cyndra",
+      githubRepository: "acme/cyndra",
+      production: {
+        ...policyFixture().production!,
+        rollbackCommand: { name: "rollback", command: "./rollback", timeoutMs: 60_000 },
+      },
+    });
     let executorSession: ExecutorSession;
     const completeDocs = (jobId: string): void => {
       const current = store.getJob(jobId);

--- a/tests/merge-authority.test.ts
+++ b/tests/merge-authority.test.ts
@@ -23,6 +23,12 @@ function grant(overrides: Partial<MergeAuthorityGrant> = {}): MergeAuthorityGran
 
 type AuthorityJob = Pick<Job, "id" | "projectId" | "prHeadSha" | "reviewCycle" | "cancelRequestedAt" | "policy">;
 
+const PRODUCTION_WITH_ROLLBACK = {
+  deployCommands: [] as const,
+  canaryCommands: [] as const,
+  rollbackCommand: { name: "rollback", command: "./rollback", timeoutMs: 60_000 },
+};
+
 function job(overrides: Partial<AuthorityJob> = {}): AuthorityJob {
   return {
     id: "job_owner",
@@ -30,7 +36,7 @@ function job(overrides: Partial<AuthorityJob> = {}): AuthorityJob {
     prHeadSha: HEAD,
     reviewCycle: 0,
     cancelRequestedAt: null,
-    policy: { production: { deployCommands: [], canaryCommands: [] } } as unknown as Job["policy"],
+    policy: { production: PRODUCTION_WITH_ROLLBACK } as unknown as Job["policy"],
     ...overrides,
   };
 }
@@ -76,6 +82,19 @@ describe("standing merge approval", () => {
     expect(decision.outcome).toBe("ask_owner");
   });
 
+  it("asks when production has no rollback command", () => {
+    const decision = decideAutoApproval({
+      job: job({
+        policy: { production: { deployCommands: [], canaryCommands: [] } } as unknown as Job["policy"],
+      }),
+      grant: grant(),
+    });
+    expect(decision).toMatchObject({
+      outcome: "ask_owner",
+      reason: expect.stringContaining("rollback"),
+    });
+  });
+
   it("still merges a change that needed one round of review fixes", () => {
     const decision = decideAutoApproval({ job: job({ reviewCycle: 1 }), grant: grant() });
     expect(decision).toEqual({ outcome: "auto_approve" });
@@ -94,7 +113,7 @@ describe("standing merge approval", () => {
 function policyGrantJob(autonomy: Record<string, unknown>, overrides: Partial<AuthorityJob> = {}) {
   return job({
     policy: {
-      production: { deployCommands: [], canaryCommands: [] },
+      production: PRODUCTION_WITH_ROLLBACK,
       autonomy,
     } as unknown as Job["policy"],
     ...overrides,

--- a/tests/navigator-release.test.ts
+++ b/tests/navigator-release.test.ts
@@ -1,0 +1,700 @@
+import { createFakePluginHost } from "@bb/plugin-sdk/testing";
+import type Database from "better-sqlite3";
+import { describe, expect, it, vi } from "vitest";
+import { productionResourceKey, projectResourceKey } from "../src/autonomy/models";
+import { DEFAULT_MODEL_POOL_REGISTRY } from "../src/capabilities/models";
+import { hashSecret } from "../src/crypto";
+import type { Job } from "../src/domain/models";
+import { NavigatorImplementationExecutor } from "../src/navigator/implementation-executor";
+import type { NavigatorSnapshot } from "../src/navigator/models";
+import { NavigatorReleaseExecutor } from "../src/navigator/release-executor";
+import { ALL_MIGRATIONS, NAVIGATOR_RELEASE_MIGRATIONS } from "../src/storage/migrations";
+import { EffectRunner } from "../src/services/effect-runner";
+import { openStore, type TelegramAgentStore } from "../src/storage/store";
+import { stableWorkArtifactId, type CaptureWorkArtifactInput } from "../src/work-artifacts/repository";
+import { policyFixture, sha } from "./helpers";
+
+const HEAD = "1".repeat(40);
+const EXTERNAL_DIGEST = "e".repeat(64);
+let fixtureSequence = 0;
+
+function productionPolicy() {
+  return policyFixture({
+    production: {
+      ...policyFixture().production!,
+      rollbackCommand: { name: "rollback", command: "./rollback", timeoutMs: 60_000 },
+    },
+  });
+}
+
+function artifactInput(input: Readonly<{
+  id: string;
+  operationId: string;
+  kind: CaptureWorkArtifactInput["kind"];
+  title: string;
+  trackerOrder: number;
+  relationships?: CaptureWorkArtifactInput["relationships"];
+}>): CaptureWorkArtifactInput {
+  return {
+    artifactId: input.id,
+    projectId: "proj_1",
+    effortId: "job_42",
+    operationId: input.operationId,
+    kind: input.kind,
+    status: "ready",
+    trackerKind: "github",
+    trackerNamespace: "github:acme/cyndra",
+    externalId: input.operationId,
+    externalUrl: `https://github.com/acme/cyndra/issues/${input.operationId}`,
+    externalRevision: `${input.operationId}:1`,
+    externalStatus: "open",
+    assignees: [],
+    title: input.title,
+    trackerOrder: input.trackerOrder,
+    content: `# ${input.title}\n\nImmutable ticket 42 fixture.`,
+    acceptanceCriteria: [`${input.title} is accepted`],
+    relationships: input.relationships ?? [],
+    capturedAt: 1_000 + input.trackerOrder,
+  };
+}
+
+function modelRoute() {
+  return { pool: "standard" as const, ...DEFAULT_MODEL_POOL_REGISTRY.worker.standard };
+}
+
+type OwnedFixture = Readonly<{
+  bb: ReturnType<typeof createFakePluginHost>["bb"];
+  store: TelegramAgentStore;
+  database: Database.Database;
+  job: Job;
+  specificationId: string;
+  ticketIds: readonly [string, string];
+  leaseGeneration: number;
+  now(): number;
+}>;
+
+function bindNavigatorTickets(store: TelegramAgentStore, job: Job, now: () => number) {
+  const specificationId = stableWorkArtifactId("proj_1", `spec-42-${job.id}`);
+  const firstTicketId = stableWorkArtifactId("proj_1", `ticket-42-1-${job.id}`);
+  const secondTicketId = stableWorkArtifactId("proj_1", `ticket-42-2-${job.id}`);
+  const specification = store.captureWorkArtifact(artifactInput({
+    id: specificationId,
+    operationId: "42-spec",
+    kind: "specification",
+    title: "Ship accepted tickets through exact-head production",
+    trackerOrder: 0,
+  }));
+  const firstTicket = store.captureWorkArtifact(artifactInput({
+    id: firstTicketId,
+    operationId: "42-1",
+    kind: "implementation_ticket",
+    title: "First release ticket",
+    trackerOrder: 1,
+    relationships: [{
+      kind: "parent",
+      sourceArtifactId: firstTicketId,
+      sourceRef: `artifact:${firstTicketId}`,
+      targetArtifactId: specificationId,
+      targetRef: `artifact:${specificationId}`,
+    }],
+  }));
+  const secondTicket = store.captureWorkArtifact(artifactInput({
+    id: secondTicketId,
+    operationId: "42-2",
+    kind: "implementation_ticket",
+    title: "Second release ticket",
+    trackerOrder: 2,
+    relationships: [{
+      kind: "parent",
+      sourceArtifactId: secondTicketId,
+      sourceRef: `artifact:${secondTicketId}`,
+      targetArtifactId: specificationId,
+      targetRef: `artifact:${specificationId}`,
+    }],
+  }));
+  const bound = store.bindNavigatorJobArtifacts({
+    jobId: job.id,
+    expectedVersion: job.version,
+    artifactBindings: [specification, firstTicket, secondTicket].map(({ artifact, snapshot }) => ({
+      artifactId: artifact.id,
+      snapshotId: snapshot.id,
+      snapshotDigest: snapshot.snapshotDigest,
+    })),
+    now: now(),
+  });
+  return { bound, specificationId, ticketIds: [firstTicketId, secondTicketId] as const };
+}
+
+function startResolvedIntegration(
+  fixture: Pick<OwnedFixture, "store" | "database" | "job" | "specificationId" | "ticketIds" | "now">,
+): void {
+  const executor = new NavigatorImplementationExecutor({
+    store: fixture.store,
+    database: fixture.database,
+    workerRunner: { run: vi.fn(), reconcileUnavailableResource: vi.fn() },
+    gitObserver: {
+      observe: vi.fn(async (request) => ({
+        kind: "navigator_git_observation" as const,
+        worktreeId: request.worktreeId,
+        branch: request.integrationBranch,
+        headSha: request.expectedHeadSha,
+        baseHeadSha: request.baseHeadSha,
+        baseHeadIsAncestor: true,
+        comparisonBaseHeadSha: request.comparisonBaseHeadSha,
+        comparisonBaseHeadIsAncestor: true,
+        clean: true,
+        changedPaths: request.expectedChangedPaths,
+        evidenceRef: `git-observation:${request.expectedHeadSha}:${request.purpose}`,
+        observedAt: 2_000,
+      })),
+    },
+    pullRequests: {
+      createOrRefresh: vi.fn(async (request) => ({
+        operationId: request.operationId,
+        jobId: request.jobId,
+        number: 42,
+        url: "https://github.com/acme/cyndra/pull/42",
+        headSha: request.headSha,
+      })),
+    },
+    modelRoute: () => modelRoute(),
+    clock: { now: fixture.now },
+  });
+  executor.startIntegration({
+    jobId: fixture.job.id,
+    specificationArtifactId: fixture.specificationId,
+    implementationTicketIds: fixture.ticketIds,
+    baseBranch: "main",
+    integrationBranch: "hanoon/job-42",
+    worktreeId: "env_job_42",
+    baseHeadSha: HEAD,
+    evidenceRefs: ["ticket:42"],
+  });
+  const now = fixture.now();
+  fixture.database.prepare(
+    "UPDATE navigator_integration_tickets SET state = 'resolved', resolved_at = ? WHERE job_id = ?",
+  ).run(now, fixture.job.id);
+  fixture.database.prepare(
+    "UPDATE navigator_integrations SET state = 'ready_for_pull_request', updated_at = ? WHERE job_id = ?",
+  ).run(now, fixture.job.id);
+}
+
+function ownedFixture(task = "Ship the accepted navigator tickets to production"): OwnedFixture {
+  fixtureSequence += 1;
+  const { bb } = createFakePluginHost({ pluginId: `navigator-release-${fixtureSequence}` });
+  let currentTime = 10_100;
+  const now = () => currentTime++;
+  const store = openStore(bb.storage, bb.storage.kv, now);
+  const policy = productionPolicy();
+  store.createPairingCode(hashSecret("pair"), 1_000, 20_000);
+  if (!store.pairOwnerWithCode(hashSecret("pair"), "7", "7", 1_001).ok) throw new Error("owner pairing failed");
+  store.upsertProjectPolicy(policy, 1_002);
+  store.enqueueControllerTurn({
+    controllerKey: "owner-7-controller",
+    telegramUserId: "7",
+    telegramChatId: "7",
+    updateId: 42_000 + fixtureSequence,
+    inputText: task,
+    now: 2_000,
+  });
+  const lease = store.acquireExecutorLease("executor", 10_000, 120_000);
+  if (!lease.acquired) throw new Error("missing executor lease");
+  const turn = store.claimNextControllerTurn({ ownerId: "executor", generation: lease.generation, now: 10_000 });
+  if (!turn) throw new Error("missing controller turn");
+  if (!store.markControllerSpawned({
+    turnId: turn.id, ownerId: "executor", generation: lease.generation, now: 10_000,
+    projectId: "proj_1", hostId: "host_1", threadId: "thr_controller_42",
+  })) throw new Error("controller spawn was not recorded");
+  if (!store.markControllerTurnSubmitted({
+    turnId: turn.id, ownerId: "executor", generation: lease.generation, now: 10_000,
+  })) throw new Error("controller submission was not recorded");
+  const created = store.createConfirmedControllerJob({
+    controllerThreadId: "thr_controller_42",
+    projectId: "proj_1",
+    task,
+    now: 10_001,
+  });
+  bb.storage.database().prepare(
+    "UPDATE jobs SET workflow_engine = 'navigator-v1', workflow_mode = 'deterministic' WHERE id = ?",
+  ).run(created.id);
+  const selected = store.getJob(created.id);
+  if (!selected) throw new Error("converted navigator job is missing");
+  const { bound, specificationId, ticketIds } = bindNavigatorTickets(store, selected, now);
+  const fixture = {
+    bb,
+    store,
+    database: bb.storage.database(),
+    job: bound,
+    specificationId,
+    ticketIds,
+    leaseGeneration: lease.generation,
+    now,
+  };
+  startResolvedIntegration(fixture);
+  bb.storage.database().prepare("UPDATE jobs SET state = 'implementing' WHERE id = ?").run(bound.id);
+  const job = store.getJob(bound.id);
+  if (!job) throw new Error("implementing navigator job is missing");
+  return { ...fixture, job };
+}
+
+function propose(
+  fixture: Pick<OwnedFixture, "store" | "job" | "now">,
+  rawProposal: Record<string, unknown>,
+  snapshot?: NavigatorSnapshot,
+) {
+  const current = snapshot ?? fixture.store.createNavigatorSnapshot({
+    jobId: fixture.job.id,
+    externalStateDigest: EXTERNAL_DIGEST,
+    evidenceRefs: ["ticket:42"],
+    now: fixture.now(),
+  });
+  const decision = fixture.store.recordNavigatorProposal({
+    snapshotId: current.snapshotId,
+    rawProposal: {
+      basedOn: current.identity,
+      rationale: "The implementation tickets are ready for exact-head release.",
+      evidenceRefs: ["ticket:42"],
+      ...rawProposal,
+    },
+    observation: {
+      nativeToolCalls: [],
+      claimedCodeWorktreeId: null,
+      dynamicEffectToolIds: [],
+      externalStateDigest: EXTERNAL_DIGEST,
+    },
+    selectModelRoute: () => modelRoute(),
+    now: fixture.now(),
+  });
+  return { ...decision, snapshot: current };
+}
+
+function releaseExecutor(
+  fixture: OwnedFixture,
+  publish = vi.fn(async () => ({
+    operationId: "pr-42",
+    jobId: fixture.job.id,
+    number: 42,
+    url: "https://github.com/acme/cyndra/pull/42",
+    headSha: HEAD,
+  })),
+) {
+  return {
+    publish,
+    executor: new NavigatorReleaseExecutor({
+      store: fixture.store,
+      publishPullRequest: publish,
+      integrationWorktreeId: () => "env_job_42",
+      clock: { now: fixture.now },
+    }),
+  };
+}
+
+function fence(fixture: OwnedFixture) {
+  return {
+    ownerId: "executor",
+    generation: fixture.leaseGeneration,
+    signal: new AbortController().signal,
+  };
+}
+
+function failedStage(
+  phase: "deploy" | "canary",
+  rollback: "pass" | "fail" | "missing" | "timed_out",
+) {
+  return {
+    phase,
+    outcome: "fail" as const,
+    summary: `Production ${phase} failed`,
+    failedCommand: phase,
+    commandReceipts: [
+      { name: "verify-merged-checkout", command: "git-head-check", outcome: "pass" as const, exitCode: 0, output: "ok" },
+      { name: phase, command: `./${phase}`, outcome: "fail" as const, exitCode: 1, output: "boom" },
+    ],
+    ...(rollback === "missing" ? {} : {
+      rollback: {
+        name: "rollback",
+        command: "./rollback",
+        outcome: rollback === "timed_out" ? "timed_out" as const : rollback,
+        exitCode: rollback === "pass" ? 0 : rollback === "timed_out" ? null : 1,
+        output: "rolled",
+      },
+    }),
+    terminalIds: [`term_${phase}`],
+    completedAt: "2026-08-10T00:01:00.000Z",
+  };
+}
+
+function seedProductionEffect(
+  fixture: OwnedFixture,
+  state: "deploying" | "verifying_production",
+): string {
+  const job = fixture.store.getJob(fixture.job.id);
+  if (!job?.policy || !job.projectId) throw new Error("production job policy is missing");
+  const policy = job.policy;
+  const db = fixture.database;
+  db.prepare(
+    `UPDATE jobs SET state = ?, environment_id = 'env_job_42', pr_number = 42,
+       pr_url = 'https://github.com/acme/cyndra/pull/42', pr_head_sha = ?,
+       merge_message = 'Merged pull request #42', merge_commit_sha = ?,
+       merged_at = '2026-08-10T00:00:00.000Z', version = version + 1
+     WHERE id = ?`,
+  ).run(state, sha("a"), sha("d"), job.id);
+  db.prepare("UPDATE effects SET status = 'done' WHERE job_id = ?").run(job.id);
+  db.prepare(
+    `UPDATE job_admissions SET project_id = ?, state = 'admitted', admitted_at = 10100 WHERE job_id = ?`,
+  ).run(job.projectId, job.id);
+  const held = db.prepare(
+    "SELECT 1 FROM job_resource_claims WHERE job_id = ? AND state = 'held' LIMIT 1",
+  ).get(job.id);
+  if (!held) {
+    const insertClaim = db.prepare(
+      `INSERT INTO job_resource_claims (
+         job_id, resource_key, resource_kind, state, owner_id, generation,
+         lease_expires_at, acquired_at, renewed_at
+       ) VALUES (?, ?, ?, 'held', 'executor', ?, 130000, 10100, 10100)`,
+    );
+    insertClaim.run(job.id, projectResourceKey(job.projectId), "project", fixture.leaseGeneration);
+    insertClaim.run(job.id, productionResourceKey(policy), "production_target", fixture.leaseGeneration);
+  }
+  const current = fixture.store.getJob(job.id);
+  if (!current) throw new Error("production job disappeared");
+  const kind = state === "deploying" ? "deploy_production" : "verify_production";
+  const key = `${current.id}:${current.version + 1}:${kind}`;
+  db.prepare(
+    `INSERT INTO effects (
+       idempotency_key, job_id, kind, payload_json, status, attempts,
+       next_attempt_at, created_at, updated_at
+     ) VALUES (?, ?, ?, '{}', 'pending', 0, 10100, 10100, 10100)`,
+  ).run(key, current.id, kind);
+  return key;
+}
+
+async function runLeasedProduction(
+  fixture: OwnedFixture,
+  key: string,
+  stage: ReturnType<typeof failedStage> | {
+    phase: "deploy" | "canary";
+    outcome: "pass";
+    summary: string;
+    failedCommand: null;
+    commandReceipts: Array<{ name: string; command: string; outcome: "pass"; exitCode: number; output: string }>;
+    terminalIds: string[];
+    completedAt: string;
+  },
+): Promise<void> {
+  const claimed = fixture.store.leaseNextJobEffect({
+    jobId: fixture.job.id,
+    ownerId: "executor",
+    generation: fixture.leaseGeneration,
+    now: fixture.now(),
+    leaseMs: 30_000,
+  });
+  if (!claimed || claimed.idempotencyKey !== key) throw new Error("production effect was not leased");
+  await new EffectRunner({
+    store: fixture.store,
+    fence: fence(fixture),
+    now: fixture.now,
+    runProductionStage: vi.fn(async () => stage),
+  }).run(claimed);
+  fixture.store.completeEffect(claimed.idempotencyKey, "executor", fixture.leaseGeneration, fixture.now());
+}
+
+function prepareApproval(fixture: OwnedFixture, headSha: string): string {
+  const policy = fixture.store.getJob(fixture.job.id)?.policy ?? productionPolicy();
+  const db = fixture.database;
+  db.prepare(
+    `UPDATE jobs SET state = 'awaiting_merge_approval', project_id = ?, policy_version = 1,
+       policy_json = ?, environment_id = 'env_job_42', pr_number = 42,
+       pr_url = 'https://github.com/acme/cyndra/pull/42', pr_head_sha = ?, version = version + 1
+     WHERE id = ?`,
+  ).run(policy.projectId, JSON.stringify(policy), headSha, fixture.job.id);
+  db.prepare(
+    `UPDATE job_admissions SET project_id = ?, state = 'admitted', admitted_at = 10100 WHERE job_id = ?`,
+  ).run(policy.projectId, fixture.job.id);
+  db.prepare("UPDATE effects SET status = 'done' WHERE job_id = ?").run(fixture.job.id);
+  const current = fixture.store.getJob(fixture.job.id);
+  if (!current) throw new Error("approval job is missing");
+  const held = db.prepare(
+    "SELECT 1 FROM job_resource_claims WHERE job_id = ? AND resource_kind = 'project' AND state = 'held'",
+  ).get(current.id);
+  if (!held) {
+    db.prepare(
+      `INSERT INTO job_resource_claims (
+         job_id, resource_key, resource_kind, state, owner_id, generation,
+         lease_expires_at, acquired_at, renewed_at
+       ) VALUES (?, ?, 'project', 'held', 'executor', ?, 130000, 10100, 10100)`,
+    ).run(current.id, projectResourceKey(policy.projectId), fixture.leaseGeneration);
+  }
+  const key = `${current.id}:${current.version}:issue_approval`;
+  db.prepare(
+    `INSERT INTO effects (
+       idempotency_key, job_id, kind, payload_json, status, attempts,
+       next_attempt_at, created_at, updated_at
+     ) VALUES (?, ?, 'issue_approval', ?, 'pending', 0, 10100, 10100, 10100)`,
+  ).run(key, current.id, JSON.stringify({ headSha }));
+  return key;
+}
+
+async function runApproval(fixture: OwnedFixture, key: string): Promise<void> {
+  const claimed = fixture.store.leaseNextJobEffect({
+    jobId: fixture.job.id,
+    ownerId: "executor",
+    generation: fixture.leaseGeneration,
+    now: fixture.now(),
+    leaseMs: 30_000,
+  });
+  if (!claimed || claimed.idempotencyKey !== key) throw new Error("approval effect was not leased");
+  await new EffectRunner({
+    store: fixture.store,
+    fence: fence(fixture),
+    now: fixture.now,
+  }).run(claimed);
+}
+
+describe("navigator exact-head release", () => {
+  it("appends the navigator release migration after the ticket 41 policy intent migrations", () => {
+    expect(ALL_MIGRATIONS.at(-1)).toBe(NAVIGATOR_RELEASE_MIGRATIONS[0]);
+    expect(NAVIGATOR_RELEASE_MIGRATIONS[0]).toContain("CREATE TABLE navigator_release_attempts");
+    expect(NAVIGATOR_RELEASE_MIGRATIONS[0]).toContain("CREATE TABLE production_recovery_observations");
+    expect(NAVIGATOR_RELEASE_MIGRATIONS[0]).toContain("production_recovery_required");
+  });
+
+  it("rejects start_release without resolved tickets or a permitted outcome", () => {
+    const fixture = ownedFixture();
+    fixture.database.prepare(
+      "UPDATE navigator_integration_tickets SET state = 'pending', resolved_at = NULL WHERE job_id = ?",
+    ).run(fixture.job.id);
+    fixture.database.prepare(
+      "UPDATE navigator_integrations SET state = 'implementing' WHERE job_id = ?",
+    ).run(fixture.job.id);
+
+    expect(propose(fixture, {
+      kind: "start_release",
+      implementationTicketIds: [...fixture.ticketIds],
+    })).toMatchObject({ decision: "rejected", reasonCode: "release_prerequisites_incomplete" });
+
+    fixture.database.prepare(
+      "UPDATE jobs SET task_outcome = 'artifact', task_constraints_json = ? WHERE id = ?",
+    ).run(JSON.stringify(["artifact_only"]), fixture.job.id);
+    expect(propose(fixture, {
+      kind: "start_release",
+      implementationTicketIds: [...fixture.ticketIds],
+    })).toMatchObject({ decision: "rejected", reasonCode: "release_outcome_not_permitted" });
+  });
+
+  it("accepts start_release once and leases one restart-safe release effect", async () => {
+    const fixture = ownedFixture();
+    const first = propose(fixture, {
+      kind: "start_release",
+      implementationTicketIds: [...fixture.ticketIds],
+    });
+    expect(first).toMatchObject({
+      decision: "accepted",
+      reasonCode: "accepted",
+      workflowStepId: expect.any(String),
+      effectIdempotencyKey: expect.stringContaining(":run_release"),
+    });
+    const job = fixture.store.getJob(fixture.job.id);
+    expect(job).toMatchObject({
+      currentWorkflowStepId: first.workflowStepId,
+      state: "implementing",
+    });
+    expect(fixture.store.listEffectsForJob(fixture.job.id).filter((effect) => effect.kind === "run_navigator_release"))
+      .toEqual([expect.objectContaining({
+        idempotencyKey: first.effectIdempotencyKey,
+        status: "pending",
+      })]);
+
+    const replay = propose(fixture, {
+      kind: "start_release",
+      implementationTicketIds: [...fixture.ticketIds],
+    }, first.snapshot);
+    expect(replay).toMatchObject({
+      decision: "accepted",
+      proposalId: first.proposalId,
+      effectIdempotencyKey: first.effectIdempotencyKey,
+    });
+    expect(fixture.store.listEffectsForJob(fixture.job.id).filter((effect) => effect.kind === "run_navigator_release"))
+      .toHaveLength(1);
+
+    const { executor, publish } = releaseExecutor(fixture);
+    expect(await executor.processOne(fence(fixture), new AbortController().signal)).toBe(true);
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(fixture.store.getJob(fixture.job.id)).toMatchObject({
+      state: "resolving_pr_head",
+      prNumber: 42,
+      environmentId: "env_job_42",
+    });
+    expect(await executor.processOne(fence(fixture), new AbortController().signal)).toBe(false);
+    expect(publish).toHaveBeenCalledTimes(1);
+    const reopened = openStore(fixture.bb.storage, fixture.bb.storage.kv, fixture.now);
+    expect(reopened.getJob(fixture.job.id)).toMatchObject({
+      state: "resolving_pr_head",
+      prNumber: 42,
+      environmentId: "env_job_42",
+    });
+    expect(reopened.listEffectsForJob(fixture.job.id).find((effect) => effect.kind === "run_navigator_release"))
+      .toMatchObject({ status: "done" });
+  });
+
+  it("auto-authorizes a shipped navigator merge without a standing grant and re-derives after head drift", async () => {
+    const fixture = ownedFixture();
+    const firstHead = sha("b");
+    const firstKey = prepareApproval(fixture, firstHead);
+    await runApproval(fixture, firstKey);
+
+    expect(fixture.store.getJob(fixture.job.id)).toMatchObject({ state: "merging", prHeadSha: firstHead });
+    expect(fixture.store.listEffectsForJob(fixture.job.id).some((effect) => effect.kind === "merge_pr")).toBe(true);
+    expect(fixture.database.prepare("SELECT COUNT(*) AS count FROM approvals WHERE job_id = ?").get(fixture.job.id))
+      .toEqual({ count: 1 });
+    expect(fixture.store.getMergeAuthority("proj_1")).toBeNull();
+
+    fixture.database.prepare(
+      "UPDATE jobs SET state = 'validating', pr_head_sha = ? WHERE id = ?",
+    ).run(firstHead, fixture.job.id);
+    const validating = fixture.store.getJob(fixture.job.id)!;
+    fixture.store.applyJobEvent(validating.id, validating.version, {
+      type: "VALIDATION_FAILED",
+      headSha: firstHead,
+      reason: "Validation did not pass",
+    }, fixture.now());
+    expect(fixture.store.getJob(fixture.job.id)).toMatchObject({ state: "implementing", prHeadSha: null });
+
+    const secondHead = sha("c");
+    const secondKey = prepareApproval(fixture, secondHead);
+    await runApproval(fixture, secondKey);
+    expect(fixture.store.getJob(fixture.job.id)).toMatchObject({ state: "merging", prHeadSha: secondHead });
+    expect(fixture.database.prepare("SELECT COUNT(*) AS count FROM approvals WHERE job_id = ?").get(fixture.job.id))
+      .toEqual({ count: 2 });
+  });
+
+  it("returns validation findings to navigation and leaves recipe remediating on the same event", () => {
+    const fixture = ownedFixture();
+    propose(fixture, {
+      kind: "start_release",
+      implementationTicketIds: [...fixture.ticketIds],
+    });
+    const current = fixture.store.getJob(fixture.job.id)!;
+    const released = fixture.store.applyJobEvent(current.id, current.version, {
+      type: "RELEASE_STARTED",
+      number: 42,
+      url: "https://github.com/acme/cyndra/pull/42",
+      environmentId: "env_job_42",
+    }, fixture.now());
+    const headed = fixture.store.applyJobEvent(released.id, released.version, {
+      type: "PR_HEAD_RESOLVED",
+      headSha: sha("a"),
+    }, fixture.now());
+    const returned = fixture.store.applyJobEvent(headed.id, headed.version, {
+      type: "VALIDATION_FAILED",
+      headSha: sha("a"),
+      reason: "Validation did not pass",
+    }, fixture.now());
+    expect(returned).toMatchObject({
+      state: "implementing",
+      prHeadSha: null,
+      currentWorkflowStepId: null,
+    });
+    expect(fixture.store.listEffectsForJob(fixture.job.id).some((effect) => effect.kind === "send_remediation"))
+      .toBe(false);
+    expect(fixture.database.prepare(
+      "SELECT reason_code, previous_state FROM navigator_release_findings WHERE job_id = ?",
+    ).all(fixture.job.id)).toEqual([
+      { reason_code: "validation_failed", previous_state: "validating" },
+    ]);
+  });
+
+  it("recovers one successful rollback to navigation and exhausts a repeated signature", async () => {
+    const fixture = ownedFixture();
+    const firstKey = seedProductionEffect(fixture, "deploying");
+    await runLeasedProduction(fixture, firstKey, failedStage("deploy", "pass"));
+
+    expect(fixture.store.getJob(fixture.job.id)).toMatchObject({
+      state: "implementing",
+      prHeadSha: null,
+    });
+    expect(fixture.store.countNavigatorReleaseIncidents({
+      jobId: fixture.job.id,
+      phase: "deploy",
+      failureSignature: "deploy",
+      rollbackOutcome: "pass",
+    })).toBe(1);
+    expect(fixture.store.getOutbox(`job:${fixture.job.id}:production-incident`)).toMatchObject({
+      payload: {
+        text: "Production deploy failed. The configured rollback restored the previous release. No action is required.",
+      },
+    });
+    expect(fixture.store.listPausedProjectAdmissions()).toEqual([]);
+    expect(fixture.store.getTaskAuthority(fixture.job.id)?.status).toBe("active");
+    expect(fixture.store.listOwnerBoundaries(fixture.job.id)).toEqual([]);
+
+    const secondKey = seedProductionEffect(fixture, "deploying");
+    await runLeasedProduction(fixture, secondKey, failedStage("deploy", "pass"));
+    expect(fixture.store.getJob(fixture.job.id)?.state).toBe("production_failed");
+    expect(fixture.store.getTaskAuthority(fixture.job.id)?.status).toBe("suspended");
+    expect(fixture.store.listPausedProjectAdmissions().map((pause) => pause.projectId)).toEqual(["proj_1"]);
+    expect(fixture.store.listOwnerBoundaries(fixture.job.id)).toEqual([
+      expect.objectContaining({ code: "production_recovery_required", status: "pending" }),
+    ]);
+    const reopened = openStore(fixture.bb.storage, fixture.bb.storage.kv, fixture.now);
+    expect(reopened.listOwnerBoundaries(fixture.job.id)[0]).toMatchObject({
+      code: "production_recovery_required",
+      goal: "Restore production after a failed release",
+    });
+  });
+
+  it("fails missing, failed, and indeterminate rollback into production recovery", async () => {
+    const missing = ownedFixture();
+    await runLeasedProduction(missing, seedProductionEffect(missing, "deploying"), failedStage("deploy", "missing"));
+    expect(missing.store.getJob(missing.job.id)?.state).toBe("production_failed");
+    expect(missing.store.listOwnerBoundaries(missing.job.id)[0]?.code).toBe("production_recovery_required");
+
+    const failed = ownedFixture();
+    await runLeasedProduction(failed, seedProductionEffect(failed, "verifying_production"), failedStage("canary", "fail"));
+    expect(failed.store.getJob(failed.job.id)?.state).toBe("production_failed");
+    expect(failed.store.getTaskAuthority(failed.job.id)?.status).toBe("suspended");
+
+    const unknown = ownedFixture();
+    await runLeasedProduction(unknown, seedProductionEffect(unknown, "deploying"), failedStage("deploy", "timed_out"));
+    expect(unknown.store.getJob(unknown.job.id)?.state).toBe("production_failed");
+    expect(unknown.store.countNavigatorReleaseIncidents({
+      jobId: unknown.job.id,
+      phase: "deploy",
+      failureSignature: "deploy",
+      rollbackOutcome: "indeterminate",
+    })).toBe(1);
+  });
+
+  it("keeps recipe jobs failed after a successful rollback", async () => {
+    const fixture = ownedFixture();
+    fixture.database.prepare(
+      "UPDATE jobs SET workflow_engine = 'recipe-v1', workflow_mode = 'live' WHERE id = ?",
+    ).run(fixture.job.id);
+    await runLeasedProduction(fixture, seedProductionEffect(fixture, "deploying"), failedStage("deploy", "pass"));
+    expect(fixture.store.getJob(fixture.job.id)?.state).toBe("production_failed");
+    expect(fixture.store.getOutbox(`job:${fixture.job.id}:production-incident`)).toBeNull();
+    expect(fixture.store.listOwnerBoundaries(fixture.job.id)).toEqual([]);
+  });
+
+  it("rejects finish without durable release evidence and accepts it after complete", () => {
+    const fixture = ownedFixture();
+    expect(propose(fixture, {
+      kind: "finish",
+      artifactIds: [...fixture.ticketIds],
+    })).toMatchObject({ decision: "rejected", reasonCode: "completion_evidence_missing" });
+
+    fixture.database.prepare("UPDATE jobs SET state = 'complete' WHERE id = ?").run(fixture.job.id);
+    const accepted = propose(fixture, {
+      kind: "finish",
+      artifactIds: [...fixture.ticketIds],
+    });
+    expect(accepted).toMatchObject({ decision: "accepted", reasonCode: "completion_recorded" });
+    expect(fixture.store.listEffectsForJob(fixture.job.id).filter((effect) => effect.kind === "run_navigator_release"))
+      .toEqual([]);
+    const replay = propose(fixture, {
+      kind: "finish",
+      artifactIds: [...fixture.ticketIds],
+    }, accepted.snapshot);
+    expect(replay.proposalId).toBe(accepted.proposalId);
+  });
+});

--- a/tests/navigator-release.test.ts
+++ b/tests/navigator-release.test.ts
@@ -453,7 +453,7 @@ async function runApproval(fixture: OwnedFixture, key: string): Promise<void> {
 
 describe("navigator exact-head release", () => {
   it("appends the navigator release migration after the ticket 41 policy intent migrations", () => {
-    expect(ALL_MIGRATIONS.at(-1)).toBe(NAVIGATOR_RELEASE_MIGRATIONS[0]);
+    expect(ALL_MIGRATIONS.at(-1)).toBe(NAVIGATOR_RELEASE_MIGRATIONS.at(-1));
     expect(NAVIGATOR_RELEASE_MIGRATIONS[0]).toContain("CREATE TABLE navigator_release_attempts");
     expect(NAVIGATOR_RELEASE_MIGRATIONS[0]).toContain("CREATE TABLE production_recovery_observations");
     expect(NAVIGATOR_RELEASE_MIGRATIONS[0]).toContain("production_recovery_required");
@@ -619,7 +619,7 @@ describe("navigator exact-head release", () => {
       failureSignature: "deploy",
       rollbackOutcome: "pass",
     })).toBe(1);
-    expect(fixture.store.getOutbox(`job:${fixture.job.id}:production-incident`)).toMatchObject({
+    expect(fixture.store.getOutbox(`job:${fixture.job.id}:production-incident:deploy`)).toMatchObject({
       payload: {
         text: "Production deploy failed. The configured rollback restored the previous release. No action is required.",
       },
@@ -640,6 +640,40 @@ describe("navigator exact-head release", () => {
     expect(reopened.listOwnerBoundaries(fixture.job.id)[0]).toMatchObject({
       code: "production_recovery_required",
       goal: "Restore production after a failed release",
+    });
+  });
+
+  it("records a distinct owner notice for each successful rollback phase", async () => {
+    const fixture = ownedFixture();
+    await runLeasedProduction(fixture, seedProductionEffect(fixture, "deploying"), failedStage("deploy", "pass"));
+    expect(fixture.store.getJob(fixture.job.id)).toMatchObject({
+      state: "implementing",
+      prHeadSha: null,
+    });
+    expect(fixture.store.getOutbox(`job:${fixture.job.id}:production-incident:deploy`)).toMatchObject({
+      payload: {
+        text: "Production deploy failed. The configured rollback restored the previous release. No action is required.",
+      },
+    });
+
+    await runLeasedProduction(
+      fixture,
+      seedProductionEffect(fixture, "verifying_production"),
+      failedStage("canary", "pass"),
+    );
+    expect(fixture.store.getJob(fixture.job.id)).toMatchObject({
+      state: "implementing",
+      prHeadSha: null,
+    });
+    expect(fixture.store.getOutbox(`job:${fixture.job.id}:production-incident:canary`)).toMatchObject({
+      payload: {
+        text: "Production canary failed. The configured rollback restored the previous release. No action is required.",
+      },
+    });
+    expect(fixture.store.getOutbox(`job:${fixture.job.id}:production-incident:deploy`)).toMatchObject({
+      payload: {
+        text: "Production deploy failed. The configured rollback restored the previous release. No action is required.",
+      },
     });
   });
 
@@ -672,7 +706,7 @@ describe("navigator exact-head release", () => {
     ).run(fixture.job.id);
     await runLeasedProduction(fixture, seedProductionEffect(fixture, "deploying"), failedStage("deploy", "pass"));
     expect(fixture.store.getJob(fixture.job.id)?.state).toBe("production_failed");
-    expect(fixture.store.getOutbox(`job:${fixture.job.id}:production-incident`)).toBeNull();
+    expect(fixture.store.getOutbox(`job:${fixture.job.id}:production-incident:deploy`)).toBeNull();
     expect(fixture.store.listOwnerBoundaries(fixture.job.id)).toEqual([]);
   });
 

--- a/tests/review-concurrency.test.ts
+++ b/tests/review-concurrency.test.ts
@@ -237,3 +237,81 @@ it("keeps simultaneous opposite review verdicts bound to their own jobs", async 
     await run.done;
   }
 });
+
+it("returns a legacy navigator review pass to navigation when the exact diff requires docs", async () => {
+  const { bb, harness } = createFakePluginHost({
+    pluginId: "navigator-review-docs-plugin",
+    sdk: {
+      subscribe: () => () => undefined,
+      threads: { interactions: { list: async () => [] } },
+    },
+  });
+  await plugin(bb);
+  const store = openStore(bb.storage);
+  const db = bb.storage.database();
+  const headSha = sha("d");
+  const job = prepareReviewJob(store, db, {
+    id: "job_nav_docs",
+    sourceUpdateId: 201,
+    projectId: "proj_nav",
+    environmentId: "environment_nav",
+    implementationThreadId: "implementation_nav",
+    reviewThreadId: "review_quality_nav",
+    riskReviewThreadId: "review_risk_nav",
+    attemptId: "attempt_nav",
+    riskAttemptId: "attempt_nav_risk",
+    headSha,
+  });
+  db.prepare(
+    `UPDATE jobs SET workflow_engine = 'navigator-v1', workflow_mode = 'deterministic',
+       routing_mode = 'legacy' WHERE id = ?`,
+  ).run(job.id);
+
+  harness.sdk.stub("environments.status", async () => ({
+    outcome: "available",
+    available: true,
+    clean: true,
+    checkout: { headSha },
+  }));
+  harness.sdk.stub("environments.diff", async () => ({
+    outcome: "available",
+    diff: {
+      diff: "diff --git a/docs/operations.md b/docs/operations.md\n+++ b/docs/operations.md\n@@ -1 +1 @@\n-old\n+new",
+      truncated: false,
+    },
+  }));
+  harness.sdk.stub("threads.get", async ({ threadId }: { threadId: string }) => makeThreadResponse({
+    id: threadId,
+    projectId: "proj_nav",
+    environmentId: "environment_nav",
+    status: threadId === "implementation_nav" ? "active" : "idle",
+    updatedAt: 2_000,
+    runtime: {
+      displayStatus: threadId === "implementation_nav" ? "active" : "idle",
+      hostReconnectGraceExpiresAt: null,
+    },
+  }));
+  harness.sdk.stub("threads.output", async () => ({
+    output: reviewOutput({
+      verdict: "pass",
+      reviewedHeadSha: headSha,
+      summary: "Navigator review passed",
+    }),
+  }));
+
+  const run = harness.behavior.runService("job-executor");
+  try {
+    await vi.waitFor(() => expect(store.getJob(job.id)).toMatchObject({
+      state: "implementing",
+      prHeadSha: null,
+    }));
+    expect(db.prepare(
+      "SELECT reason_code, previous_state FROM navigator_release_findings WHERE job_id = ?",
+    ).all(job.id)).toEqual([
+      { reason_code: "documentation_required", previous_state: "reviewing" },
+    ]);
+  } finally {
+    run.controller.abort();
+    await run.done;
+  }
+});

--- a/tests/state-machine.test.ts
+++ b/tests/state-machine.test.ts
@@ -802,3 +802,230 @@ it("completes a cancellation that was already requested but never confirmed", ()
   expect(result.job.state).toBe("cancelled");
   expect(result.job.cancelRequestedAt).toBe(4_000);
 });
+
+describe("navigator-v1 release transitions", () => {
+  const head = sha();
+  const navigator = (state: JobState, overrides: Parameters<typeof stateJob>[1] = {}) =>
+    stateJob(state, {
+      workflowEngine: "navigator-v1",
+      workflowMode: "deterministic",
+      taskOutcome: "shipped_change",
+      ...overrides,
+    });
+
+  it("starts exact-head release from implementing without inspecting the implementation", () => {
+    const result = transition(
+      navigator("implementing"),
+      {
+        type: "RELEASE_STARTED",
+        number: 42,
+        url: "https://github.test/pr/42",
+        environmentId: "env_job_42",
+      },
+      10_000,
+    );
+
+    expect(result.job).toMatchObject({
+      state: "resolving_pr_head",
+      prNumber: 42,
+      prUrl: "https://github.test/pr/42",
+      environmentId: "env_job_42",
+    });
+    expect(result.effects.map((effect) => effect.kind)).toEqual(["resolve_pr_head"]);
+  });
+
+  it("rejects implementation idle and recipe release-started on the opposite engines", () => {
+    expect(() => transition(navigator("implementing"), { type: "IMPLEMENTATION_IDLE" }, 10_000))
+      .toThrow(IllegalTransitionError);
+    expect(() => transition(
+      stateJob("implementing"),
+      {
+        type: "RELEASE_STARTED",
+        number: 42,
+        url: "https://github.test/pr/42",
+        environmentId: "env_job_42",
+      },
+      10_000,
+    )).toThrow(IllegalTransitionError);
+  });
+
+  it("returns validation, review, and documentation findings to navigation without remediation or docs work", () => {
+    const validation = transition(
+      navigator("validating", { prHeadSha: head, prNumber: 42 }),
+      { type: "VALIDATION_FAILED", headSha: head, reason: "Validation did not pass" },
+      10_000,
+    );
+    expect(validation.job).toMatchObject({ state: "implementing", prHeadSha: null });
+    expect(validation.effects.map((effect) => effect.kind)).toEqual(["revoke_approvals", "render_status"]);
+
+    const review = transition(
+      navigator("reviewing", { prHeadSha: head, prNumber: 42 }),
+      { type: "REVIEW_CHANGES_REQUESTED", headSha: head, summary: "Review requested changes" },
+      10_001,
+    );
+    expect(review.job).toMatchObject({ state: "implementing", prHeadSha: null });
+    expect(review.effects.map((effect) => effect.kind)).toEqual(["revoke_approvals", "render_status"]);
+
+    const docs = transition(
+      navigator("reviewing", { prHeadSha: head, prNumber: 42, policy: policyFixture() }),
+      {
+        type: "REVIEW_PASSED",
+        headSha: head,
+        documentation: { required: true, reasons: ["docs.stale"], diffDigest: "b".repeat(64) },
+      },
+      10_002,
+    );
+    expect(docs.job).toMatchObject({ state: "implementing", prHeadSha: null });
+    expect(docs.effects.map((effect) => effect.kind)).toEqual(["revoke_approvals", "render_status"]);
+  });
+
+  it("still patches and documents recipe jobs after the same findings", () => {
+    const validation = transition(
+      stateJob("validating", { prHeadSha: head }),
+      { type: "VALIDATION_FAILED", headSha: head, reason: "Validation did not pass" },
+      10_000,
+    );
+    expect(validation.job.state).toBe("remediating");
+    expect(validation.effects.map((effect) => effect.kind)).toContain("send_remediation");
+
+    const docs = transition(
+      stateJob("reviewing", { prHeadSha: head, policy: policyFixture() }),
+      { type: "REVIEW_PASSED", headSha: head },
+      10_001,
+    );
+    expect(docs.job.state).toBe("documenting");
+    expect(docs.effects.map((effect) => effect.kind)).toContain("spawn_docs");
+  });
+
+  it("skips the recipe docs loop and issues approval for a shipped navigator head", () => {
+    const result = transition(
+      navigator("reviewing", { prHeadSha: head, policy: policyFixture() }),
+      { type: "REVIEW_PASSED", headSha: head },
+      10_000,
+    );
+
+    expect(result.job.state).toBe("awaiting_merge_approval");
+    expect(result.effects.map((effect) => effect.kind)).toEqual(["issue_approval"]);
+  });
+
+  it("returns a recovered production incident to navigation and rejects that event on recipe jobs", () => {
+    const recovered = transition(
+      navigator("deploying", {
+        mergeMessage: "Merged pull request #42",
+        mergeCommitSha: sha("d"),
+        mergedAt: "2026-08-10T18:00:00.000Z",
+        prHeadSha: head,
+      }),
+      { type: "PRODUCTION_INCIDENT_RECOVERED", phase: "deploy", reason: "Production deploy failed" },
+      10_000,
+    );
+    expect(recovered.job).toMatchObject({
+      state: "implementing",
+      prHeadSha: null,
+      mergeCommitSha: sha("d"),
+    });
+    expect(recovered.effects.map((effect) => effect.kind)).toEqual(["revoke_approvals", "render_status"]);
+
+    const canary = transition(
+      navigator("verifying_production", {
+        mergeCommitSha: sha("d"),
+        mergedAt: "2026-08-10T18:00:00.000Z",
+      }),
+      { type: "PRODUCTION_INCIDENT_RECOVERED", phase: "canary", reason: "Production canary failed" },
+      10_001,
+    );
+    expect(canary.job.state).toBe("implementing");
+
+    expect(() => transition(
+      stateJob("deploying"),
+      { type: "PRODUCTION_INCIDENT_RECOVERED", phase: "deploy", reason: "Production deploy failed" },
+      10_002,
+    )).toThrow(IllegalTransitionError);
+  });
+
+  it("still fails recipe production after a successful rollback event is withheld", () => {
+    const result = transition(
+      stateJob("deploying", {
+        mergeMessage: "Merged pull request #7",
+        mergeCommitSha: sha("d"),
+        mergedAt: "2026-08-10T18:00:00.000Z",
+      }),
+      { type: "DEPLOY_FAILED", reason: "Production deploy failed" },
+      10_000,
+    );
+    expect(result.job.state).toBe("production_failed");
+  });
+
+  it("keeps merge-once and unverified base-content incidents for navigator jobs", () => {
+    const merged = transition(
+      navigator("awaiting_merge_approval", { prHeadSha: head, prNumber: 42 }),
+      { type: "APPROVAL_ACCEPTED", headSha: head },
+      10_000,
+    );
+    expect(merged.job.state).toBe("merging");
+    expect(merged.effects.map((effect) => effect.kind)).toEqual(["merge_pr"]);
+
+    const unverified = transition(
+      navigator("merging"),
+      {
+        type: "MERGE_SUCCEEDED",
+        message: "Merged pull request #42",
+        mergeCommitSha: sha("d"),
+        mergedAt: "2026-08-10T18:00:00.000Z",
+        baseContentVerified: false,
+      },
+      10_001,
+    );
+    expect(unverified.job.state).toBe("production_failed");
+    expect(unverified.job.lastError).toMatch(/did not verify the approved content/u);
+  });
+
+  it("deploys before canary and completes only after canary, or merges without production", () => {
+    const deployed = transition(
+      navigator("merging", { policy: policyFixture() }),
+      {
+        type: "MERGE_SUCCEEDED",
+        message: "Merged pull request #42",
+        mergeCommitSha: sha("d"),
+        mergedAt: "2026-08-10T18:00:00.000Z",
+        baseContentVerified: true,
+      },
+      10_000,
+    );
+    expect(deployed.job.state).toBe("deploying");
+    expect(deployed.effects.map((effect) => effect.kind)).toEqual(["render_status", "deploy_production"]);
+
+    const canary = transition(
+      navigator("deploying", { policy: policyFixture() }),
+      { type: "DEPLOY_SUCCEEDED", summary: "Production deployment passed" },
+      10_001,
+    );
+    expect(canary.job.state).toBe("verifying_production");
+    expect(canary.effects.map((effect) => effect.kind)).toContain("verify_production");
+
+    const complete = transition(
+      navigator("verifying_production"),
+      { type: "CANARY_SUCCEEDED", summary: "Production canary passed" },
+      10_002,
+    );
+    expect(complete.job.state).toBe("complete");
+
+    const policy = policyFixture({
+      autonomy: { unattendedMerge: false, mergeWithoutProduction: true },
+    });
+    delete (policy as Partial<typeof policy>).production;
+    const merged = transition(
+      navigator("merging", { policy, taskOutcome: "shipped_change" }),
+      {
+        type: "MERGE_SUCCEEDED",
+        message: "Merged pull request #42",
+        mergeCommitSha: sha("d"),
+        mergedAt: "2026-08-10T18:00:00.000Z",
+        baseContentVerified: true,
+      },
+      10_003,
+    );
+    expect(merged.job.state).toBe("merged");
+  });
+});
+

--- a/tests/state-machine.test.ts
+++ b/tests/state-machine.test.ts
@@ -900,7 +900,11 @@ describe("navigator-v1 release transitions", () => {
   it("skips the recipe docs loop and issues approval for a shipped navigator head", () => {
     const result = transition(
       navigator("reviewing", { prHeadSha: head, policy: policyFixture() }),
-      { type: "REVIEW_PASSED", headSha: head },
+      {
+        type: "REVIEW_PASSED",
+        headSha: head,
+        documentation: { required: false, reasons: [], diffDigest: "b".repeat(64) },
+      },
       10_000,
     );
 

--- a/tests/task-authority.test.ts
+++ b/tests/task-authority.test.ts
@@ -12,6 +12,14 @@ import { openStore } from "../src/storage/store";
 import { jobFixture, policyFixture, sha } from "./helpers";
 
 let fixtureIndex = 0;
+function policyWithRollback() {
+  return policyFixture({
+    production: {
+      ...policyFixture().production!,
+      rollbackCommand: { name: "rollback", command: "./rollback", timeoutMs: 60_000 },
+    },
+  });
+}
 function ownerJobFixture(task: string, policy = policyFixture()) {
   fixtureIndex += 1;
   const { bb } = createFakePluginHost({ pluginId: `task-authority-${fixtureIndex}` });
@@ -445,7 +453,7 @@ function staleAuthoritativeBoundarySource(
     expect(fixture.store.admitTaskAuthorityOperation(effect, "merge", 10_003)).toBe(true);
   } else if (code === "policy_change_required") {
     db.prepare("UPDATE jobs SET policy_json = ? WHERE id = ?")
-      .run(JSON.stringify(policyFixture()), fixture.job.id);
+      .run(JSON.stringify(policyWithRollback()), fixture.job.id);
   } else if (code === "technical_tradeoff_required") {
     db.prepare("UPDATE effects SET attempts = 19 WHERE idempotency_key = ?")
       .run(affected.affectedEffectIdempotencyKey);
@@ -1195,7 +1203,7 @@ describe("owner task authority intake", () => {
     }],
     ["resolved policy", (fixture: ReturnType<typeof ownerJobFixture>, affectedEffectIdempotencyKey: string) => {
       fixture.bb.storage.database().prepare("UPDATE jobs SET policy_json = ? WHERE id = ?")
-        .run(JSON.stringify(policyFixture()), fixture.job.id);
+        .run(JSON.stringify(policyWithRollback()), fixture.job.id);
       return { affectedEffectIdempotencyKey };
     }],
   ] as const)("rejects a policy boundary with %s", (_scenario, arrange) => {
@@ -1642,9 +1650,10 @@ describe("owner task authority intake", () => {
   });
 
   it("auto-authorizes the exact shipped task merge with a durable accepted approval", async () => {
-    const fixture = ownerJobFixture("Fix the retry loop");
+    const policy = policyWithRollback();
+    const fixture = ownerJobFixture("Fix the retry loop", policy);
     const headSha = sha("b");
-    const key = prepareApprovalEffect(fixture, policyFixture(), headSha);
+    const key = prepareApprovalEffect(fixture, policy, headSha);
 
     await runApprovalEffect(fixture, key);
 
@@ -1674,8 +1683,9 @@ describe("owner task authority intake", () => {
   });
 
   it("does not issue approval while a repeatedly reviewed shipped task seeks independent evidence", async () => {
-    const fixture = ownerJobFixture("Fix and ship the retry loop");
-    const key = prepareApprovalEffect(fixture, policyFixture(), sha("b"));
+    const policy = policyWithRollback();
+    const fixture = ownerJobFixture("Fix and ship the retry loop", policy);
+    const key = prepareApprovalEffect(fixture, policy, sha("b"));
     fixture.bb.storage.database().prepare(
       "UPDATE jobs SET review_cycle = 2 WHERE id = ?",
     ).run(fixture.job.id);
@@ -1709,6 +1719,30 @@ describe("owner task authority intake", () => {
       status: "pending",
       affectedEffectIdempotencyKey: `${fixture.job.id}:3:merge_pr`,
     });
+    expect(fixture.store.listEffectsForJob(fixture.job.id).some((effect) => effect.kind === "merge_pr")).toBe(false);
+    const reopened = openStore(fixture.bb.storage, fixture.bb.storage.kv, () => 10_000);
+    expect(reopened.listOwnerBoundaries(fixture.job.id)).toEqual(boundaries);
+  });
+
+  it("records one policy boundary instead of merging production without rollback", async () => {
+    const policy = policyFixture();
+    const fixture = ownerJobFixture("Fix the retry loop", policy);
+    const key = prepareApprovalEffect(fixture, policy, sha("c"));
+
+    await runApprovalEffect(fixture, key);
+
+    expect(fixture.store.getJob(fixture.job.id)?.state).toBe("awaiting_merge_approval");
+    expect(fixture.bb.storage.database().prepare(
+      "SELECT COUNT(*) AS count FROM approvals WHERE job_id = ?",
+    ).get(fixture.job.id)).toEqual({ count: 0 });
+    const boundaries = fixture.store.listOwnerBoundaries(fixture.job.id);
+    expect(boundaries).toHaveLength(1);
+    expect(boundaries[0]).toMatchObject({
+      code: "policy_change_required",
+      status: "pending",
+      affectedEffectIdempotencyKey: `${fixture.job.id}:3:merge_pr`,
+    });
+    expect(boundaries[0]?.blocker.toLowerCase()).toContain("rollback");
     expect(fixture.store.listEffectsForJob(fixture.job.id).some((effect) => effect.kind === "merge_pr")).toBe(false);
     const reopened = openStore(fixture.bb.storage, fixture.bb.storage.kv, () => 10_000);
     expect(reopened.listOwnerBoundaries(fixture.job.id)).toEqual(boundaries);


### PR DESCRIPTION
A navigator job can now take an implementation-complete task through the guarded release that already exists. Start-release is accepted only after durable implementation artifacts. The controller creates or refreshes the final pull request at the exact accepted head, derives one exact-head authority receipt after earlier gates, merges at most once, then runs configured deploy, canary, and rollback without a routine owner prompt. Review, validation, or required documentation returns the job to navigation and revokes stale head evidence. A failed deploy or canary rolls back within a one-notice incident budget. Missing or failed rollback brakes admission and requires production recovery.

This PR is exactly two commits on `ticket/41-owner-authority`.

`0c40ff4` feat: ship navigator tasks through exact-head production adds the navigator release path. Contracts, executor, repository, state-machine transitions, effect-runner, and storage now create or refresh the final PR, keep repository identity and exact-head evidence, consume a live task, explicit, or standing grant, and run production from the configured owner-authored commands.

`eb081a5` fix: compute navigator docs, require rollback for unattended production, and key incident notices by phase computes documentation from the actual navigator diff instead of skipping it, pauses unattended production that has no rollback command, and keys incident notices by deploy versus canary so one recovered phase does not overwrite the other.

Stacked on `ticket/41-owner-authority`, the current head of PR #50 (`809c717195f8154fa75cc73acc8ec1aff93b19fe`). Refs #42. Issue #42 stays open.

The review-fix loop closed with zero open findings at this exact head (`eb081a59f430ebf91fb056ecb9f1f8af317776b1`). CLOSURE_GATE burden 0, Standards 0 / Spec 0.
