### PR TITLE
fix: reply when a Telegram pairing code is expired or invalid

### DIFF
--- a/src/telegram/ingress.ts
+++ b/src/telegram/ingress.ts
@@ -278,6 +278,16 @@ export class TelegramIngress {
           text: "Telegram Agent paired. Talk naturally with Luna, or use /help for recovery controls.",
           disable_web_page_preview: true,
         });
+      } else {
+        // A failed code must not fall silent: an owner who opened an expired or
+        // already-used pairing link would otherwise get no reply and assume the
+        // bot is dead. Tell them why and how to recover.
+        await this.telegram.sendMessage(identity.chatId, {
+          text: result.reason === "already_paired"
+            ? "This bot is already paired with an owner. Unpair the current owner before pairing another account."
+            : "That pairing link is invalid or has expired. Pairing links last 10 minutes — generate a fresh one and open it right away.",
+          disable_web_page_preview: true,
+        });
       }
       return;
     }

--- a/tests/telegram-ingress.test.ts
+++ b/tests/telegram-ingress.test.ts
@@ -547,6 +547,22 @@ it("pairs only a valid unconsumed code in a private chat", async () => {
   expect(groupFixture.store.getOwner()).toBeNull();
 });
 
+it("tells the private-chat sender when a pairing code is expired or invalid instead of going silent", async () => {
+  // The code is valid 1_000..11_000; deliver it after it expired.
+  const expiredFixture = ingressFixture({ pairingCode: "pair-code" });
+  await expiredFixture.ingress.handleClaimed(messageUpdate(1, 7, 70, "/start pair-code"), 12_000);
+  expect(expiredFixture.store.getOwner()).toBeNull();
+  expect(expiredFixture.telegram.sent).toHaveLength(1);
+  expect(expiredFixture.telegram.sent[0]?.payload.text ?? "").toMatch(/expired|invalid|new pairing link/i);
+
+  // An unknown code (typo, or a link that was never issued here).
+  const unknownFixture = ingressFixture({ pairingCode: "pair-code" });
+  await unknownFixture.ingress.handleClaimed(messageUpdate(2, 8, 80, "/start wrong-code"), 2_000);
+  expect(unknownFixture.store.getOwner()).toBeNull();
+  expect(unknownFixture.telegram.sent).toHaveLength(1);
+  expect(unknownFixture.telegram.sent[0]?.payload.text ?? "").toMatch(/expired|invalid|new pairing link/i);
+});
+
 it("keeps /projects deterministic and out of the Luna controller queue", async () => {
   const fixture = ingressFixture({ owner: { userId: "7", chatId: "70" } });
 


### PR DESCRIPTION
## The bug (found via a real user)

An owner configured the bot, opened a pairing link, and got **no reply at all** — the bot looked dead. Root cause: the ingress `/start <code>` handler only sends a message when pairing **succeeds**:

```ts
if (result.ok) { await sendMessage(... "Telegram Agent paired ..."); }
return;   // failure → silent
```

Pairing links expire after 10 minutes, so this is easy to hit: open the link a little late (or reuse one) and `pairOwnerWithPrivateChatCode` returns `{ ok: false, reason: "expired" | "missing" | "consumed" | "already_paired" }`, the handler returns without sending anything, and the user is stuck with silence.

## The fix

Send a private-chat reply on a failed `/start <code>`:
- expired / unknown / already-used code → "That pairing link is invalid or has expired. Pairing links last 10 minutes — generate a fresh one and open it right away."
- an owner already exists → "This bot is already paired with an owner. Unpair the current owner before pairing another account."

Successful pairing is unchanged. The reply only fires in a private chat (an identified sender), so group chats and unidentified senders stay silent as before.

## Test

`tests/telegram-ingress.test.ts` gains a regression test that drives an **expired** code and an **unknown** code and asserts the sender is told — the same test goes red on the old silent-return behavior.

Full `npm run check` passes (194 files / 4884 tests) against the pinned `bbPluginSdk ^0.4.1`.
