### PR TITLE
feat(browser): implement protected Vercel identity journey

### DIFF
--- a/broker/src/browser-journey.ts
+++ b/broker/src/browser-journey.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { createHmac, timingSafeEqual } from "node:crypto";
 import { promisify } from "node:util";
 import {
   parseProtectedConnectorTarget,
@@ -7,6 +8,7 @@ import {
   VERCEL_PROJECT_IDENTITY_JOURNEY_VERSION,
   type BrowserVercelProjectTarget,
 } from "../../src/credentials/connector-policy.js";
+import { canonicalBrokerJson } from "../../src/credentials/protocol.js";
 import type { BrowserVercelProjectIdentity } from "../../src/credentials/connector-protocol.js";
 import type {
   ProtectedConnectorExecutionFailure,
@@ -68,7 +70,7 @@ export type BrowserJourneyDeniedObservation = Readonly<{
 
 export type BrowserJourneyRun = BrowserJourneyObservation | BrowserJourneyDeniedObservation;
 
-export type BrowserTopologyEvidence = Readonly<{
+export type BrowserTopologyEvidencePayload = Readonly<{
   schemaVersion: 1;
   evidenceId: string;
   observedAt: number;
@@ -77,6 +79,10 @@ export type BrowserTopologyEvidence = Readonly<{
   controllerMayAdminGrants: boolean;
   workerMayAdminProfiles: boolean;
   workerMayAdminGrants: boolean;
+}>;
+
+export type BrowserTopologyEvidence = BrowserTopologyEvidencePayload & Readonly<{
+  attestation: string;
 }>;
 
 export type BrowserProfileLeasePort = Readonly<{
@@ -115,6 +121,7 @@ export type ProtectedVercelBrowserExecutor = Readonly<{
 export type BrowserJourneyDependencies = Readonly<{
   browser: BrowserJourneyBrowserPort;
   topology: () => BrowserTopologyEvidence;
+  topologyKey: Uint8Array;
   lease: BrowserProfileLeasePort;
   clock: () => number;
 }>;
@@ -151,17 +158,80 @@ function browserTarget(candidateTarget: unknown): BrowserVercelProjectTarget | n
   return parsed.ok && parsed.value.operation === "browser.vercel_project.inspect.v1" ? parsed.value : null;
 }
 
-export function browserTopologyIsProtected(evidence: BrowserTopologyEvidence, now: number): boolean {
-  return evidence.schemaVersion === 1 &&
-    safeId(evidence.evidenceId) &&
-    safeTimestamp(evidence.observedAt) &&
-    safeTimestamp(evidence.expiresAt) &&
-    evidence.observedAt <= now &&
-    now < evidence.expiresAt &&
-    evidence.controllerMayAdminProfiles === false &&
-    evidence.controllerMayAdminGrants === false &&
-    evidence.workerMayAdminProfiles === false &&
-    evidence.workerMayAdminGrants === false;
+const TOPOLOGY_EVIDENCE_KEYS = Object.freeze([
+  "schemaVersion",
+  "evidenceId",
+  "observedAt",
+  "expiresAt",
+  "controllerMayAdminProfiles",
+  "controllerMayAdminGrants",
+  "workerMayAdminProfiles",
+  "workerMayAdminGrants",
+] as const);
+
+function topologyEvidencePayload(evidence: BrowserTopologyEvidencePayload): BrowserTopologyEvidencePayload {
+  return {
+    schemaVersion: evidence.schemaVersion,
+    evidenceId: evidence.evidenceId,
+    observedAt: evidence.observedAt,
+    expiresAt: evidence.expiresAt,
+    controllerMayAdminProfiles: evidence.controllerMayAdminProfiles,
+    controllerMayAdminGrants: evidence.controllerMayAdminGrants,
+    workerMayAdminProfiles: evidence.workerMayAdminProfiles,
+    workerMayAdminGrants: evidence.workerMayAdminGrants,
+  };
+}
+
+function topologyAttestation(evidence: BrowserTopologyEvidencePayload, key: Uint8Array): string {
+  if (key.byteLength !== 32) throw new Error("browser_topology_key_invalid");
+  return createHmac("sha256", Buffer.from(key))
+    .update(canonicalBrokerJson(topologyEvidencePayload(evidence)), "utf8")
+    .digest("hex");
+}
+
+export function attestBrowserTopologyEvidence(
+  evidence: BrowserTopologyEvidencePayload,
+  key: Uint8Array,
+): BrowserTopologyEvidence {
+  return Object.freeze({
+    ...topologyEvidencePayload(evidence),
+    attestation: topologyAttestation(evidence, key),
+  });
+}
+
+function hasExactTopologyEvidenceKeys(candidateEvidence: object): boolean {
+  const keys = Object.keys(candidateEvidence);
+  return keys.length === TOPOLOGY_EVIDENCE_KEYS.length + 1 &&
+    [...TOPOLOGY_EVIDENCE_KEYS, "attestation"].every((key) => keys.includes(key));
+}
+
+export function browserTopologyIsProtected(
+  evidence: BrowserTopologyEvidence,
+  now: number,
+  key: Uint8Array,
+): boolean {
+  try {
+    if (!evidence || typeof evidence !== "object" || !hasExactTopologyEvidenceKeys(evidence)) return false;
+    if (
+      evidence.schemaVersion !== 1 ||
+      !safeId(evidence.evidenceId) ||
+      !safeTimestamp(evidence.observedAt) ||
+      !safeTimestamp(evidence.expiresAt) ||
+      evidence.observedAt > now ||
+      now >= evidence.expiresAt ||
+      evidence.controllerMayAdminProfiles !== false ||
+      evidence.controllerMayAdminGrants !== false ||
+      evidence.workerMayAdminProfiles !== false ||
+      evidence.workerMayAdminGrants !== false ||
+      typeof evidence.attestation !== "string" ||
+      !/^[a-f0-9]{64}$/u.test(evidence.attestation)
+    ) return false;
+    const expected = Buffer.from(topologyAttestation(evidence, key), "hex");
+    const supplied = Buffer.from(evidence.attestation, "hex");
+    return expected.length === supplied.length && timingSafeEqual(expected, supplied);
+  } catch {
+    return false;
+  }
 }
 
 function journeyPath(target: BrowserVercelProjectTarget): string {
@@ -188,30 +258,51 @@ const deny = (reason) => ({ ok: false, reason });
 try {
   const initial = new URL(page.url());
   if (initial.origin !== EXPECTED_ORIGIN) return deny("stale_tab");
-  await page.goto(${JSON.stringify(url)}, { waitUntil: "domcontentloaded" });
-  const finalUrl = new URL(page.url());
-  if (finalUrl.origin !== EXPECTED_ORIGIN) return deny("login_redirect");
-  if (finalUrl.pathname !== EXPECTED_PATH) return deny("wrong_project");
-  const frameOrigins = page.frames().map((frame) => new URL(frame.url()).origin);
-  if (frameOrigins.some((frameOrigin) => frameOrigin !== EXPECTED_ORIGIN)) return deny("cross_origin_frame");
-  if (await page.locator('input[type="password"]').count() > 0) return deny("login_redirect");
-  const projectHeading = page.getByRole("heading", { name: EXPECTED_PROJECT, exact: true });
-  if (await projectHeading.count() !== 1) return deny("wrong_project");
-  const teamLinks = page.locator('a[href^="/"]');
-  let teamMatches = false;
-  for (let index = 0; index < await teamLinks.count(); index += 1) {
-    if (await teamLinks.nth(index).getAttribute("href") === "/" + EXPECTED_TEAM) teamMatches = true;
-  }
-  if (!teamMatches) return deny("wrong_team");
-  return {
-    ok: true,
-    origin: EXPECTED_ORIGIN,
-    frameOrigins,
-    teamSlug: EXPECTED_TEAM,
-    projectName: EXPECTED_PROJECT,
-    sessionStatus: "authenticated",
-    observedAt: Date.now()
+  let crossOriginNavigation = false;
+  const trackNavigation = (request) => {
+    if (!request.isNavigationRequest()) return;
+    let current = request;
+    while (current) {
+      try {
+        if (new URL(current.url()).origin !== EXPECTED_ORIGIN) crossOriginNavigation = true;
+      } catch {
+        crossOriginNavigation = true;
+      }
+      current = current.redirectedFrom();
+    }
   };
+  page.on("request", trackNavigation);
+  try {
+    await page.goto(${JSON.stringify(url)}, { waitUntil: "domcontentloaded" });
+    if (crossOriginNavigation) return deny("login_redirect");
+    const finalUrl = new URL(page.url());
+    if (finalUrl.origin !== EXPECTED_ORIGIN) return deny("login_redirect");
+    if (finalUrl.pathname !== EXPECTED_PATH) return deny("wrong_project");
+    const frameOrigins = page.frames().map((frame) => new URL(frame.url()).origin);
+    if (frameOrigins.some((frameOrigin) => frameOrigin !== EXPECTED_ORIGIN)) return deny("cross_origin_frame");
+    if (await page.locator('input[type="password"]').count() > 0) return deny("login_redirect");
+    const projectHeading = page.getByRole("heading", { name: EXPECTED_PROJECT, exact: true });
+    if (await projectHeading.count() !== 1) return deny("wrong_project");
+    const teamLinks = page.locator('a[href^="/"]');
+    let teamMatches = false;
+    for (let index = 0; index < await teamLinks.count(); index += 1) {
+      if (await teamLinks.nth(index).getAttribute("href") === "/" + EXPECTED_TEAM) teamMatches = true;
+    }
+    if (!teamMatches) return deny("wrong_team");
+    return {
+      ok: true,
+      origin: EXPECTED_ORIGIN,
+      frameOrigins,
+      teamSlug: EXPECTED_TEAM,
+      projectName: EXPECTED_PROJECT,
+      sessionStatus: "authenticated",
+      observedAt: Date.now()
+    };
+  } catch {
+    return deny(crossOriginNavigation ? "login_redirect" : "ambiguous");
+  } finally {
+    page.off("request", trackNavigation);
+  }
 } catch {
   return deny("ambiguous");
 }`.trim();
@@ -275,7 +366,7 @@ export function createVercelBrowserJourneyExecutor(
       } catch {
         return browserJourneyFailure("unsafe_topology");
       }
-      if (!browserTopologyIsProtected(topology, now)) return browserJourneyFailure("unsafe_topology");
+      if (!browserTopologyIsProtected(topology, now, dependencies.topologyKey)) return browserJourneyFailure("unsafe_topology");
       if (input.signal?.aborted || !currentLease(dependencies.lease, target, input.leaseId)) {
         return browserJourneyFailure("reconciliation_required");
       }
@@ -320,7 +411,7 @@ export function createVercelBrowserJourneyExecutor(
       } catch {
         return browserJourneyFailure("unsafe_topology");
       }
-      if (!browserTopologyIsProtected(topologyAfter, dependencies.clock()) || topologyAfter.evidenceId !== topology.evidenceId) {
+      if (!browserTopologyIsProtected(topologyAfter, dependencies.clock(), dependencies.topologyKey) || topologyAfter.evidenceId !== topology.evidenceId) {
         return browserJourneyFailure("unsafe_topology");
       }
       if (
@@ -490,14 +581,14 @@ export function createBbBrowserJourneyBrowserPort(options: Readonly<{ invoke?: B
     async runVercelProjectJourney(target) {
       const journey = buildVercelBrowserJourney(target);
       const opened = parseOpenTab(await run([
-        "browser", "open", journey.url, "--profile", target.profileId,
+        "browser", "open", journey.url, "--host", target.hostId, "--profile", target.profileId,
         "--timeout", String(VERCEL_BROWSER_JOURNEY_TIMEOUT_MS), "--json",
       ]));
       if (opened.origin !== journey.origin) throw new Error("browser_origin_denied");
       const observation = parseJourneyObservation(await run([
         "browser", "script", "--purpose", VERCEL_BROWSER_JOURNEY_PURPOSE,
         "--code", journey.script, "--origin", journey.origin,
-        "--profile", target.profileId, "--tab", opened.tabId,
+        "--host", target.hostId, "--profile", target.profileId, "--tab", opened.tabId,
         "--timeout", String(VERCEL_BROWSER_JOURNEY_TIMEOUT_MS), "--json",
       ]), opened.tabId);
       return observation;

--- a/broker/src/browser-journey.ts
+++ b/broker/src/browser-journey.ts
@@ -1,0 +1,506 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  parseProtectedConnectorTarget,
+  VERCEL_BROWSER_ORIGIN,
+  VERCEL_PROJECT_IDENTITY_JOURNEY_ID,
+  VERCEL_PROJECT_IDENTITY_JOURNEY_VERSION,
+  type BrowserVercelProjectTarget,
+} from "../../src/credentials/connector-policy.js";
+import type { BrowserVercelProjectIdentity } from "../../src/credentials/connector-protocol.js";
+import type {
+  ProtectedConnectorExecutionFailure,
+  ProtectedConnectorExecutionSuccess,
+} from "./connector-authority-service.js";
+
+const execFileAsync = promisify(execFile);
+
+export const VERCEL_BROWSER_JOURNEY_CONNECTOR_VERSION = "browser-journey-1" as const;
+export const VERCEL_BROWSER_JOURNEY_PURPOSE = "Protected Vercel project identity journey v1" as const;
+export const VERCEL_BROWSER_JOURNEY_TIMEOUT_MS = 15_000;
+
+/** The BB Browser capabilities required by this journey's protected host. */
+export const BROWSER_REQUIRED_CAPABILITIES = Object.freeze([
+  "bb-connect",
+  "browser",
+  "dedicated-user",
+  "protected-storage",
+  "sandbox",
+] as const);
+
+const SAFE_OPAQUE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
+
+export type BrowserCapabilityObservation = Readonly<{
+  id: string;
+  status: "ready" | "unavailable";
+}>;
+
+export type BrowserStatusObservation = Readonly<{
+  hostId: string;
+  profileId: string;
+  state: "ready" | "sleeping";
+  capabilities: readonly BrowserCapabilityObservation[];
+  observedAt: number;
+}>;
+
+export type BrowserGrantObservation = Readonly<{
+  grantId: string;
+  hostId: string;
+  profileId: string;
+  origin: string;
+  state: "active" | "expired" | "revoked";
+  expiresAt: number | null;
+}>;
+
+export type BrowserJourneyObservation = Readonly<{
+  tabId: string;
+  origin: string;
+  frameOrigins: readonly string[];
+  teamSlug: string;
+  projectName: string;
+  sessionStatus: "authenticated" | "login";
+  observedAt: number;
+}>;
+
+export type BrowserJourneyDeniedObservation = Readonly<{
+  deniedReason: "stale_tab" | "login_redirect" | "wrong_project" | "wrong_team" | "cross_origin_frame" | "ambiguous";
+}>;
+
+export type BrowserJourneyRun = BrowserJourneyObservation | BrowserJourneyDeniedObservation;
+
+export type BrowserTopologyEvidence = Readonly<{
+  schemaVersion: 1;
+  evidenceId: string;
+  observedAt: number;
+  expiresAt: number;
+  controllerMayAdminProfiles: boolean;
+  controllerMayAdminGrants: boolean;
+  workerMayAdminProfiles: boolean;
+  workerMayAdminGrants: boolean;
+}>;
+
+export type BrowserProfileLeasePort = Readonly<{
+  isCurrent(input: Readonly<{
+    leaseId: string;
+    hostId: string;
+    profileId: string;
+  }>): boolean;
+}>;
+
+export type BrowserJourneyBrowserPort = Readonly<{
+  readStatus(input: Readonly<{ hostId: string; profileId: string }>): Promise<BrowserStatusObservation>;
+  readGrants(input: Readonly<{ hostId: string; profileId: string }>): Promise<readonly BrowserGrantObservation[]>;
+  runVercelProjectJourney(target: BrowserVercelProjectTarget): Promise<BrowserJourneyRun>;
+}>;
+
+export type VercelBrowserJourney = Readonly<{
+  journeyId: typeof VERCEL_PROJECT_IDENTITY_JOURNEY_ID;
+  journeyVersion: typeof VERCEL_PROJECT_IDENTITY_JOURNEY_VERSION;
+  origin: typeof VERCEL_BROWSER_ORIGIN;
+  url: string;
+  script: string;
+}>;
+
+export type ProtectedVercelBrowserExecutor = Readonly<{
+  inspectBrowserVercel(input: Readonly<{
+    target: BrowserVercelProjectTarget;
+    leaseId: string;
+    signal?: AbortSignal;
+  }>): Promise<
+    ProtectedConnectorExecutionSuccess<BrowserVercelProjectIdentity> |
+    ProtectedConnectorExecutionFailure
+  >;
+}>;
+
+export type BrowserJourneyDependencies = Readonly<{
+  browser: BrowserJourneyBrowserPort;
+  topology: () => BrowserTopologyEvidence;
+  lease: BrowserProfileLeasePort;
+  clock: () => number;
+}>;
+
+export type BrowserCliInvoker = (argv: readonly string[]) => Promise<unknown>;
+
+function safeId(candidateId: unknown): candidateId is string {
+  return typeof candidateId === "string" && SAFE_OPAQUE_ID.test(candidateId);
+}
+
+function safeTimestamp(candidateTimestamp: unknown): candidateTimestamp is number {
+  return typeof candidateTimestamp === "number" && Number.isSafeInteger(candidateTimestamp) && candidateTimestamp >= 0;
+}
+
+function safeBoundedLabel(candidateLabel: unknown): candidateLabel is string {
+  return typeof candidateLabel === "string" && candidateLabel.length >= 1 && candidateLabel.length <= 128 && !/[\u0000-\u001f\u007f]/u.test(candidateLabel);
+}
+
+function browserJourneyFailure(
+  failureClass: ProtectedConnectorExecutionFailure["failureClass"],
+  retryable = false,
+): ProtectedConnectorExecutionFailure {
+  return {
+    outcome: "failed",
+    failureClass,
+    retryable,
+    retryAfterMs: retryable ? 30_000 : null,
+    connectorVersion: VERCEL_BROWSER_JOURNEY_CONNECTOR_VERSION,
+  };
+}
+
+function browserTarget(candidateTarget: unknown): BrowserVercelProjectTarget | null {
+  const parsed = parseProtectedConnectorTarget(candidateTarget);
+  return parsed.ok && parsed.value.operation === "browser.vercel_project.inspect.v1" ? parsed.value : null;
+}
+
+export function browserTopologyIsProtected(evidence: BrowserTopologyEvidence, now: number): boolean {
+  return evidence.schemaVersion === 1 &&
+    safeId(evidence.evidenceId) &&
+    safeTimestamp(evidence.observedAt) &&
+    safeTimestamp(evidence.expiresAt) &&
+    evidence.observedAt <= now &&
+    now < evidence.expiresAt &&
+    evidence.controllerMayAdminProfiles === false &&
+    evidence.controllerMayAdminGrants === false &&
+    evidence.workerMayAdminProfiles === false &&
+    evidence.workerMayAdminGrants === false;
+}
+
+function journeyPath(target: BrowserVercelProjectTarget): string {
+  return `/${encodeURIComponent(target.teamSlug)}/${encodeURIComponent(target.projectName)}`;
+}
+
+/**
+ * The only JavaScript admitted to BB Browser. Target labels are enrolled
+ * broker data, quoted as JSON; callers cannot provide URL, selector, or code.
+ */
+export function buildVercelBrowserJourney(target: BrowserVercelProjectTarget): VercelBrowserJourney {
+  const parsed = browserTarget(target);
+  if (!parsed) throw new Error("browser_journey_target_invalid");
+  const path = journeyPath(parsed);
+  const team = JSON.stringify(parsed.teamSlug);
+  const project = JSON.stringify(parsed.projectName);
+  const url = `${VERCEL_BROWSER_ORIGIN}${path}`;
+  const script = `
+const EXPECTED_ORIGIN = ${JSON.stringify(VERCEL_BROWSER_ORIGIN)};
+const EXPECTED_PATH = ${JSON.stringify(path)};
+const EXPECTED_TEAM = ${team};
+const EXPECTED_PROJECT = ${project};
+const deny = (reason) => ({ ok: false, reason });
+try {
+  const initial = new URL(page.url());
+  if (initial.origin !== EXPECTED_ORIGIN) return deny("stale_tab");
+  await page.goto(${JSON.stringify(url)}, { waitUntil: "domcontentloaded" });
+  const finalUrl = new URL(page.url());
+  if (finalUrl.origin !== EXPECTED_ORIGIN) return deny("login_redirect");
+  if (finalUrl.pathname !== EXPECTED_PATH) return deny("wrong_project");
+  const frameOrigins = page.frames().map((frame) => new URL(frame.url()).origin);
+  if (frameOrigins.some((frameOrigin) => frameOrigin !== EXPECTED_ORIGIN)) return deny("cross_origin_frame");
+  if (await page.locator('input[type="password"]').count() > 0) return deny("login_redirect");
+  const projectHeading = page.getByRole("heading", { name: EXPECTED_PROJECT, exact: true });
+  if (await projectHeading.count() !== 1) return deny("wrong_project");
+  const teamLinks = page.locator('a[href^="/"]');
+  let teamMatches = false;
+  for (let index = 0; index < await teamLinks.count(); index += 1) {
+    if (await teamLinks.nth(index).getAttribute("href") === "/" + EXPECTED_TEAM) teamMatches = true;
+  }
+  if (!teamMatches) return deny("wrong_team");
+  return {
+    ok: true,
+    origin: EXPECTED_ORIGIN,
+    frameOrigins,
+    teamSlug: EXPECTED_TEAM,
+    projectName: EXPECTED_PROJECT,
+    sessionStatus: "authenticated",
+    observedAt: Date.now()
+  };
+} catch {
+  return deny("ambiguous");
+}`.trim();
+  return Object.freeze({
+    journeyId: VERCEL_PROJECT_IDENTITY_JOURNEY_ID,
+    journeyVersion: VERCEL_PROJECT_IDENTITY_JOURNEY_VERSION,
+    origin: VERCEL_BROWSER_ORIGIN,
+    url,
+    script,
+  });
+}
+
+function hasReadyCapabilities(status: BrowserStatusObservation): boolean {
+  return BROWSER_REQUIRED_CAPABILITIES.every((id) =>
+    status.capabilities.some((capability) => capability.id === id && capability.status === "ready"));
+}
+
+function currentLease(lease: BrowserProfileLeasePort, target: BrowserVercelProjectTarget, leaseId: string): boolean {
+  try {
+    return lease.isCurrent({ leaseId, hostId: target.hostId, profileId: target.profileId });
+  } catch {
+    return false;
+  }
+}
+
+function exactGrant(
+  grants: readonly BrowserGrantObservation[],
+  target: BrowserVercelProjectTarget,
+  now: number,
+): ProtectedConnectorExecutionFailure | BrowserGrantObservation {
+  const targetGrants = grants.filter((grant) => grant.hostId === target.hostId && grant.profileId === target.profileId);
+  if (targetGrants.some((grant) => grant.origin !== target.origin && grant.state === "active")) {
+    return browserJourneyFailure("destination_denied");
+  }
+  const matching = targetGrants.filter((grant) => grant.origin === target.origin);
+  if (matching.length !== 1) return browserJourneyFailure(matching.length === 0 ? "scope_insufficient" : "result_ambiguous");
+  const grant = matching[0]!;
+  if (grant.state !== "active") return browserJourneyFailure(grant.state === "expired" ? "credential_expired" : "scope_insufficient");
+  if (grant.expiresAt !== null && grant.expiresAt <= now) return browserJourneyFailure("credential_expired");
+  return grant;
+}
+
+function deniedJourneyFailure(reason: BrowserJourneyDeniedObservation["deniedReason"]): ProtectedConnectorExecutionFailure {
+  if (reason === "login_redirect") return browserJourneyFailure("credential_expired");
+  if (reason === "ambiguous") return browserJourneyFailure("result_ambiguous");
+  if (reason === "stale_tab") return browserJourneyFailure("reconciliation_required");
+  return browserJourneyFailure("destination_denied");
+}
+
+export function createVercelBrowserJourneyExecutor(
+  dependencies: BrowserJourneyDependencies,
+): ProtectedVercelBrowserExecutor {
+  return {
+    async inspectBrowserVercel(input) {
+      const target = browserTarget(input.target);
+      if (!target || !safeId(input.leaseId)) return browserJourneyFailure("destination_denied");
+      const now = dependencies.clock();
+      let topology: BrowserTopologyEvidence;
+      try {
+        topology = dependencies.topology();
+      } catch {
+        return browserJourneyFailure("unsafe_topology");
+      }
+      if (!browserTopologyIsProtected(topology, now)) return browserJourneyFailure("unsafe_topology");
+      if (input.signal?.aborted || !currentLease(dependencies.lease, target, input.leaseId)) {
+        return browserJourneyFailure("reconciliation_required");
+      }
+
+      let status: BrowserStatusObservation;
+      try {
+        status = await dependencies.browser.readStatus({ hostId: target.hostId, profileId: target.profileId });
+      } catch {
+        return browserJourneyFailure("provider_unavailable", true);
+      }
+      if (
+        status.hostId !== target.hostId ||
+        status.profileId !== target.profileId ||
+        !["ready", "sleeping"].includes(status.state) ||
+        !hasReadyCapabilities(status) ||
+        !safeTimestamp(status.observedAt) ||
+        status.observedAt > now
+      ) return browserJourneyFailure("destination_denied");
+      if (input.signal?.aborted || !currentLease(dependencies.lease, target, input.leaseId)) {
+        return browserJourneyFailure("reconciliation_required");
+      }
+
+      let grants: readonly BrowserGrantObservation[];
+      try {
+        grants = await dependencies.browser.readGrants({ hostId: target.hostId, profileId: target.profileId });
+      } catch {
+        return browserJourneyFailure("provider_unavailable", true);
+      }
+      const grant = exactGrant(grants, target, now);
+      if ("outcome" in grant) return grant;
+      if (!currentLease(dependencies.lease, target, input.leaseId)) return browserJourneyFailure("reconciliation_required");
+
+      let journeyObservation: BrowserJourneyRun;
+      try {
+        journeyObservation = await dependencies.browser.runVercelProjectJourney(target);
+      } catch {
+        return browserJourneyFailure("provider_unavailable", true);
+      }
+      let topologyAfter: BrowserTopologyEvidence;
+      try {
+        topologyAfter = dependencies.topology();
+      } catch {
+        return browserJourneyFailure("unsafe_topology");
+      }
+      if (!browserTopologyIsProtected(topologyAfter, dependencies.clock()) || topologyAfter.evidenceId !== topology.evidenceId) {
+        return browserJourneyFailure("unsafe_topology");
+      }
+      if (
+        input.signal?.aborted ||
+        !currentLease(dependencies.lease, target, input.leaseId)
+      ) return browserJourneyFailure("reconciliation_required");
+      if ("deniedReason" in journeyObservation) return deniedJourneyFailure(journeyObservation.deniedReason);
+      if (
+        !safeId(journeyObservation.tabId) ||
+        journeyObservation.origin !== target.origin ||
+        journeyObservation.frameOrigins.length === 0 ||
+        journeyObservation.frameOrigins.some((origin) => origin !== target.origin)
+      ) return browserJourneyFailure("destination_denied");
+      if (journeyObservation.sessionStatus !== "authenticated") return browserJourneyFailure("credential_expired");
+      if (journeyObservation.teamSlug !== target.teamSlug || journeyObservation.projectName !== target.projectName) {
+        return browserJourneyFailure("destination_denied");
+      }
+      if (!safeTimestamp(journeyObservation.observedAt) || journeyObservation.observedAt > dependencies.clock()) {
+        return browserJourneyFailure("result_ambiguous");
+      }
+      return {
+        outcome: "succeeded",
+        connectorVersion: VERCEL_BROWSER_JOURNEY_CONNECTOR_VERSION,
+        identity: {
+          profileId: target.profileId,
+          journeyId: target.journeyId,
+          journeyVersion: target.journeyVersion,
+          origin: target.origin,
+          teamSlug: target.teamSlug,
+          projectName: target.projectName,
+          sessionStatus: "authenticated",
+          observedAt: journeyObservation.observedAt,
+        },
+      };
+    },
+  };
+}
+
+function jsonObject(candidatePayload: unknown): Record<string, unknown> {
+  if (!candidatePayload || typeof candidatePayload !== "object" || Array.isArray(candidatePayload)) throw new Error("browser_json_invalid");
+  return candidatePayload as Record<string, unknown>;
+}
+
+function parseStatus(statusPayload: unknown, observedAt: number): BrowserStatusObservation {
+  const statusRecord = jsonObject(statusPayload);
+  const capabilities = statusRecord.capabilities;
+  if (!Array.isArray(capabilities)) throw new Error("browser_status_invalid");
+  const normalized = capabilities.map((entry) => {
+    const capabilityRecord = jsonObject(entry);
+    if (!safeBoundedLabel(capabilityRecord.id) || (capabilityRecord.status !== "ready" && capabilityRecord.status !== "unavailable")) {
+      throw new Error("browser_status_invalid");
+    }
+    return { id: capabilityRecord.id, status: capabilityRecord.status } as const;
+  });
+  if (!safeId(statusRecord.hostId) || !safeId(statusRecord.profileId) || (statusRecord.state !== "ready" && statusRecord.state !== "sleeping")) {
+    throw new Error("browser_status_invalid");
+  }
+  return { hostId: statusRecord.hostId, profileId: statusRecord.profileId, state: statusRecord.state, capabilities: normalized, observedAt };
+}
+
+function parseGrant(grantPayload: unknown): BrowserGrantObservation {
+  const grantRecord = jsonObject(grantPayload);
+  const grantId = grantRecord.grantId ?? grantRecord.id;
+  const state = grantRecord.state ?? grantRecord.status;
+  if (
+    !safeId(grantId) ||
+    !safeId(grantRecord.hostId) ||
+    !safeId(grantRecord.profileId) ||
+    typeof grantRecord.origin !== "string" ||
+    !["active", "expired", "revoked"].includes(String(state)) ||
+    !(grantRecord.expiresAt === null || safeTimestamp(grantRecord.expiresAt))
+  ) throw new Error("browser_grant_invalid");
+  return {
+    grantId,
+    hostId: grantRecord.hostId,
+    profileId: grantRecord.profileId,
+    origin: grantRecord.origin,
+    state: state as BrowserGrantObservation["state"],
+    expiresAt: grantRecord.expiresAt as number | null,
+  };
+}
+
+function parseJourneyObservation(journeyPayload: unknown, tabId: string): BrowserJourneyRun {
+  const wrapperRecord = jsonObject(journeyPayload);
+  const journeyResult = "result" in wrapperRecord ? wrapperRecord.result : wrapperRecord;
+  const journeyRecord = jsonObject(journeyResult);
+  if (
+    journeyRecord.ok === false &&
+    ["stale_tab", "login_redirect", "wrong_project", "wrong_team", "cross_origin_frame", "ambiguous"].includes(String(journeyRecord.reason))
+  ) {
+    return { deniedReason: journeyRecord.reason as BrowserJourneyDeniedObservation["deniedReason"] };
+  }
+  if (
+    journeyRecord.ok !== true ||
+    journeyRecord.origin !== VERCEL_BROWSER_ORIGIN ||
+    !Array.isArray(journeyRecord.frameOrigins) ||
+    !journeyRecord.frameOrigins.every((origin) => origin === VERCEL_BROWSER_ORIGIN) ||
+    !safeBoundedLabel(journeyRecord.teamSlug) ||
+    !safeBoundedLabel(journeyRecord.projectName) ||
+    journeyRecord.sessionStatus !== "authenticated" ||
+    !safeTimestamp(journeyRecord.observedAt)
+  ) throw new Error("browser_journey_observation_invalid");
+  return {
+    tabId,
+    origin: VERCEL_BROWSER_ORIGIN,
+    frameOrigins: Object.freeze([...journeyRecord.frameOrigins]),
+    teamSlug: journeyRecord.teamSlug,
+    projectName: journeyRecord.projectName,
+    sessionStatus: "authenticated",
+    observedAt: journeyRecord.observedAt,
+  };
+}
+
+function parseOpenTab(openPayload: unknown): Readonly<{ tabId: string; origin: string }> {
+  const openRecord = jsonObject(openPayload);
+  const tabId = openRecord.tabId;
+  const url = openRecord.url;
+  if (!safeId(tabId) || typeof url !== "string") throw new Error("browser_tab_invalid");
+  let origin: string;
+  try {
+    origin = new URL(url).origin;
+  } catch {
+    throw new Error("browser_tab_invalid");
+  }
+  return { tabId, origin };
+}
+
+async function defaultBrowserCliInvoker(argv: readonly string[]): Promise<unknown> {
+  try {
+    const childProcessResult = await execFileAsync("bb", [...argv], {
+      shell: false,
+      maxBuffer: 256 * 1024,
+    });
+    return JSON.parse(childProcessResult.stdout);
+  } catch {
+    throw new Error("browser_cli_failed");
+  }
+}
+
+/**
+ * Exact-argv BB Browser adapter. It exposes no generic command, URL, selector,
+ * script, cookie, storage, screenshot, or credential operation.
+ */
+export function createBbBrowserJourneyBrowserPort(options: Readonly<{ invoke?: BrowserCliInvoker }> = {}): BrowserJourneyBrowserPort {
+  const invoke = options.invoke ?? defaultBrowserCliInvoker;
+  const run = async (argv: readonly string[]): Promise<unknown> => {
+    try {
+      return await invoke(argv);
+    } catch {
+      throw new Error("browser_cli_failed");
+    }
+  };
+  return {
+    async readStatus(input) {
+      return parseStatus(await run([
+        "browser", "status", "--host", input.hostId, "--profile", input.profileId, "--json",
+      ]), Date.now());
+    },
+    async readGrants(input) {
+      const grantsPayload = await run([
+        "browser", "grants", "--host", input.hostId, "--profile", input.profileId, "--json",
+      ]);
+      const grants = Array.isArray(grantsPayload) ? grantsPayload : jsonObject(grantsPayload).grants;
+      if (!Array.isArray(grants)) throw new Error("browser_grants_invalid");
+      return Object.freeze(grants.map(parseGrant));
+    },
+    async runVercelProjectJourney(target) {
+      const journey = buildVercelBrowserJourney(target);
+      const opened = parseOpenTab(await run([
+        "browser", "open", journey.url, "--profile", target.profileId,
+        "--timeout", String(VERCEL_BROWSER_JOURNEY_TIMEOUT_MS), "--json",
+      ]));
+      if (opened.origin !== journey.origin) throw new Error("browser_origin_denied");
+      const observation = parseJourneyObservation(await run([
+        "browser", "script", "--purpose", VERCEL_BROWSER_JOURNEY_PURPOSE,
+        "--code", journey.script, "--origin", journey.origin,
+        "--profile", target.profileId, "--tab", opened.tabId,
+        "--timeout", String(VERCEL_BROWSER_JOURNEY_TIMEOUT_MS), "--json",
+      ]), opened.tabId);
+      return observation;
+    },
+  };
+}

--- a/broker/src/connector-authority-service.ts
+++ b/broker/src/connector-authority-service.ts
@@ -36,6 +36,7 @@ export type ProtectedConnectorExecutionFailure = Readonly<{
     ProtectedConnectorFailureClass,
     | "scope_insufficient"
     | "destination_denied"
+    | "unsafe_topology"
     | "human_presence_required"
     | "credential_invalid"
     | "credential_expired"
@@ -74,6 +75,7 @@ export type ProtectedConnectorExecutor = Readonly<{
   }>): Promise<ProtectedConnectorExecutionSuccess<VercelProjectIdentity> | ProtectedConnectorExecutionFailure>;
   inspectBrowserVercel(input: Readonly<{
     target: BrowserVercelProjectTarget;
+    leaseId: string;
     signal?: AbortSignal;
   }>): Promise<ProtectedConnectorExecutionSuccess<BrowserVercelProjectIdentity> | ProtectedConnectorExecutionFailure>;
 }>;
@@ -108,6 +110,7 @@ type ConnectorAuthorization =
       binding: BrokerConnectorBinding;
       target: ProtectedConnectorTarget;
       credentialReference: string | null;
+      browserLeaseId: string | null;
     }>
   | Readonly<{ outcome: "denied"; response: ProtectedConnectorResponseEnvelope }>;
 
@@ -235,7 +238,56 @@ export class ProtectedConnectorAuthorityService {
     if (authorityDenial) return { outcome: "denied", response: authorityDenial };
     const bindingAuthorization = this.authorizeBinding(request, now);
     if (bindingAuthorization.outcome === "denied") return bindingAuthorization;
-    return this.resolveBindingTarget(request, bindingAuthorization.binding, now);
+    const targetAuthorization = this.resolveBindingTarget(request, bindingAuthorization.binding, now);
+    if (targetAuthorization.outcome === "denied") return targetAuthorization;
+    return this.claimBrowserProfile(request, targetAuthorization, now);
+  }
+
+  private claimBrowserProfile(
+    request: ProtectedConnectorRequestEnvelope,
+    authorization: Extract<ConnectorAuthorization, { outcome: "authorized" }>,
+    now: number,
+  ): ConnectorAuthorization {
+    if (authorization.target.operation !== "browser.vercel_project.inspect.v1") {
+      return authorization;
+    }
+    try {
+      const claim = this.connectorStore.claimBrowserProfile({
+        installationId: request.installationId,
+        requestId: request.requestId,
+        idempotencyKey: request.idempotencyKey,
+        hostId: authorization.target.hostId,
+        profileId: authorization.target.profileId,
+        bindingGeneration: request.bindingGeneration,
+        fenceOwner: request.fenceOwner,
+        fenceGeneration: request.fenceGeneration,
+        leaseId: `browser_lease_${randomUUID()}`,
+        leaseExpiresAt: request.deadlineAt,
+        now,
+      });
+      if (claim.outcome === "busy") {
+        return {
+          outcome: "denied",
+          response: this.completeFailure({
+            request,
+            binding: authorization.binding,
+            failureClass: "reconciliation_required",
+            completedAt: now,
+          }),
+        };
+      }
+      return { ...authorization, browserLeaseId: claim.leaseId };
+    } catch {
+      return {
+        outcome: "denied",
+        response: this.completeFailure({
+          request,
+          binding: authorization.binding,
+          failureClass: "reconciliation_required",
+          completedAt: now,
+        }),
+      };
+    }
   }
 
   private claimedAuthorityDenial(
@@ -305,6 +357,7 @@ export class ProtectedConnectorAuthorityService {
         binding,
         target,
         credentialReference: this.connectorStore.resolveCredentialReference(binding),
+        browserLeaseId: null,
       };
     } catch {
       return {
@@ -319,7 +372,12 @@ export class ProtectedConnectorAuthorityService {
     signal?: AbortSignal,
   ): Promise<ConnectorExecution> {
     try {
-      return await this.dispatch(authorization.target, authorization.credentialReference, signal);
+      return await this.dispatch(
+        authorization.target,
+        authorization.credentialReference,
+        authorization.browserLeaseId,
+        signal,
+      );
     } catch {
       return {
         outcome: "failed",
@@ -339,7 +397,12 @@ export class ProtectedConnectorAuthorityService {
   }>): ProtectedConnectorResponseEnvelope {
     const completedAt = this.clock();
     const { binding, target } = input.authorization;
-    if (!this.completionAuthorityCurrent(input.certificateFingerprint, input.request, binding, completedAt)) {
+    if (!this.completionAuthorityCurrent(
+      input.certificateFingerprint,
+      input.request,
+      input.authorization,
+      completedAt,
+    )) {
       return this.completeFailure({
         request: input.request,
         binding,
@@ -368,7 +431,7 @@ export class ProtectedConnectorAuthorityService {
   private completionAuthorityCurrent(
     certificateFingerprint: string,
     request: ProtectedConnectorRequestEnvelope,
-    binding: BrokerConnectorBinding,
+    authorization: Extract<ConnectorAuthorization, { outcome: "authorized" }>,
     completedAt: number,
   ): boolean {
     return !temporalFailure(request, completedAt) &&
@@ -376,7 +439,27 @@ export class ProtectedConnectorAuthorityService {
       this.policyStillCurrent(request) &&
       this.authority.topologyReady(request.operation) &&
       this.fenceCurrent(request) &&
-      this.bindingStillCurrent(request, binding, completedAt);
+      this.bindingStillCurrent(request, authorization.binding, completedAt) &&
+      this.browserLeaseStillCurrent(request, authorization, completedAt);
+  }
+
+  private browserLeaseStillCurrent(
+    request: ProtectedConnectorRequestEnvelope,
+    authorization: Extract<ConnectorAuthorization, { outcome: "authorized" }>,
+    now: number,
+  ): boolean {
+    if (authorization.target.operation !== "browser.vercel_project.inspect.v1") return true;
+    return authorization.browserLeaseId !== null && this.connectorStore.isBrowserProfileLeaseCurrent({
+      leaseId: authorization.browserLeaseId,
+      installationId: request.installationId,
+      requestId: request.requestId,
+      hostId: authorization.target.hostId,
+      profileId: authorization.target.profileId,
+      bindingGeneration: request.bindingGeneration,
+      fenceOwner: request.fenceOwner,
+      fenceGeneration: request.fenceGeneration,
+      now,
+    });
   }
 
   private completeExecutionFailure(
@@ -465,6 +548,7 @@ export class ProtectedConnectorAuthorityService {
   private async dispatch(
     target: ProtectedConnectorTarget,
     credentialReference: string | null,
+    browserLeaseId: string | null,
     signal?: AbortSignal,
   ): Promise<ProtectedConnectorExecutionSuccess<ProtectedConnectorIdentity> | ProtectedConnectorExecutionFailure> {
     if (target.operation === "convex.project.inspect.v1") {
@@ -475,8 +559,8 @@ export class ProtectedConnectorAuthorityService {
       if (!credentialReference) return this.missingCredentialFailure();
       return this.executor.inspectVercel({ target, credentialReference, signal });
     }
-    if (credentialReference !== null) return this.missingCredentialFailure();
-    return this.executor.inspectBrowserVercel({ target, signal });
+    if (credentialReference !== null || browserLeaseId === null) return this.missingCredentialFailure();
+    return this.executor.inspectBrowserVercel({ target, leaseId: browserLeaseId, signal });
   }
 
   private missingCredentialFailure(): ProtectedConnectorExecutionFailure {

--- a/broker/src/connector-store.ts
+++ b/broker/src/connector-store.ts
@@ -69,6 +69,22 @@ type ConnectorRequestRow = {
   completed_at: number | null;
 };
 
+type BrowserProfileLeaseRow = {
+  lease_id: string;
+  installation_id: string;
+  request_id: string;
+  idempotency_key: string;
+  host_id: string;
+  profile_id: string;
+  binding_generation: number;
+  fence_owner: string;
+  fence_generation: number;
+  state: "held" | "released" | "expired";
+  lease_expires_at: number;
+  created_at: number;
+  updated_at: number;
+};
+
 export type BrokerConnectorPolicy = Readonly<{
   installationId: string;
   projectId: string;
@@ -97,6 +113,10 @@ export type BrokerConnectorRequestClaim =
   | { outcome: "completed"; response: ProtectedConnectorResponseEnvelope }
   | { outcome: "ambiguous" }
   | { outcome: "digest_mismatch" };
+
+export type BrokerBrowserProfileLeaseClaim =
+  | Readonly<{ outcome: "claimed" | "already_held"; leaseId: string; leaseExpiresAt: number }>
+  | Readonly<{ outcome: "busy" }>;
 
 export type BrokerConnectorStoreOptions = Readonly<{
   dataKey: Uint8Array;
@@ -415,6 +435,109 @@ export class BrokerProtectedConnectorStore {
     return { outcome: "claimed" };
   }
 
+  /** Atomically reserves one enrolled browser profile for one request/fence. */
+  public claimBrowserProfile(input: Readonly<{
+    installationId: string;
+    requestId: string;
+    idempotencyKey: string;
+    hostId: string;
+    profileId: string;
+    bindingGeneration: number;
+    fenceOwner: string;
+    fenceGeneration: number;
+    leaseId: string;
+    leaseExpiresAt: number;
+    now: number;
+  }>): BrokerBrowserProfileLeaseClaim {
+    if (
+      !input.installationId || !input.requestId || !input.idempotencyKey || !input.hostId || !input.profileId ||
+      !input.leaseId || input.leaseExpiresAt <= input.now
+    ) throw stableError("browser_profile_lease_invalid");
+    this.assertActiveInstallation(input.installationId);
+    try {
+      return this.db.transaction((): BrokerBrowserProfileLeaseClaim => {
+        const existing = this.db.prepare(`
+          SELECT * FROM broker_browser_profile_leases
+           WHERE installation_id = ? AND host_id = ? AND profile_id = ? AND state = 'held'
+        `).get(input.installationId, input.hostId, input.profileId) as BrowserProfileLeaseRow | undefined;
+        if (existing) {
+          if (existing.lease_expires_at <= input.now) {
+            this.db.prepare(`
+              UPDATE broker_browser_profile_leases
+                 SET state = 'expired', updated_at = ?
+               WHERE lease_id = ? AND state = 'held'
+            `).run(input.now, existing.lease_id);
+          } else if (
+            existing.request_id === input.requestId &&
+            existing.idempotency_key === input.idempotencyKey &&
+            existing.binding_generation === input.bindingGeneration &&
+            existing.fence_owner === input.fenceOwner &&
+            existing.fence_generation === input.fenceGeneration
+          ) {
+            return {
+              outcome: "already_held",
+              leaseId: existing.lease_id,
+              leaseExpiresAt: existing.lease_expires_at,
+            };
+          } else {
+            return { outcome: "busy" };
+          }
+        }
+        this.db.prepare(`
+          INSERT INTO broker_browser_profile_leases (
+            lease_id, installation_id, request_id, idempotency_key, host_id, profile_id,
+            binding_generation, fence_owner, fence_generation, state,
+            lease_expires_at, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'held', ?, ?, ?)
+        `).run(
+          input.leaseId,
+          input.installationId,
+          input.requestId,
+          input.idempotencyKey,
+          input.hostId,
+          input.profileId,
+          input.bindingGeneration,
+          input.fenceOwner,
+          input.fenceGeneration,
+          input.leaseExpiresAt,
+          input.now,
+          input.now,
+        );
+        return { outcome: "claimed", leaseId: input.leaseId, leaseExpiresAt: input.leaseExpiresAt };
+      }).immediate();
+    } catch (error) {
+      if (error instanceof Error && "code" in error && String(error.code).startsWith("SQLITE_CONSTRAINT")) {
+        return { outcome: "busy" };
+      }
+      throw error;
+    }
+  }
+
+  public isBrowserProfileLeaseCurrent(input: Readonly<{
+    leaseId: string;
+    installationId: string;
+    requestId: string;
+    hostId: string;
+    profileId: string;
+    bindingGeneration: number;
+    fenceOwner: string;
+    fenceGeneration: number;
+    now: number;
+  }>): boolean {
+    const row = this.db.prepare(`
+      SELECT * FROM broker_browser_profile_leases
+       WHERE lease_id = ? AND installation_id = ? AND request_id = ?
+    `).get(input.leaseId, input.installationId, input.requestId) as BrowserProfileLeaseRow | undefined;
+    return row !== undefined &&
+      row.host_id === input.hostId &&
+      row.profile_id === input.profileId &&
+      row.binding_generation === input.bindingGeneration &&
+      row.fence_owner === input.fenceOwner &&
+      row.fence_generation === input.fenceGeneration &&
+      row.state === "held" &&
+      row.lease_expires_at > input.now;
+  }
+
   public completeRequest(input: Readonly<{
     request: ProtectedConnectorRequestEnvelope;
     response: ProtectedConnectorResponseEnvelope;
@@ -499,6 +622,11 @@ export class BrokerProtectedConnectorStore {
         row.installation_id,
         row.idempotency_key,
       );
+      this.db.prepare(`
+        UPDATE broker_browser_profile_leases
+           SET state = 'released', updated_at = ?
+         WHERE installation_id = ? AND request_id = ? AND state = 'held'
+      `).run(input.now, row.installation_id, row.request_id);
       return parsed.value;
     }).immediate();
   }

--- a/broker/src/connector-store.ts
+++ b/broker/src/connector-store.ts
@@ -538,6 +538,25 @@ export class BrokerProtectedConnectorStore {
       row.lease_expires_at > input.now;
   }
 
+  /** Checks the opaque lease fence used while the browser adapter is active. */
+  public isBrowserProfileLeaseCurrentForTarget(input: Readonly<{
+    leaseId: string;
+    hostId: string;
+    profileId: string;
+    now: number;
+  }>): boolean {
+    const row = this.db.prepare(`
+      SELECT host_id, profile_id, state, lease_expires_at
+        FROM broker_browser_profile_leases
+       WHERE lease_id = ?
+    `).get(input.leaseId) as Pick<BrowserProfileLeaseRow, "host_id" | "profile_id" | "state" | "lease_expires_at"> | undefined;
+    return row !== undefined &&
+      row.host_id === input.hostId &&
+      row.profile_id === input.profileId &&
+      row.state === "held" &&
+      row.lease_expires_at > input.now;
+  }
+
   public completeRequest(input: Readonly<{
     request: ProtectedConnectorRequestEnvelope;
     response: ProtectedConnectorResponseEnvelope;

--- a/broker/src/main.ts
+++ b/broker/src/main.ts
@@ -11,6 +11,20 @@ import { BrokerOperationService } from "./operation-service.js";
 import { BrokerStore } from "./store.js";
 import { createBrokerServer } from "./server.js";
 import { createAdminServer } from "./admin-server.js";
+import {
+  attestBrowserTopologyEvidence,
+  createBbBrowserJourneyBrowserPort,
+  createVercelBrowserJourneyExecutor,
+  type BrowserCliInvoker,
+  type BrowserTopologyEvidence,
+} from "./browser-journey.js";
+import { BrokerProtectedConnectorStore } from "./connector-store.js";
+import {
+  ProtectedConnectorAuthorityService,
+  type ProtectedConnectorAuthorityPort,
+  type ProtectedConnectorExecutionFailure,
+  type ProtectedConnectorExecutor,
+} from "./connector-authority-service.js";
 
 const BROKER_VERSION = "0.1.0";
 const SHUTDOWN_TIMEOUT_MS = 10_000;
@@ -29,7 +43,65 @@ export type RunningBroker = Readonly<{
 
 export type BrokerStartupOptions = Readonly<{
   adminServer?: BrokerAdminLifecycle;
+  protectedBrowser?: Readonly<{
+    topology?: () => BrowserTopologyEvidence;
+    authority?: ProtectedConnectorAuthorityPort;
+    invoke?: BrowserCliInvoker;
+  }>;
 }>;
+
+export type ProtectedBrowserConnectorServiceDependencies = Readonly<{
+  foundationStore: BrokerStore;
+  connectorStore: BrokerProtectedConnectorStore;
+  topology: () => BrowserTopologyEvidence;
+  topologyKey: Uint8Array;
+  authority: ProtectedConnectorAuthorityPort;
+  clock: () => number;
+  invoke?: BrowserCliInvoker;
+}>;
+
+function unsupportedProtectedConnectorFailure(): ProtectedConnectorExecutionFailure {
+  return {
+    outcome: "failed",
+    failureClass: "reconciliation_required",
+    retryable: false,
+    retryAfterMs: null,
+    connectorVersion: "protected-runtime-1",
+  };
+}
+
+/** Composes the protected authority with the fixed browser journey at startup. */
+export function createProtectedBrowserConnectorService(
+  dependencies: ProtectedBrowserConnectorServiceDependencies,
+): ProtectedConnectorAuthorityService {
+  const browser = createBbBrowserJourneyBrowserPort({ invoke: dependencies.invoke });
+  const browserExecutor = createVercelBrowserJourneyExecutor({
+    browser,
+    topology: dependencies.topology,
+    topologyKey: dependencies.topologyKey,
+    lease: {
+      isCurrent: (input) => dependencies.connectorStore.isBrowserProfileLeaseCurrentForTarget({
+        leaseId: input.leaseId,
+        hostId: input.hostId,
+        profileId: input.profileId,
+        now: dependencies.clock(),
+      }),
+    },
+    clock: dependencies.clock,
+  });
+  const executor: ProtectedConnectorExecutor = {
+    inspectConvex: async () => unsupportedProtectedConnectorFailure(),
+    inspectVercel: async () => unsupportedProtectedConnectorFailure(),
+    inspectBrowserVercel: browserExecutor.inspectBrowserVercel,
+  };
+  return new ProtectedConnectorAuthorityService({
+    foundationStore: dependencies.foundationStore,
+    connectorStore: dependencies.connectorStore,
+    executor,
+    authority: dependencies.authority,
+    clock: dependencies.clock,
+  });
+}
 
 function parseConfigPath(argv: readonly string[]): string {
   if (argv.length !== 2 || argv[0] !== "--config" || !isAbsolute(argv[1])) {
@@ -88,6 +160,35 @@ export async function startBroker(
       clock: Date.now,
       retentionDays: config.retentionDays,
     });
+    const connectorStore = new BrokerProtectedConnectorStore(database, {
+      dataKey: credentials.brokerDataKey,
+      clock: Date.now,
+    });
+    const defaultTopology = attestBrowserTopologyEvidence({
+      schemaVersion: 1,
+      evidenceId: "unconfigured-browser-topology",
+      observedAt: 0,
+      expiresAt: 0,
+      controllerMayAdminProfiles: true,
+      controllerMayAdminGrants: true,
+      workerMayAdminProfiles: true,
+      workerMayAdminGrants: true,
+    }, credentials.brokerAuditKey);
+    const topology = options.protectedBrowser?.topology ?? (() => defaultTopology);
+    const authority = options.protectedBrowser?.authority ?? {
+      topologyReady: () => false,
+      auditWritable: () => true,
+      fenceCurrent: () => false,
+    } satisfies ProtectedConnectorAuthorityPort;
+    const protectedService = createProtectedBrowserConnectorService({
+      foundationStore: store,
+      connectorStore,
+      topology,
+      topologyKey: credentials.brokerAuditKey,
+      authority,
+      clock: Date.now,
+      invoke: options.protectedBrowser?.invoke,
+    });
     const adapter = await createOnePasswordAdapter({ serviceToken: credentials.onepasswordServiceToken });
     const service = new BrokerOperationService({
       store,
@@ -102,6 +203,7 @@ export async function startBroker(
       serverPrivateKeyPem: credentials.serverPrivateKeyPem,
       clientCaCertificatePem: credentials.clientCaCertificatePem,
       service,
+      protectedService,
       clock: Date.now,
       requestBodyLimitBytes: config.requestBodyLimitBytes,
       responseBodyLimitBytes: config.responseBodyLimitBytes,

--- a/broker/src/migrations.ts
+++ b/broker/src/migrations.ts
@@ -1,7 +1,7 @@
 import { chmodSync } from "node:fs";
 import type Database from "better-sqlite3";
 
-const MIGRATION_VERSIONS = [1, 2] as const;
+const MIGRATION_VERSIONS = [1, 2, 3] as const;
 
 export const BROKER_FOUNDATION_SCHEMA = String.raw`
 CREATE TABLE IF NOT EXISTS broker_schema_migrations (
@@ -198,6 +198,31 @@ CREATE TABLE IF NOT EXISTS broker_connector_requests (
 
 CREATE INDEX IF NOT EXISTS broker_connector_requests_task
   ON broker_connector_requests (installation_id, task_id, state);
+
+CREATE TABLE IF NOT EXISTS broker_browser_profile_leases (
+  lease_id TEXT PRIMARY KEY,
+  installation_id TEXT NOT NULL,
+  request_id TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  host_id TEXT NOT NULL,
+  profile_id TEXT NOT NULL,
+  binding_generation INTEGER NOT NULL CHECK (binding_generation >= 1),
+  fence_owner TEXT NOT NULL,
+  fence_generation INTEGER NOT NULL CHECK (fence_generation >= 1),
+  state TEXT NOT NULL CHECK (state IN ('held', 'released', 'expired')),
+  lease_expires_at INTEGER NOT NULL CHECK (lease_expires_at >= 0),
+  created_at INTEGER NOT NULL CHECK (created_at >= 0),
+  updated_at INTEGER NOT NULL CHECK (updated_at >= 0),
+  FOREIGN KEY (installation_id) REFERENCES broker_installations (installation_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS broker_browser_profile_leases_held_profile
+  ON broker_browser_profile_leases (installation_id, host_id, profile_id)
+  WHERE state = 'held';
+CREATE UNIQUE INDEX IF NOT EXISTS broker_browser_profile_leases_request
+  ON broker_browser_profile_leases (installation_id, request_id);
+CREATE INDEX IF NOT EXISTS broker_browser_profile_leases_expiry
+  ON broker_browser_profile_leases (state, lease_expires_at);
 
 CREATE TABLE IF NOT EXISTS broker_connector_receipts (
   receipt_id TEXT PRIMARY KEY,

--- a/broker/src/server.ts
+++ b/broker/src/server.ts
@@ -6,11 +6,17 @@ import type { TLSSocket } from "node:tls";
 import {
   BROKER_MAX_REQUEST_BYTES,
   BROKER_MAX_RESPONSE_BYTES,
-  parseBrokerRequest,
-  parseBrokerResponse,
   type BrokerRequestEnvelope,
   type BrokerResponseEnvelope,
 } from "../../src/credentials/protocol.js";
+import {
+  parseCredentialProtocolRequest,
+  parseCredentialProtocolResponse,
+  type CredentialProtocolRequestEnvelope,
+  type CredentialProtocolResponseEnvelope,
+  type ProtectedConnectorRequestEnvelope,
+  type ProtectedConnectorResponseEnvelope,
+} from "../../src/credentials/connector-protocol.js";
 
 export type BrokerRequestService = Readonly<{
   execute(input: {
@@ -20,11 +26,20 @@ export type BrokerRequestService = Readonly<{
   }): Promise<BrokerResponseEnvelope>;
 }>;
 
+export type ProtectedBrokerRequestService = Readonly<{
+  execute(input: {
+    certificateFingerprint: string;
+    now: number;
+    request: ProtectedConnectorRequestEnvelope;
+  }): Promise<ProtectedConnectorResponseEnvelope>;
+}>;
+
 export type BrokerServerDependencies = Readonly<{
   serverCertificatePem: string;
   serverPrivateKeyPem: string;
   clientCaCertificatePem: string;
   service: BrokerRequestService;
+  protectedService?: ProtectedBrokerRequestService;
   clock?: () => number;
   requestBodyLimitBytes?: number;
   responseBodyLimitBytes?: number;
@@ -103,10 +118,10 @@ function readRequestBody(request: IncomingMessage, limit: number): Promise<BodyR
 
 function sendBrokerResponse(
   response: ServerResponse,
-  brokerResponse: BrokerResponseEnvelope,
+  brokerResponse: CredentialProtocolResponseEnvelope,
   responseLimit: number,
 ): void {
-  const parsed = parseBrokerResponse(brokerResponse);
+  const parsed = parseCredentialProtocolResponse(brokerResponse);
   if (!parsed.ok) {
     sendHttpError(response, 500, "invalid_request");
     return;
@@ -140,10 +155,10 @@ function rejectUnsupportedHttpRequest(request: IncomingMessage, response: Server
   return false;
 }
 
-function parseRequestEnvelope(body: Buffer): BrokerRequestEnvelope | null {
+function parseRequestEnvelope(body: Buffer): CredentialProtocolRequestEnvelope | null {
   try {
     const parsedJson: unknown = JSON.parse(body.toString("utf8"));
-    const parsedRequest = parseBrokerRequest(parsedJson);
+    const parsedRequest = parseCredentialProtocolRequest(parsedJson);
     return parsedRequest.ok ? parsedRequest.value : null;
   } catch {
     return null;
@@ -154,7 +169,7 @@ async function executeBrokerRequest(
   request: IncomingMessage,
   response: ServerResponse,
   dependencies: BrokerServerDependencies,
-  parsedRequest: BrokerRequestEnvelope,
+  parsedRequest: CredentialProtocolRequestEnvelope,
   responseLimit: number,
 ): Promise<void> {
   const fingerprint = certificateFingerprint(request);
@@ -163,11 +178,24 @@ async function executeBrokerRequest(
     return;
   }
   try {
-    const brokerResponse = await dependencies.service.execute({
-      certificateFingerprint: fingerprint,
-      now: dependencies.clock?.() ?? Date.now(),
-      request: parsedRequest,
-    });
+    const now = dependencies.clock?.() ?? Date.now();
+    const brokerResponse = parsedRequest.schemaVersion === 2
+      ? dependencies.protectedService
+        ? await dependencies.protectedService.execute({
+            certificateFingerprint: fingerprint,
+            now,
+            request: parsedRequest,
+          })
+        : null
+      : await dependencies.service.execute({
+          certificateFingerprint: fingerprint,
+          now,
+          request: parsedRequest,
+        });
+    if (!brokerResponse) {
+      sendHttpError(response, 404, "not_found");
+      return;
+    }
     sendBrokerResponse(response, brokerResponse, responseLimit);
   } catch {
     sendHttpError(response, 500, "invalid_request");

--- a/tests/protected-browser-journey.test.ts
+++ b/tests/protected-browser-journey.test.ts
@@ -3,6 +3,7 @@ import {
   BROWSER_REQUIRED_CAPABILITIES,
   VERCEL_BROWSER_JOURNEY_CONNECTOR_VERSION,
   VERCEL_BROWSER_JOURNEY_PURPOSE,
+  attestBrowserTopologyEvidence,
   buildVercelBrowserJourney,
   browserTopologyIsProtected,
   createBbBrowserJourneyBrowserPort,
@@ -24,6 +25,7 @@ import { FOUNDATION_BROKER_POLICY_DIGEST } from "../src/credentials/protocol";
 import { assertCanaryAbsent, temporaryBrokerDatabase } from "./support/credential-broker-fixtures";
 
 const NOW = 1_800_000_000_000;
+const TOPOLOGY_KEY = new Uint8Array(32).fill(0x41);
 
 const target: BrowserVercelProjectTarget = {
   operation: "browser.vercel_project.inspect.v1",
@@ -36,7 +38,7 @@ const target: BrowserVercelProjectTarget = {
   projectName: "hanoon",
 };
 
-const topology: BrowserTopologyEvidence = {
+const topology = attestBrowserTopologyEvidence({
   schemaVersion: 1,
   evidenceId: "topology-1",
   observedAt: NOW,
@@ -45,7 +47,7 @@ const topology: BrowserTopologyEvidence = {
   controllerMayAdminGrants: false,
   workerMayAdminProfiles: false,
   workerMayAdminGrants: false,
-};
+}, TOPOLOGY_KEY);
 
 const status: BrowserStatusObservation = {
   hostId: target.hostId,
@@ -93,6 +95,8 @@ describe("protected Vercel browser journey contract", () => {
     });
     expect(journey.script).toContain(VERCEL_BROWSER_ORIGIN);
     expect(journey.script).toContain("getByRole");
+    expect(journey.script).toContain("redirectedFrom");
+    expect(journey.script).toContain('page.on("request"');
     expect(journey.script).not.toContain("page.content");
     expect(journey.script).not.toContain("document.cookie");
     expect(journey.script).not.toContain("localStorage");
@@ -100,10 +104,51 @@ describe("protected Vercel browser journey contract", () => {
     expect(VERCEL_BROWSER_JOURNEY_CONNECTOR_VERSION).toBe("browser-journey-1");
   });
 
+  it("rejects an intermediate cross-origin redirect even when navigation returns home", async () => {
+    const journey = buildVercelBrowserJourney(target);
+    type FakeRequest = {
+      isNavigationRequest(): boolean;
+      url(): string;
+      redirectedFrom(): FakeRequest | null;
+    };
+    const listeners = new Map<string, (request: FakeRequest) => void>();
+    let currentUrl = journey.url;
+    const initialRequest: FakeRequest = {
+      isNavigationRequest: () => true,
+      url: () => journey.url,
+      redirectedFrom: () => null,
+    };
+    const crossOriginRequest: FakeRequest = {
+      isNavigationRequest: () => true,
+      url: () => "https://evil.example/login",
+      redirectedFrom: () => initialRequest,
+    };
+    const page = {
+      url: () => currentUrl,
+      on: (event: string, listener: (request: FakeRequest) => void) => listeners.set(event, listener),
+      off: (event: string) => listeners.delete(event),
+      goto: async () => {
+        listeners.get("request")?.(initialRequest);
+        listeners.get("request")?.(crossOriginRequest);
+        currentUrl = journey.url;
+      },
+      frames: () => [{ url: () => journey.origin }],
+      locator: (selector: string) => selector.includes("password")
+        ? { count: async () => 0 }
+        : { count: async () => 1, nth: () => ({ getAttribute: async () => "/" + target.teamSlug }) },
+      getByRole: () => ({ count: async () => 1 }),
+    };
+    const execute = new Function("page", `return (async () => { ${journey.script} })();`) as (value: typeof page) => Promise<unknown>;
+
+    await expect(execute(page)).resolves.toEqual({ ok: false, reason: "login_redirect" });
+    expect(listeners.size).toBe(0);
+  });
+
   it("admits only explicit protected-topology evidence", () => {
-    expect(browserTopologyIsProtected(topology, NOW)).toBe(true);
-    expect(browserTopologyIsProtected({ ...topology, workerMayAdminGrants: true }, NOW)).toBe(false);
-    expect(browserTopologyIsProtected({ ...topology, expiresAt: NOW }, NOW)).toBe(false);
+    expect(browserTopologyIsProtected(topology, NOW, TOPOLOGY_KEY)).toBe(true);
+    expect(browserTopologyIsProtected({ ...topology, workerMayAdminGrants: true }, NOW, TOPOLOGY_KEY)).toBe(false);
+    expect(browserTopologyIsProtected({ ...topology, expiresAt: NOW }, NOW, TOPOLOGY_KEY)).toBe(false);
+    expect(browserTopologyIsProtected({ ...topology, attestation: "0".repeat(64) }, NOW, TOPOLOGY_KEY)).toBe(false);
   });
 
   it("rejects arbitrary journey controls instead of forwarding them", () => {
@@ -120,6 +165,7 @@ describe("protected Vercel browser journey contract", () => {
     const executor = createVercelBrowserJourneyExecutor({
       browser: port,
       topology: () => topology,
+      topologyKey: TOPOLOGY_KEY,
       lease: { isCurrent: () => true },
       clock: () => NOW,
     });
@@ -191,6 +237,7 @@ describe("protected Vercel browser journey contract", () => {
     const executor = createVercelBrowserJourneyExecutor({
       browser: port,
       topology: "topology" in overrides ? overrides.topology : (() => topology),
+      topologyKey: TOPOLOGY_KEY,
       lease: { isCurrent: () => true },
       clock: () => NOW,
     });
@@ -208,6 +255,7 @@ describe("protected Vercel browser journey contract", () => {
     const executor = createVercelBrowserJourneyExecutor({
       browser: port,
       topology: () => topology,
+      topologyKey: TOPOLOGY_KEY,
       lease: { isCurrent: () => {
         checks += 1;
         return checks === 1;
@@ -231,6 +279,7 @@ describe("protected Vercel browser journey contract", () => {
     const executor = createVercelBrowserJourneyExecutor({
       browser: port,
       topology: () => topology,
+      topologyKey: TOPOLOGY_KEY,
       lease: { isCurrent: () => true },
       clock: () => NOW,
     });
@@ -269,12 +318,15 @@ describe("protected Vercel browser journey contract", () => {
     expect(calls[0]).toEqual(["browser", "status", "--host", target.hostId, "--profile", target.profileId, "--json"]);
     expect(calls[1]).toEqual(["browser", "grants", "--host", target.hostId, "--profile", target.profileId, "--json"]);
     expect(calls[2]).toEqual([
-      "browser", "open", "https://vercel.com/vercel-team/hanoon", "--profile", target.profileId,
+      "browser", "open", "https://vercel.com/vercel-team/hanoon", "--host", target.hostId,
+      "--profile", target.profileId,
       "--timeout", "15000", "--json",
     ]);
     expect(calls[3]?.slice(0, 2)).toEqual(["browser", "script"]);
     expect(calls[3]).toContain("--origin");
     expect(calls[3]).toContain(target.origin);
+    expect(calls[3]).toContain("--host");
+    expect(calls[3]).toContain(target.hostId);
     expect(calls[3]).toContain("--profile");
     expect(calls[3]).toContain(target.profileId);
     expect(calls[3]).toContain("--tab");

--- a/tests/protected-browser-journey.test.ts
+++ b/tests/protected-browser-journey.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BROWSER_REQUIRED_CAPABILITIES,
+  VERCEL_BROWSER_JOURNEY_CONNECTOR_VERSION,
+  VERCEL_BROWSER_JOURNEY_PURPOSE,
+  buildVercelBrowserJourney,
+  browserTopologyIsProtected,
+  createBbBrowserJourneyBrowserPort,
+  createVercelBrowserJourneyExecutor,
+  type BrowserGrantObservation,
+  type BrowserJourneyBrowserPort,
+  type BrowserStatusObservation,
+  type BrowserTopologyEvidence,
+} from "../broker/src/browser-journey";
+import {
+  VERCEL_BROWSER_ORIGIN,
+  VERCEL_PROJECT_IDENTITY_JOURNEY_ID,
+  VERCEL_PROJECT_IDENTITY_JOURNEY_VERSION,
+  type BrowserVercelProjectTarget,
+} from "../src/credentials/connector-policy";
+import { BrokerProtectedConnectorStore } from "../broker/src/connector-store";
+import { BrokerStore } from "../broker/src/store";
+import { FOUNDATION_BROKER_POLICY_DIGEST } from "../src/credentials/protocol";
+import { assertCanaryAbsent, temporaryBrokerDatabase } from "./support/credential-broker-fixtures";
+
+const NOW = 1_800_000_000_000;
+
+const target: BrowserVercelProjectTarget = {
+  operation: "browser.vercel_project.inspect.v1",
+  hostId: "host-1",
+  profileId: "profile-1",
+  origin: VERCEL_BROWSER_ORIGIN,
+  journeyId: VERCEL_PROJECT_IDENTITY_JOURNEY_ID,
+  journeyVersion: VERCEL_PROJECT_IDENTITY_JOURNEY_VERSION,
+  teamSlug: "vercel-team",
+  projectName: "hanoon",
+};
+
+const topology: BrowserTopologyEvidence = {
+  schemaVersion: 1,
+  evidenceId: "topology-1",
+  observedAt: NOW,
+  expiresAt: NOW + 60_000,
+  controllerMayAdminProfiles: false,
+  controllerMayAdminGrants: false,
+  workerMayAdminProfiles: false,
+  workerMayAdminGrants: false,
+};
+
+const status: BrowserStatusObservation = {
+  hostId: target.hostId,
+  profileId: target.profileId,
+  state: "sleeping",
+  observedAt: NOW,
+  capabilities: BROWSER_REQUIRED_CAPABILITIES.map((id) => ({ id, status: "ready" as const })),
+};
+
+const grant: BrowserGrantObservation = {
+  grantId: "grant-1",
+  hostId: target.hostId,
+  profileId: target.profileId,
+  origin: target.origin,
+  state: "active",
+  expiresAt: NOW + 60_000,
+};
+
+function browserPort(overrides: Partial<BrowserJourneyBrowserPort> = {}): BrowserJourneyBrowserPort {
+  return {
+    readStatus: vi.fn(async () => status),
+    readGrants: vi.fn(async () => [grant]),
+    runVercelProjectJourney: vi.fn(async () => ({
+      tabId: "tab-1",
+      origin: target.origin,
+      frameOrigins: [target.origin],
+      teamSlug: target.teamSlug,
+      projectName: target.projectName,
+      sessionStatus: "authenticated" as const,
+      observedAt: NOW,
+    })),
+    ...overrides,
+  };
+}
+
+describe("protected Vercel browser journey contract", () => {
+  it("builds one fixed versioned journey from the enrolled target only", () => {
+    const journey = buildVercelBrowserJourney(target);
+
+    expect(journey).toMatchObject({
+      journeyId: VERCEL_PROJECT_IDENTITY_JOURNEY_ID,
+      journeyVersion: VERCEL_PROJECT_IDENTITY_JOURNEY_VERSION,
+      origin: VERCEL_BROWSER_ORIGIN,
+      url: "https://vercel.com/vercel-team/hanoon",
+    });
+    expect(journey.script).toContain(VERCEL_BROWSER_ORIGIN);
+    expect(journey.script).toContain("getByRole");
+    expect(journey.script).not.toContain("page.content");
+    expect(journey.script).not.toContain("document.cookie");
+    expect(journey.script).not.toContain("localStorage");
+    expect(VERCEL_BROWSER_JOURNEY_PURPOSE).toBe("Protected Vercel project identity journey v1");
+    expect(VERCEL_BROWSER_JOURNEY_CONNECTOR_VERSION).toBe("browser-journey-1");
+  });
+
+  it("admits only explicit protected-topology evidence", () => {
+    expect(browserTopologyIsProtected(topology, NOW)).toBe(true);
+    expect(browserTopologyIsProtected({ ...topology, workerMayAdminGrants: true }, NOW)).toBe(false);
+    expect(browserTopologyIsProtected({ ...topology, expiresAt: NOW }, NOW)).toBe(false);
+  });
+
+  it("rejects arbitrary journey controls instead of forwarding them", () => {
+    expect(() => buildVercelBrowserJourney({
+      ...target,
+      url: "https://evil.example",
+      selector: "input[type=password]",
+      code: "return document.cookie",
+    } as unknown as BrowserVercelProjectTarget)).toThrow("browser_journey_target_invalid");
+  });
+
+  it("preflights exact status and grant, then returns only bounded identity", async () => {
+    const port = browserPort();
+    const executor = createVercelBrowserJourneyExecutor({
+      browser: port,
+      topology: () => topology,
+      lease: { isCurrent: () => true },
+      clock: () => NOW,
+    });
+
+    const result = await executor.inspectBrowserVercel({ target, leaseId: "lease-1" });
+
+    expect(result).toEqual({
+      outcome: "succeeded",
+      connectorVersion: VERCEL_BROWSER_JOURNEY_CONNECTOR_VERSION,
+      identity: {
+        profileId: target.profileId,
+        journeyId: target.journeyId,
+        journeyVersion: target.journeyVersion,
+        origin: target.origin,
+        teamSlug: target.teamSlug,
+        projectName: target.projectName,
+        sessionStatus: "authenticated",
+        observedAt: NOW,
+      },
+    });
+    expect(port.readStatus).toHaveBeenCalledWith({ hostId: target.hostId, profileId: target.profileId });
+    expect(port.readGrants).toHaveBeenCalledWith({ hostId: target.hostId, profileId: target.profileId });
+    expect(port.runVercelProjectJourney).toHaveBeenCalledWith(target);
+  });
+
+  it.each([
+    ["unsafe topology", { topology: () => ({ ...topology, workerMayAdminProfiles: true }) }, "unsafe_topology"],
+    ["wrong profile status", {
+      browser: browserPort({ readStatus: vi.fn(async () => ({ ...status, profileId: "other-profile" })) }),
+    }, "destination_denied"],
+    ["stale browser state", {
+      browser: browserPort({ readStatus: vi.fn(async () => ({
+        ...status,
+        capabilities: status.capabilities.map((capability) => capability.id === "browser"
+          ? { ...capability, status: "unavailable" as const }
+          : capability),
+      })) }),
+    }, "destination_denied"],
+    ["missing grant", { browser: browserPort({ readGrants: vi.fn(async () => []) }) }, "scope_insufficient"],
+    ["wrong origin grant", {
+      browser: browserPort({ readGrants: vi.fn(async () => [{ ...grant, origin: "https://evil.example" }]) }),
+    }, "destination_denied"],
+    ["expired grant", {
+      browser: browserPort({ readGrants: vi.fn(async () => [{ ...grant, expiresAt: NOW }]) }),
+    }, "credential_expired"],
+    ["wrong project", {
+      browser: browserPort({ runVercelProjectJourney: vi.fn(async () => ({
+        tabId: "tab-1", origin: target.origin, frameOrigins: [target.origin], teamSlug: target.teamSlug,
+        projectName: "other-project", sessionStatus: "authenticated" as const, observedAt: NOW,
+      })) }),
+    }, "destination_denied"],
+    ["login redirect", {
+      browser: browserPort({ runVercelProjectJourney: vi.fn(async () => ({
+        tabId: "tab-1", origin: target.origin, frameOrigins: [target.origin], teamSlug: target.teamSlug,
+        projectName: target.projectName, sessionStatus: "login" as const, observedAt: NOW,
+      })) }),
+    }, "credential_expired"],
+    ["cross-origin frame", {
+      browser: browserPort({ runVercelProjectJourney: vi.fn(async () => ({
+        tabId: "tab-1", origin: target.origin, frameOrigins: [target.origin, "https://evil.example"],
+        teamSlug: target.teamSlug, projectName: target.projectName, sessionStatus: "authenticated" as const, observedAt: NOW,
+      })) }),
+    }, "destination_denied"],
+    ["stale tab", {
+      browser: browserPort({ runVercelProjectJourney: vi.fn(async () => ({ deniedReason: "stale_tab" as const })) }),
+    }, "reconciliation_required"],
+  ] as const)("fails closed for %s", async (_label, overrides, failureClass) => {
+    const port = "browser" in overrides ? overrides.browser : browserPort();
+    const executor = createVercelBrowserJourneyExecutor({
+      browser: port,
+      topology: "topology" in overrides ? overrides.topology : (() => topology),
+      lease: { isCurrent: () => true },
+      clock: () => NOW,
+    });
+
+    const result = await executor.inspectBrowserVercel({ target, leaseId: "lease-1" });
+
+    expect(result).toMatchObject({ outcome: "failed", failureClass });
+    const runCount = vi.mocked(port.runVercelProjectJourney).mock.calls.length;
+    expect(runCount).toBe(["wrong project", "login redirect", "cross-origin frame", "stale tab"].includes(_label) ? 1 : 0);
+  });
+
+  it("stops before browser control when the lease fence is lost", async () => {
+    const port = browserPort();
+    let checks = 0;
+    const executor = createVercelBrowserJourneyExecutor({
+      browser: port,
+      topology: () => topology,
+      lease: { isCurrent: () => {
+        checks += 1;
+        return checks === 1;
+      } },
+      clock: () => NOW,
+    });
+
+    const result = await executor.inspectBrowserVercel({ target, leaseId: "lease-1" });
+
+    expect(result).toMatchObject({ outcome: "failed", failureClass: "reconciliation_required" });
+    expect(port.readStatus).toHaveBeenCalledOnce();
+    expect(port.readGrants).not.toHaveBeenCalled();
+    expect(port.runVercelProjectJourney).not.toHaveBeenCalled();
+  });
+
+  it("does not expose raw browser output or thrown secrets", async () => {
+    const canary = "Q9z7_CANARY_69!secret";
+    const port = browserPort({
+      readStatus: vi.fn(async () => { throw new Error(canary); }),
+    });
+    const executor = createVercelBrowserJourneyExecutor({
+      browser: port,
+      topology: () => topology,
+      lease: { isCurrent: () => true },
+      clock: () => NOW,
+    });
+
+    const result = await executor.inspectBrowserVercel({ target, leaseId: "lease-1" });
+
+    assertCanaryAbsent(JSON.stringify(result), [canary]);
+  });
+
+  it("uses exact BB Browser argv and never accepts caller-supplied script controls", async () => {
+    const calls: (readonly string[])[] = [];
+    const invoke = vi.fn(async (argv: readonly string[]) => {
+      calls.push(argv);
+      if (argv[1] === "status") return {
+        hostId: target.hostId,
+        profileId: target.profileId,
+        state: "ready",
+        capabilities: BROWSER_REQUIRED_CAPABILITIES.map((id) => ({ id, status: "ready" })),
+      };
+      if (argv[1] === "grants") return { grants: [{
+        id: grant.grantId, hostId: grant.hostId, profileId: grant.profileId, origin: grant.origin,
+        state: grant.state, expiresAt: grant.expiresAt,
+      }] };
+      if (argv[1] === "open") return { tabId: "tab-1", url: argv[2] };
+      return { result: {
+        ok: true, origin: target.origin, frameOrigins: [target.origin], teamSlug: target.teamSlug,
+        projectName: target.projectName, sessionStatus: "authenticated", observedAt: NOW,
+      } };
+    });
+    const browser = createBbBrowserJourneyBrowserPort({ invoke });
+
+    await browser.readStatus({ hostId: target.hostId, profileId: target.profileId });
+    await browser.readGrants({ hostId: target.hostId, profileId: target.profileId });
+    await browser.runVercelProjectJourney(target);
+
+    expect(calls[0]).toEqual(["browser", "status", "--host", target.hostId, "--profile", target.profileId, "--json"]);
+    expect(calls[1]).toEqual(["browser", "grants", "--host", target.hostId, "--profile", target.profileId, "--json"]);
+    expect(calls[2]).toEqual([
+      "browser", "open", "https://vercel.com/vercel-team/hanoon", "--profile", target.profileId,
+      "--timeout", "15000", "--json",
+    ]);
+    expect(calls[3]?.slice(0, 2)).toEqual(["browser", "script"]);
+    expect(calls[3]).toContain("--origin");
+    expect(calls[3]).toContain(target.origin);
+    expect(calls[3]).toContain("--profile");
+    expect(calls[3]).toContain(target.profileId);
+    expect(calls[3]).toContain("--tab");
+    expect(calls[3]).not.toContain("--screenshot");
+    expect(calls[3]).not.toContain("--file-transfer");
+    expect(calls[3]?.[calls[3]!.indexOf("--code") + 1]).toContain("EXPECTED_ORIGIN");
+    expect(calls[3]?.[calls[3]!.indexOf("--code") + 1]).not.toContain("document.cookie");
+  });
+
+  it("keeps fixed journey denials typed and secret-free at the CLI boundary", async () => {
+    const canary = "raw-browser-result-secret-canary-69";
+    const invoke = vi.fn(async (argv: readonly string[]) => {
+      if (argv[1] === "open") return { tabId: "tab-1", url: "https://vercel.com/vercel-team/hanoon" };
+      return { result: { ok: false, reason: "cross_origin_frame", details: canary } };
+    });
+    const browser = createBbBrowserJourneyBrowserPort({ invoke });
+
+    const result = await browser.runVercelProjectJourney(target);
+
+    expect(result).toEqual({ deniedReason: "cross_origin_frame" });
+    expect(JSON.stringify(result)).not.toContain(canary);
+  });
+
+  it("serializes a profile lease, preserves the same lease on retry, and reclaims only after expiry", () => {
+    const fixture = temporaryBrokerDatabase();
+    const dataKey = new Uint8Array(32).fill(0x31);
+    try {
+      const foundation = new BrokerStore(fixture.db, {
+        dataKey,
+        auditKey: new Uint8Array(32).fill(0x32),
+        clock: () => NOW,
+      });
+      foundation.addInstallation({
+        installationId: "installation-1",
+        clientCertificateFingerprint: "a".repeat(64),
+        policyDigest: FOUNDATION_BROKER_POLICY_DIGEST,
+        topologyReceiptDigest: "b".repeat(64),
+        topologyReceiptExpiresAt: NOW + 100_000,
+        expectedVaultId: "vault-1",
+      });
+      const store = new BrokerProtectedConnectorStore(fixture.db, { dataKey, clock: () => NOW });
+      const first = store.claimBrowserProfile({
+        installationId: "installation-1", requestId: "request-1", idempotencyKey: "idempotency-1",
+        hostId: target.hostId, profileId: target.profileId, bindingGeneration: 1,
+        fenceOwner: "executor-1", fenceGeneration: 1, leaseId: "lease-1", leaseExpiresAt: NOW + 10,
+        now: NOW,
+      });
+      expect(first).toEqual({ outcome: "claimed", leaseId: "lease-1", leaseExpiresAt: NOW + 10 });
+      expect(store.claimBrowserProfile({
+        installationId: "installation-1", requestId: "request-2", idempotencyKey: "idempotency-2",
+        hostId: target.hostId, profileId: target.profileId, bindingGeneration: 1,
+        fenceOwner: "executor-2", fenceGeneration: 1, leaseId: "lease-2", leaseExpiresAt: NOW + 10,
+        now: NOW,
+      })).toEqual({ outcome: "busy" });
+      expect(store.claimBrowserProfile({
+        installationId: "installation-1", requestId: "request-1", idempotencyKey: "idempotency-1",
+        hostId: target.hostId, profileId: target.profileId, bindingGeneration: 1,
+        fenceOwner: "executor-1", fenceGeneration: 1, leaseId: "different-lease", leaseExpiresAt: NOW + 10,
+        now: NOW,
+      })).toEqual({ outcome: "already_held", leaseId: "lease-1", leaseExpiresAt: NOW + 10 });
+      expect(store.isBrowserProfileLeaseCurrent({
+        leaseId: "lease-1", installationId: "installation-1", requestId: "request-1",
+        hostId: target.hostId, profileId: target.profileId, bindingGeneration: 1,
+        fenceOwner: "executor-1", fenceGeneration: 1, now: NOW,
+      })).toBe(true);
+      expect(store.claimBrowserProfile({
+        installationId: "installation-1", requestId: "request-2", idempotencyKey: "idempotency-2",
+        hostId: target.hostId, profileId: target.profileId, bindingGeneration: 1,
+        fenceOwner: "executor-2", fenceGeneration: 1, leaseId: "lease-2", leaseExpiresAt: NOW + 100,
+        now: NOW + 10,
+      })).toEqual({ outcome: "claimed", leaseId: "lease-2", leaseExpiresAt: NOW + 100 });
+      expect(store.isBrowserProfileLeaseCurrent({
+        leaseId: "lease-1", installationId: "installation-1", requestId: "request-1",
+        hostId: target.hostId, profileId: target.profileId, bindingGeneration: 1,
+        fenceOwner: "executor-1", fenceGeneration: 1, now: NOW + 10,
+      })).toBe(false);
+      const restarted = new BrokerProtectedConnectorStore(fixture.db, { dataKey, clock: () => NOW });
+      expect(restarted.claimBrowserProfile({
+        installationId: "installation-1", requestId: "request-2", idempotencyKey: "idempotency-2",
+        hostId: target.hostId, profileId: target.profileId, bindingGeneration: 1,
+        fenceOwner: "executor-2", fenceGeneration: 1, leaseId: "different-lease", leaseExpiresAt: NOW + 100,
+        now: NOW,
+      })).toEqual({ outcome: "already_held", leaseId: "lease-2", leaseExpiresAt: NOW + 100 });
+    } finally {
+      fixture.close();
+    }
+  });
+});

--- a/tests/protected-browser-runtime.test.ts
+++ b/tests/protected-browser-runtime.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BROWSER_REQUIRED_CAPABILITIES,
+  attestBrowserTopologyEvidence,
+  type BrowserTopologyEvidence,
+} from "../broker/src/browser-journey";
+import { createProtectedBrowserConnectorService } from "../broker/src/main";
+import {
+  PROTECTED_CONNECTOR_POLICY_DIGEST,
+  VERCEL_BROWSER_ORIGIN,
+  VERCEL_PROJECT_IDENTITY_JOURNEY_ID,
+  type ProtectedConnectorBindingProjection,
+} from "../src/credentials/connector-policy";
+import {
+  protectedConnectorCapabilityFor,
+  type ProtectedConnectorRequestEnvelope,
+} from "../src/credentials/connector-protocol";
+import { FOUNDATION_BROKER_POLICY_DIGEST } from "../src/credentials/protocol";
+import { BrokerProtectedConnectorStore } from "../broker/src/connector-store";
+import { BrokerStore } from "../broker/src/store";
+import { temporaryBrokerDatabase } from "./support/credential-broker-fixtures";
+
+const NOW = Date.now() + 30_000;
+const DATA_KEY = new Uint8Array(32).fill(0x11);
+const TOPOLOGY_KEY = new Uint8Array(32).fill(0x33);
+const CERTIFICATE = "a".repeat(64);
+
+const topology: BrowserTopologyEvidence = attestBrowserTopologyEvidence({
+  schemaVersion: 1,
+  evidenceId: "topology-runtime-1",
+  observedAt: NOW - 10_000,
+  expiresAt: NOW + 10_000,
+  controllerMayAdminProfiles: false,
+  controllerMayAdminGrants: false,
+  workerMayAdminProfiles: false,
+  workerMayAdminGrants: false,
+}, TOPOLOGY_KEY);
+
+function browserProjection(): ProtectedConnectorBindingProjection {
+  return {
+    schemaVersion: 2,
+    installationId: "installation-1",
+    bindingId: "binding-browser",
+    operation: "browser.vercel_project.inspect.v1",
+    bindingKind: "browser_session",
+    authorityProvider: "bb_browser",
+    secretProvider: "broker_session",
+    principalLabel: "Hanoon employee",
+    capabilityIds: [protectedConnectorCapabilityFor("browser.vercel_project.inspect.v1")],
+    audiences: [],
+    origins: [VERCEL_BROWSER_ORIGIN],
+    scopes: [],
+    riskClass: "low",
+    mfaMode: "human_presence",
+    approvalMode: "standing_policy",
+    state: "pending",
+    generation: 1,
+    verifiedAt: null,
+    expiresAt: null,
+  };
+}
+
+const browserTarget = {
+  operation: "browser.vercel_project.inspect.v1" as const,
+  hostId: "host-runtime",
+  profileId: "profile-runtime",
+  origin: VERCEL_BROWSER_ORIGIN,
+  journeyId: VERCEL_PROJECT_IDENTITY_JOURNEY_ID,
+  journeyVersion: 1 as const,
+  teamSlug: "vercel-team",
+  projectName: "hanoon",
+};
+
+const browserRequest: ProtectedConnectorRequestEnvelope = {
+  schemaVersion: 2,
+  installationId: "installation-1",
+  requestId: "request-browser-runtime",
+  idempotencyKey: "idempotency-browser-runtime",
+  nonce: "nonce-browser-runtime",
+  operation: "browser.vercel_project.inspect.v1",
+  bindingId: "binding-browser",
+  bindingGeneration: 1,
+  taskId: "task-runtime",
+  projectId: "project-runtime",
+  capabilityId: "telegram_agent_browser_vercel_project_inspect",
+  policyDigest: PROTECTED_CONNECTOR_POLICY_DIGEST,
+  fenceOwner: "executor-runtime",
+  fenceGeneration: 1,
+  issuedAt: NOW - 1_000,
+  deadlineAt: NOW + 10_000,
+};
+
+describe("protected browser production wiring", () => {
+  it("routes an enrolled browser request through the startup composition", async () => {
+    const fixture = temporaryBrokerDatabase();
+    const calls: (readonly string[])[] = [];
+    const invoke = vi.fn(async (argv: readonly string[]) => {
+      calls.push(argv);
+      if (argv[1] === "status") return {
+        hostId: browserTarget.hostId,
+        profileId: browserTarget.profileId,
+        state: "ready",
+        capabilities: BROWSER_REQUIRED_CAPABILITIES.map((id) => ({ id, status: "ready" })),
+      };
+      if (argv[1] === "grants") return { grants: [{
+        id: "grant-runtime",
+        hostId: browserTarget.hostId,
+        profileId: browserTarget.profileId,
+        origin: VERCEL_BROWSER_ORIGIN,
+        state: "active",
+        expiresAt: NOW + 10_000,
+      }] };
+      if (argv[1] === "open") return { tabId: "tab-runtime", url: argv[2] };
+      return { result: {
+        ok: true,
+        origin: VERCEL_BROWSER_ORIGIN,
+        frameOrigins: [VERCEL_BROWSER_ORIGIN],
+        teamSlug: browserTarget.teamSlug,
+        projectName: browserTarget.projectName,
+        sessionStatus: "authenticated",
+        observedAt: NOW,
+      } };
+    });
+    const foundationStore = new BrokerStore(fixture.db, {
+      dataKey: DATA_KEY,
+      auditKey: TOPOLOGY_KEY,
+      clock: () => NOW,
+    });
+    foundationStore.addInstallation({
+      installationId: "installation-1",
+      clientCertificateFingerprint: CERTIFICATE,
+      policyDigest: FOUNDATION_BROKER_POLICY_DIGEST,
+      topologyReceiptDigest: "b".repeat(64),
+      topologyReceiptExpiresAt: NOW + 100_000,
+      expectedVaultId: "vault-runtime",
+      now: NOW,
+    });
+    const connectorStore = new BrokerProtectedConnectorStore(fixture.db, { dataKey: DATA_KEY, clock: () => NOW });
+    connectorStore.setPolicy({
+      installationId: "installation-1",
+      projectId: browserRequest.projectId,
+      policyDigest: PROTECTED_CONNECTOR_POLICY_DIGEST,
+      enabledOperations: ["browser.vercel_project.inspect.v1"],
+      now: NOW,
+    });
+    connectorStore.enrollBinding({
+      projection: browserProjection(),
+      target: browserTarget,
+      now: NOW,
+    });
+
+    try {
+      const service = createProtectedBrowserConnectorService({
+        foundationStore,
+        connectorStore,
+        topology: () => topology,
+        topologyKey: TOPOLOGY_KEY,
+        authority: {
+          topologyReady: () => true,
+          auditWritable: () => true,
+          fenceCurrent: () => true,
+        },
+        clock: () => NOW,
+        invoke,
+      });
+
+      const response = await service.execute({
+        certificateFingerprint: CERTIFICATE,
+        request: browserRequest,
+        now: NOW,
+      });
+
+      expect(response).toMatchObject({ outcome: "succeeded", operation: browserRequest.operation });
+      expect(calls.find((argv) => argv[1] === "open")).toContain(browserTarget.hostId);
+      expect(calls.find((argv) => argv[1] === "script")).toContain(browserTarget.hostId);
+    } finally {
+      fixture.close();
+    }
+  });
+});

--- a/tests/protected-connector-authority.test.ts
+++ b/tests/protected-connector-authority.test.ts
@@ -534,6 +534,27 @@ describe("protected connector audit and idempotency", () => {
     }
   });
 
+  it("replays a completed browser receipt without rerunning the journey", async () => {
+    const harness = createHarness();
+    try {
+      const browserRequest = request("browser.vercel_project.inspect.v1");
+      const first = await harness.service.execute({
+        certificateFingerprint: CERTIFICATE,
+        request: browserRequest,
+        now: NOW,
+      });
+      const replay = await harness.service.execute({
+        certificateFingerprint: CERTIFICATE,
+        request: browserRequest,
+        now: NOW,
+      });
+      expect(replay).toEqual(first);
+      expect(harness.calls.browser).toBe(1);
+    } finally {
+      harness.close();
+    }
+  });
+
   it("reconciles an interrupted claim after restart without a second connector observation", async () => {
     const harness = createHarness();
     try {
@@ -551,6 +572,162 @@ describe("protected connector audit and idempotency", () => {
       expect(response).toMatchObject({ outcome: "failed", failureClass: "result_ambiguous" });
       expect(response.receiptId).not.toBeNull();
       expect(totalCalls(harness)).toBe(0);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("serializes browser profile use and releases the lease only after a receipt", async () => {
+    const harness = createHarness();
+    let releaseObservation!: () => void;
+    const observationReleased = new Promise<void>((resolve) => {
+      releaseObservation = resolve;
+    });
+    try {
+      vi.mocked(harness.executor.inspectBrowserVercel).mockImplementationOnce(async () => {
+        await observationReleased;
+        return {
+          outcome: "succeeded",
+          connectorVersion: "journey-1",
+          identity: {
+            profileId: "profile-1",
+            journeyId: VERCEL_PROJECT_IDENTITY_JOURNEY_ID,
+            journeyVersion: 1,
+            origin: VERCEL_BROWSER_ORIGIN,
+            teamSlug: "vercel-team",
+            projectName: "hanoon",
+            sessionStatus: "authenticated",
+            observedAt: NOW,
+          },
+        };
+      });
+      const firstRequest = request("browser.vercel_project.inspect.v1");
+      const first = harness.service.execute({ certificateFingerprint: CERTIFICATE, request: firstRequest, now: NOW });
+      await Promise.resolve();
+      const second = await harness.service.execute({
+        certificateFingerprint: CERTIFICATE,
+        request: request("browser.vercel_project.inspect.v1", {
+          requestId: "browser-request-2",
+          idempotencyKey: "browser-idempotency-2",
+          nonce: "browser-nonce-2",
+        }),
+        now: NOW,
+      });
+      expect(second).toMatchObject({ outcome: "failed", failureClass: "reconciliation_required" });
+      expect(harness.executor.inspectBrowserVercel).toHaveBeenCalledOnce();
+      expect(harness.fixture.db.prepare(
+        "SELECT state FROM broker_browser_profile_leases WHERE request_id = ?",
+      ).get(firstRequest.requestId)).toEqual({ state: "held" });
+      releaseObservation();
+      await expect(first).resolves.toMatchObject({ outcome: "succeeded" });
+      expect(harness.fixture.db.prepare(
+        "SELECT state FROM broker_browser_profile_leases WHERE request_id = ?",
+      ).get(firstRequest.requestId)).toEqual({ state: "released" });
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("does not settle a browser observation after fence loss", async () => {
+    const harness = createHarness();
+    try {
+      vi.mocked(harness.executor.inspectBrowserVercel).mockImplementationOnce(async () => {
+        harness.authorityState.fenceCurrent = false;
+        return {
+          outcome: "succeeded",
+          connectorVersion: "journey-1",
+          identity: {
+            profileId: "profile-1",
+            journeyId: VERCEL_PROJECT_IDENTITY_JOURNEY_ID,
+            journeyVersion: 1,
+            origin: VERCEL_BROWSER_ORIGIN,
+            teamSlug: "vercel-team",
+            projectName: "hanoon",
+            sessionStatus: "authenticated",
+            observedAt: NOW,
+          },
+        };
+      });
+      const browserRequest = request("browser.vercel_project.inspect.v1");
+      const response = await harness.service.execute({
+        certificateFingerprint: CERTIFICATE,
+        request: browserRequest,
+        now: NOW,
+      });
+      expect(response).toMatchObject({ outcome: "failed", failureClass: "reconciliation_required" });
+      expect(harness.fixture.db.prepare(
+        "SELECT state FROM broker_browser_profile_leases WHERE request_id = ?",
+      ).get(browserRequest.requestId)).toEqual({ state: "released" });
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("keeps a browser lease held when receipt persistence fails", async () => {
+    const harness = createHarness();
+    try {
+      harness.fixture.db.exec(`
+        CREATE TRIGGER fail_browser_receipt BEFORE INSERT ON broker_connector_receipts
+        BEGIN SELECT RAISE(ABORT, 'browser receipt canary'); END
+      `);
+      const browserRequest = request("browser.vercel_project.inspect.v1");
+      const response = await harness.service.execute({
+        certificateFingerprint: CERTIFICATE,
+        request: browserRequest,
+        now: NOW,
+      });
+      expect(response).toMatchObject({
+        outcome: "failed",
+        failureClass: "receipt_persistence_failed",
+        receiptId: null,
+      });
+      expect(harness.fixture.db.prepare(
+        "SELECT state FROM broker_browser_profile_leases WHERE request_id = ?",
+      ).get(browserRequest.requestId)).toEqual({ state: "held" });
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("reconciles an interrupted browser lease on restart and never reruns the journey", async () => {
+    const harness = createHarness();
+    try {
+      const browserRequest = request("browser.vercel_project.inspect.v1");
+      expect(harness.connectorStore.claimRequest({
+        request: browserRequest,
+        certificateFingerprint: CERTIFICATE,
+        now: NOW,
+      })).toEqual({ outcome: "claimed" });
+      expect(harness.connectorStore.claimBrowserProfile({
+        installationId: browserRequest.installationId,
+        requestId: browserRequest.requestId,
+        idempotencyKey: browserRequest.idempotencyKey,
+        hostId: "host-1",
+        profileId: "profile-1",
+        bindingGeneration: browserRequest.bindingGeneration,
+        fenceOwner: browserRequest.fenceOwner,
+        fenceGeneration: browserRequest.fenceGeneration,
+        leaseId: "browser-lease-restart",
+        leaseExpiresAt: browserRequest.deadlineAt,
+        now: NOW,
+      })).toMatchObject({ outcome: "claimed" });
+      const restarted = new ProtectedConnectorAuthorityService({
+        foundationStore: harness.foundationStore,
+        connectorStore: harness.connectorStore,
+        executor: harness.executor,
+        authority: harness.authority,
+        clock: () => NOW + 1,
+      });
+      const response = await restarted.execute({
+        certificateFingerprint: CERTIFICATE,
+        request: browserRequest,
+        now: NOW + 1,
+      });
+      expect(response).toMatchObject({ outcome: "failed", failureClass: "result_ambiguous" });
+      expect(harness.calls.browser).toBe(0);
+      expect(harness.fixture.db.prepare(
+        "SELECT state FROM broker_browser_profile_leases WHERE request_id = ?",
+      ).get(browserRequest.requestId)).toEqual({ state: "released" });
     } finally {
       harness.close();
     }

--- a/tests/protected-connector-persistence.test.ts
+++ b/tests/protected-connector-persistence.test.ts
@@ -437,7 +437,7 @@ describe("append-only schema compatibility", () => {
       expect(fixture.db.prepare("SELECT result, protocol_version FROM broker_receipts WHERE receipt_id = 'receipt-v1'").get())
         .toEqual({ result: "valid", protocol_version: 1 });
       expect(fixture.db.prepare("SELECT version FROM broker_schema_migrations ORDER BY version").all())
-        .toEqual([{ version: 1 }, { version: 2 }]);
+        .toEqual([{ version: 1 }, { version: 2 }, { version: 3 }]);
 
       const reopened = new Database(fixture.databasePath);
       applyBrokerMigrations(reopened);


### PR DESCRIPTION
Implements Ticket #69 on top of the protected connector protocol. The broker now routes the v2 protected operation through startup wiring and admits only an enrolled browser host/profile, exact `https://vercel.com` origin, fixed journey id/version, team slug, and project name. It preflights `bb browser status` and grants, runs the built-in Playwright journey, rejects stale tabs, login or cross-origin redirects/frames, wrong project/team, and ambiguous observations, and returns only bounded identity/session fields.

The safety boundary is deliberate: a durable, fence-coupled profile lease serializes use and stays held until a receipt is committed; fresh HMAC-attested topology evidence must prove that neither controller nor worker can administer profiles or grants, otherwise execution fails with `unsafe_topology`. Callers cannot supply URLs, selectors, JavaScript, arbitrary browser commands, or expected identity, and raw DOM/page text, screenshots, cookies, storage, credentials, and authentication/admin flows remain outside the broker evidence. The default startup topology is unsafe, so authenticated browser execution remains unavailable until protected topology is configured. Review focus is the lease/receipt lifecycle, exact-origin redirect handling, and the fixed adapter boundary.

Refs #69
