### PR TITLE
fix(controller): exclude cached context from the turn token budget

### DIFF
--- a/src/controller/bb-controller.ts
+++ b/src/controller/bb-controller.ts
@@ -79,7 +79,8 @@ export type ControllerEventObservation = {
   toolCalls: number;
   /** Non-zero command exits in this window; the caller accumulates them. */
   commandFailures: number;
-  /** Highest cumulative thread token total in this window, else 0. */
+  /** Highest cumulative thread token total in this window, else 0. Fresh input
+   *  plus output only: the cached context re-read on every call is excluded. */
   totalTokens: number;
 };
 
@@ -164,6 +165,26 @@ const TOOL_ITEM_TYPES: ReadonlySet<string> = new Set([
   "fileChange",
   "backgroundTask",
 ]);
+
+/**
+ * What a thread has spent, cumulatively: fresh input plus output. BB's
+ * `totalTokens` also counts the cached prefix the provider re-reads on every
+ * call, and on a long-lived controller thread that prefix is the whole
+ * conversation so far. The turn that first hit the token budget made ten tool
+ * calls and produced ~6k output tokens, yet its total grew by ~80k a call
+ * because ~79k of each call was the same cached context. Counting that would
+ * make the budget a bound on the thread's age rather than on the turn's work,
+ * so it is left out. A missing cached figure counts as zero, which falls back
+ * to the raw total rather than inventing spend the provider never reported.
+ */
+function uncachedTokenTotal(
+  total: Readonly<{ totalTokens: number; cachedInputTokens?: number }>,
+): number {
+  if (!Number.isFinite(total.totalTokens)) return 0;
+  const cached = total.cachedInputTokens;
+  const cachedCount = typeof cached === "number" && Number.isFinite(cached) ? cached : 0;
+  return Math.max(0, total.totalTokens - cachedCount);
+}
 
 type BbSdk = BbPluginApi["sdk"];
 type ControllerPromptInput = Parameters<BbSdk["threads"]["send"]>[0]["input"];
@@ -681,8 +702,8 @@ export class BbControllerAdapter implements ControllerAdapterMethods {
           if (typeof exitCode === "number" && exitCode !== 0) commandFailures += 1;
         }
         if (row.type === "thread/tokenUsage/updated") {
-          const total = row.data.tokenUsage.total.totalTokens;
-          if (Number.isFinite(total) && total > totalTokens) totalTokens = total;
+          const spent = uncachedTokenTotal(row.data.tokenUsage.total);
+          if (spent > totalTokens) totalTokens = spent;
         }
         if (row.type === "system/error" || row.type === "provider/error") {
           failure = providerFailure(row, inputAccepted);

--- a/src/controller/finalization-contract.ts
+++ b/src/controller/finalization-contract.ts
@@ -506,8 +506,9 @@ export function renderControllerFinalization(candidate: ControllerFinalization):
 function rejected(
   code: FinalizationRejectionCode,
   storedCandidate: ControllerFinalization,
+  correction: string | null = null,
 ): ControllerFinalizationValidation {
-  return { outcome: "rejected", code, correction: CORRECTIONS[code], storedCandidate };
+  return { outcome: "rejected", code, correction: correction ?? CORRECTIONS[code], storedCandidate };
 }
 
 function fixedStorageProjection(): ControllerFinalization {
@@ -620,6 +621,44 @@ function hasProofIncompatibility(
   context: ControllerFinalizationValidationContext,
 ): boolean {
   return candidateClaims.some((claim) => !evidenceSupportsClaim(claim, evidenceRows(claim, context)));
+}
+
+/**
+ * A proof mismatch is the one rejection the fixed correction cannot steer out
+ * of. That text tells every claim to become a source report, but a source
+ * report needs thread-state proof, and a claim resting on a command result has
+ * none: a model that follows the correction exactly is rejected again with the
+ * same words. One turn was rejected twice that way, spent a model call on each
+ * attempt, and was stopped by the token budget while still trying. Naming the
+ * kinds the cited evidence can carry gives the model a move the validator will
+ * accept. Only the evidence-backed mismatch is specific; the text-based
+ * `proof_incompatible` branches keep the source-report guidance, which is the
+ * right answer for them. Returns null when no claim fails on proof or outcome.
+ */
+function proofIncompatibilityCorrection(
+  candidateClaims: readonly ControllerClaim[],
+  context: ControllerFinalizationValidationContext,
+): string | null {
+  for (const claim of candidateClaims) {
+    const rows = evidenceRows(claim, context);
+    const refs = claim.evidenceRefs.join(", ");
+    if (!evidenceProofsSupportClaim(claim, rows)) {
+      const proofs = [...new Set(rows.flatMap((row) => row.proofKinds))].join(", ");
+      const kinds = CONTROLLER_CLAIM_KINDS.filter((kind) => (
+        kind !== "uncertainty" &&
+        rows.every((row) => row.proofKinds.some((proof) => CLAIM_PROOFS[kind].has(proof)))
+      ));
+      if (kinds.length === 0) {
+        return `Claim kind ${claim.kind} cannot rest on ${refs} (proof: ${proofs}), and no single claim kind covers that evidence. Cite evidence that proves the claim, or say it in plain text without a claim.`;
+      }
+      return `Claim kind ${claim.kind} cannot rest on ${refs} (proof: ${proofs}). That evidence supports ${kinds.join(" or ")}: use that kind with the outcome the evidence shows, or say it in plain text without a claim.`;
+    }
+    if (!evidenceOutcomesSupportClaim(claim, rows)) {
+      const outcomes = [...new Set(rows.map((row) => row.outcome))].join(", ");
+      return `Claim outcome ${claim.outcome} does not match ${refs} (evidence outcome: ${outcomes}). Use the outcome the evidence shows, or say it in plain text without a claim.`;
+    }
+  }
+  return null;
 }
 
 function normalizedSentences(text: string): string[] {
@@ -1518,6 +1557,9 @@ export function validateControllerFinalization(
   }
   for (const reading of readings) {
     const rejectionCode = semanticRejectionCode(candidate, reading, context);
+    if (rejectionCode === "proof_incompatible") {
+      return rejected(rejectionCode, candidate, proofIncompatibilityCorrection(claims(candidate), context));
+    }
     if (rejectionCode) return rejected(rejectionCode, candidate);
   }
   return { outcome: "accepted", candidate, renderedMessage };

--- a/src/controller/models.ts
+++ b/src/controller/models.ts
@@ -261,7 +261,8 @@ export type ControllerTurnRecord = {
   toolCalls: number;
   /** Non-zero command exits observed so far on this turn. */
   commandFailures: number;
-  /** Highest cumulative thread token total observed on this turn. */
+  /** Highest cumulative thread token total observed on this turn: fresh input
+   *  plus output, with the cached context re-read on every call excluded. */
   totalTokens: number;
   /** The thread's cumulative token total before this turn began, so spend can
    *  be measured for the turn rather than for the thread's whole lifetime. */

--- a/src/controller/service.ts
+++ b/src/controller/service.ts
@@ -1292,7 +1292,7 @@ export class LunaControllerService {
     if (!turn || turn.state !== "submitted" || controller.threadId === null ||
         turn.acceptedFinalizationId !== null ||
         this.dependencies.store.getAcceptedControllerFinalization(turnId) !== null) return false;
-    const decision = evaluateSupervisor({
+    const signals = {
       toolCalls: turn.toolCalls,
       // Spend for *this* turn: the reported figure counts the whole thread,
       // which has answered every earlier message too.
@@ -1301,17 +1301,30 @@ export class LunaControllerService {
       evidenceRows: this.dependencies.store.countControllerEvidence(turnId),
       steersIssued: turn.supervisorSteers,
       steeredReasons: turn.supervisorReasons,
-    });
+    };
+    const decision = evaluateSupervisor(signals);
     if (decision.kind === "continue") return false;
     if (decision.kind === "steer") {
       return this.issueSupervisorSteer(turn, controller, fence, signal, decision.reason, decision.text);
     }
     if (this.dependencies.store.getAcceptedControllerFinalization(turnId) !== null) return false;
+    // The stored error names the budget and the figures. "Exceeded its budget"
+    // alone once sent a diagnosis to the raw event log to learn that a
+    // ten-call turn had been stopped for tokens.
+    this.dependencies.warn?.(JSON.stringify({
+      event: "controller_supervisor_stop",
+      turnId: turn.id,
+      controllerThreadId: controller.threadId,
+      reason: decision.reason,
+      toolCalls: signals.toolCalls,
+      totalTokens: signals.totalTokens,
+      commandFailures: signals.commandFailures,
+    }));
     this.failAndRetire(
       turn,
       controller,
       fence,
-      "Controller turn exceeded its budget",
+      `Controller turn exceeded its budget (${decision.reason}: ${signals.toolCalls} tool calls, ${signals.totalTokens} uncached tokens)`,
       "budget_exceeded",
     );
     return true;

--- a/src/controller/supervisor.ts
+++ b/src/controller/supervisor.ts
@@ -21,8 +21,12 @@ export const SUPERVISOR_MAX_STEERS_PER_TURN = 2;
 export const SUPERVISOR_SOFT_TOOL_CALLS = 60;
 export const SUPERVISOR_HARD_TOOL_CALLS = 120;
 
-// Opus runs a 1M window, so tokens bound cost rather than context. A long
-// investigation lands under 300k; past 600k the turn is not converging.
+// Tokens bound cost rather than context, so the figure is what a turn spent:
+// fresh input plus output, with the cached prefix the provider re-reads on
+// every call left out. Counted with that prefix, a ten-call turn on a mature
+// thread read as 660k and was stopped while delivering its answer; without
+// it the same turn is ~20k. A long investigation lands under 300k; past 600k
+// the turn is not converging.
 export const SUPERVISOR_SOFT_TOKENS = 300_000;
 export const SUPERVISOR_HARD_TOKENS = 600_000;
 

--- a/tests/controller-finalization-contract.test.ts
+++ b/tests/controller-finalization-contract.test.ts
@@ -610,6 +610,52 @@ describe("ordered rejection branches", () => {
     );
   });
 
+  it("tells a claim on the wrong proof which kinds its evidence can carry", () => {
+    // A spawn command's result was cited for an external_mutation claim. The
+    // fixed correction asked for a source report, which that evidence cannot
+    // back either, so the corrected retry was rejected with the same words.
+    const validation = validateControllerFinalization(
+      claimFinalization({
+        kind: "external_mutation",
+        outcome: "succeeded",
+        subjectRef: "bb-item:i80",
+        evidenceRefs: ["evidence:214"],
+        text: "The spawn command ran.",
+      }),
+      contextWithEvidence(evidenceRow("evidence:214", "command_result", "succeeded", "bb-item:i80")),
+    );
+
+    expect(validation).toMatchObject({ outcome: "rejected", code: "proof_incompatible" });
+    const correction = validation.outcome === "rejected" ? validation.correction : "";
+    expect(correction).toContain("evidence:214");
+    expect(correction).toContain("execution_result");
+    expect(correction).not.toContain("observed_state");
+  });
+
+  it("tells a claim whose outcome contradicts its evidence what the evidence shows", () => {
+    const validation = validateControllerFinalization(
+      claimFinalization({ kind: "execution_result", outcome: "succeeded", text: "The check ran." }),
+      contextWithEvidence(evidenceRow("evidence:1", "command_result", "failed")),
+    );
+
+    expect(validation).toMatchObject({ outcome: "rejected", code: "proof_incompatible" });
+    const correction = validation.outcome === "rejected" ? validation.correction : "";
+    expect(correction).toContain("evidence outcome: failed");
+  });
+
+  it("keeps the source-report correction for a proof rejection raised by claim text", () => {
+    const validation = validateControllerFinalization(
+      claimFinalization({ kind: "observed_state", outcome: "observed", text: "The deployment succeeded." }),
+      contextWithEvidence(evidenceRow("evidence:1", "project_state", "observed")),
+    );
+
+    expect(validation).toMatchObject({
+      outcome: "rejected",
+      code: "proof_incompatible",
+      correction: controllerFinalizationCorrection("proof_incompatible"),
+    });
+  });
+
   it("does not treat merge-only pipeline evidence as production proof", () => {
     expectRejection(
       claimFinalization({ kind: "pipeline_outcome", outcome: "succeeded", text: "Deployment succeeded." }),

--- a/tests/controller-supervisor.test.ts
+++ b/tests/controller-supervisor.test.ts
@@ -140,6 +140,24 @@ it("counts tool starts, failed commands, and the cumulative token total", async 
   expect(observation).toMatchObject({ toolCalls: 2, commandFailures: 1, totalTokens: 9_004 });
 });
 
+it("counts the tokens a call spent, not the cached context it re-read", async () => {
+  // Figures from a real controller thread: the provider re-reads the whole
+  // conversation from cache on every call, so `totalTokens` grows by ~80k a
+  // call while the call itself produced a few hundred fresh tokens.
+  const adapter = observingAdapter([[
+    event(1, "thread/tokenUsage/updated", { tokenUsage: { total: {
+      totalTokens: 1_624_683, inputTokens: 1_612_411, cachedInputTokens: 1_564_928, outputTokens: 12_272,
+    } } }),
+    event(2, "thread/tokenUsage/updated", { tokenUsage: { total: {
+      totalTokens: 1_704_814, inputTokens: 1_691_446, cachedInputTokens: 1_638_400, outputTokens: 13_368,
+    } } }),
+  ]]);
+
+  const observation = await adapter.events("thr_controller", 0, AbortSignal.timeout(1_000));
+
+  expect(observation.totalTokens).toBe(1_704_814 - 1_638_400);
+});
+
 it("reports no usage for a window that carried none", async () => {
   const adapter = observingAdapter([[event(1, "item/agentMessage/delta", { delta: "hi" })]]);
 
@@ -437,7 +455,7 @@ it("steers a turn that crosses the soft tool budget, then stops it at the hard b
 
   expect(store.getControllerTurn(turn.id)).toMatchObject({
     state: "failed",
-    lastError: "Controller turn exceeded its budget",
+    lastError: expect.stringContaining("Controller turn exceeded its budget"),
   });
   expect(store.getControllerForOwner("7", "7")).toMatchObject({ threadId: null, state: "pending_spawn" });
   expect(store.getOutbox(`controller:${turn.id}:reply`)?.payload.text)
@@ -605,6 +623,51 @@ it("budgets this turn's tokens, not the whole thread's history", async () => {
 
   expect(store.getControllerTurn(turn.id)).toMatchObject({
     state: "failed",
-    lastError: "Controller turn exceeded its budget",
+    lastError: expect.stringContaining("Controller turn exceeded its budget"),
   });
+});
+
+it("lets a short turn on a long-lived thread finish when every call re-reads a large cached context", async () => {
+  const { store, fence } = storeFixture("cached-context");
+  const turn = submittedTurn(store, fence);
+  // The nine cumulative thread totals BB reported during one real turn that
+  // made ten tool calls and produced ~6k output tokens. Each call added ~80k
+  // to the total because the provider re-read the ~80k conversation from
+  // cache; measured by the total alone, the turn "spent" 660k and was killed
+  // while it was delivering its answer.
+  const calls: ReadonlyArray<readonly [total: number, cached: number]> = [
+    [1_624_683, 1_564_928],
+    [1_704_814, 1_638_400],
+    [1_785_507, 1_717_248],
+    [1_866_431, 1_797_504],
+    [1_947_498, 1_878_016],
+    [2_030_402, 1_958_784],
+    [2_113_933, 2_040_832],
+    [2_199_000, 2_123_648],
+    [2_284_543, 2_207_360],
+  ];
+  const pages = calls.map(([total, cached], index) => [
+    event(index * 2 + 1, "item/started", { item: { type: "toolCall", id: `t${index}` } }),
+    event(index * 2 + 2, "thread/tokenUsage/updated", { tokenUsage: { total: {
+      totalTokens: total, inputTokens: total - 2_000, cachedInputTokens: cached, outputTokens: 2_000,
+    } } }),
+  ]);
+  const observing = observingAdapter(pages);
+  const adapter = serviceAdapter(() => observation(), () => "active");
+  adapter.events = vi.fn((threadId: string, afterSeq: number, signal: AbortSignal) =>
+    observing.events(threadId, afterSeq, signal));
+  const service = new LunaControllerService({ store, adapter, evidenceProjector: testEvidenceProjector, clock: { now: () => 2_001 } });
+  const runFence = { ...fence, signal: AbortSignal.timeout(5_000) };
+
+  for (let poll = 0; poll < calls.length; poll += 1) {
+    await expect(service.reconcile(runFence, runFence.signal)).resolves.toBe(true);
+  }
+
+  expect(store.getControllerTurn(turn.id)).toMatchObject({
+    state: "submitted",
+    toolCalls: calls.length,
+    lastError: null,
+  });
+  expect(adapter.steer).not.toHaveBeenCalled();
+  expect(store.getOutbox(`controller:${turn.id}:reply`)?.payload.text).not.toMatch(/safety limit/);
 });


### PR DESCRIPTION
A ten-tool-call turn on a long-lived controller thread was stopped for "exceeding its budget" while it was delivering its answer. The token budget was measuring the wrong thing: BB's cumulative total grows by the whole cached conversation prefix on every model call, so on a mature thread every call cost ~80k regardless of work. The budget had become a bound on the thread's age, not on the turn's work.

A turn's spend is now the thread's uncached total: fresh input plus output. The thresholds do not change.

```diff
 one model call on the thread that hit the budget
   inputTokens          ~80,000
-  cachedInputTokens    ~79,000   counted
+  cachedInputTokens    ~79,000   excluded
   outputTokens            ~500
-turn spend after 9 calls: 659,860   hard budget 600,000, stopped
+turn spend after 9 calls:  ~20,000
```

Where the figure flows, and the one line that changes it:

```diff
 BbControllerAdapter.events                (bb-controller.ts)
-  totalTokens = max(total.totalTokens)
+  totalTokens = max(total.totalTokens - total.cachedInputTokens)
 LunaControllerService.reconcile           (service.ts)
   store.updateControllerStream            max + first-reading baseline, unchanged
   superviseBudget
     evaluateSupervisor(totalTokens - tokenBaseline)    thresholds unchanged
+    warn controller_supervisor_stop { reason, toolCalls, totalTokens }
+    failAndRetire("... budget (token_budget: 10 tool calls, 659860 uncached tokens)")
```

The trace also showed why the turn needed nine calls. Both answer attempts were rejected with `proof_incompatible`, and the fixed correction sent the model somewhere the validator could not accept:

```mermaid
sequenceDiagram
    participant M as Controller model
    participant V as Finalization contract
    M->>V: claim external_mutation, evidence: command_result
    V-->>M: proof_incompatible "set kind observed_state"
    M->>V: claim observed_state, same evidence
    V-->>M: proof_incompatible "set kind observed_state"
    Note over M,V: each retry was another ~80k-weighted call
```

A proof mismatch now names what the cited evidence can carry:

```text
Claim kind external_mutation cannot rest on evidence:214 (proof: command_result).
That evidence supports execution_result: use that kind with the outcome the
evidence shows, or say it in plain text without a claim.
```

Rejections raised by claim text rather than by evidence keep the source-report guidance.

Review focus: `uncachedTokenTotal` in `bb-controller.ts` is the whole behavior change for the budget, and `proofIncompatibilityCorrection` in `finalization-contract.ts` changes only the correction string, never the rejection code. A turn in flight at upgrade keeps its old-measure baseline, so its spend reads as zero for the rest of that turn rather than tripping anything.

Two regression tests replay the incident's nine real token snapshots through the real adapter, store, and supervisor. They retired the turn before the fix and keep it running after.
