### PR TITLE
fix(storage): split the policy-approval migration back into two entries

### DIFF
--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -4056,6 +4056,7 @@ SELECT observation.observation_id, observation.job_id, observation.authority_id,
    AND boundary.authority_revision = observation.authority_revision
    AND boundary.affected_effect_idempotency_key = observation.affected_effect_idempotency_key
  WHERE boundary.status <> 'revoked';
+`, String.raw`
 CREATE TRIGGER policy_boundary_observations_require_live_executor_fence
 BEFORE INSERT ON policy_boundary_observations
 WHEN EXISTS (


### PR DESCRIPTION
An existing installation could not be upgraded past commit 809c717. Its plugin database refused every newer build:

```text
migration 87 does not match the recorded statement; append a new migration
instead of changing or reusing an index
```

The ledger is indexed by position. 809c717 concatenated the two statements of `POLICY_APPROVAL_INTENT_MIGRATIONS` into one entry — the SQL was untouched, the two strings were simply joined — which deleted a slot and shifted everything after it:

```diff
 ALL_MIGRATIONS
  ...
  86  unchanged
- 87  UPDATE effects … + CREATE TRIGGER …   (two statements, one entry)
+ 87  UPDATE effects …
+ 88  CREATE TRIGGER policy_boundary_observations_require_live_executor_fence
- 88  navigator_release_attempts            (was 89)
- 89  DROP TRIGGER owner_boundaries…        (was 90)
   …every later index shifted down one
```

A database that had already applied the old list then found a *different* statement recorded under id 87, and BB's guard stopped the plugin rather than run it. A fresh install builds the whole list from scratch and is unaffected, which is exactly why the suite never caught this.

Measured against the live plugin database, before and after:

```text
before   ids 0–86 match; 87–95 mismatch   (9 broken)
after    all 96 recorded hashes match     (0 broken)
```

The diff is one line — the entry separator — because that is the entire defect. No SQL is added, removed, or reordered, so a fresh database builds the identical schema in the identical order, and the eleven genuinely new migrations still append after the applied ones.

Review focus: confirm the restored block is byte-identical to the pre-809c717 definition. It was spliced from that commit rather than retyped, and `old[0] + old[1]` differs from the merged string by a single blank line at the seam.
